### PR TITLE
Add microphone and speaker selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ skill.
 | `model` | `gpt-realtime-2` | OpenAI Realtime model |
 | `voice` | `marin` | Assistant voice |
 
+Microphone and speaker choices are available under **Audio devices** in the
+Realtime plugin settings and on the Realtime page. They are stored in the
+current browser and apply to the next voice session. If a selected device is
+disconnected, Realtime falls back to the system default. Speaker selection
+depends on browser support for audio output routing.
+
 Change with `bb plugin config realtime set <key> <value>`, then
 `bb plugin reload aide`.
 

--- a/app.tsx
+++ b/app.tsx
@@ -16,7 +16,7 @@ import {
 } from "@get-bb/plugin-sdk/app";
 import type { rpcContract } from "./server";
 import { voiceAgent } from "./voice-agent";
-import { SessionsPanel } from "./sessions-panel";
+import { AudioDeviceSettings, SessionsPanel } from "./sessions-panel";
 import { cn } from "@/lib/utils";
 import "./app.css";
 
@@ -160,6 +160,12 @@ function SidebarLiveIndicator() {
 }
 
 export default definePluginApp((app) => {
+  app.slots.settingsSection({
+    id: "audio-devices",
+    title: "Audio devices",
+    description: "Choose the microphone and speaker used by new Realtime voice sessions.",
+    component: AudioDeviceSettings,
+  });
   app.composer.customize({
     id: "aide-voice",
     actions: [{ id: "voice-agent", component: AideVoiceButton }],

--- a/app.tsx
+++ b/app.tsx
@@ -18,6 +18,7 @@ import type { rpcContract } from "./server";
 import { voiceAgent } from "./voice-agent";
 import { AudioDeviceSettings, SessionsPanel } from "./sessions-panel";
 import { cn } from "@/lib/utils";
+import { AUDIO_DEVICE_STORAGE_KEY } from "./audio-devices";
 import "./app.css";
 
 
@@ -184,6 +185,9 @@ export default definePluginApp((app) => {
   app.contentScripts.register({
     id: "aide-voice-lifecycle",
     mount({ signal }) {
+      window.addEventListener("storage", (event) => {
+        if (event.key === AUDIO_DEVICE_STORAGE_KEY) voiceAgent.refreshAudioPreferences();
+      }, { signal });
       signal.addEventListener("abort", () => voiceAgent.stop());
       return () => voiceAgent.stop();
     },

--- a/audio-devices.test.ts
+++ b/audio-devices.test.ts
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  audioCaptureConstraint,
+  deviceDisplayLabel,
+  readAudioDevicePreferences,
+  resolveDeviceId,
+  shouldRetryWithDefaultDevice,
+  writeAudioDevicePreferences,
+} from "./audio-devices.ts";
+
+test("uses the browser default microphone when no preference is saved", () => {
+  assert.equal(audioCaptureConstraint(""), true);
+});
+
+test("requests a saved microphone by exact device id", () => {
+  assert.deepEqual(audioCaptureConstraint("input-123"), {
+    deviceId: { exact: "input-123" },
+  });
+});
+
+test("falls back to the system default when a saved device disappears", () => {
+  const devices = [
+    { deviceId: "input-456", kind: "audioinput" as const, label: "Desk Mic" },
+  ];
+
+  assert.equal(resolveDeviceId("input-123", devices), "");
+  assert.equal(resolveDeviceId("input-456", devices), "input-456");
+});
+
+test("provides readable labels before browser permission reveals device names", () => {
+  assert.equal(
+    deviceDisplayLabel({ deviceId: "in", kind: "audioinput", label: "" }, 2),
+    "Microphone 3",
+  );
+  assert.equal(
+    deviceDisplayLabel({ deviceId: "out", kind: "audiooutput", label: "" }, 0),
+    "Speaker 1",
+  );
+});
+
+test("persists browser-local audio preferences", () => {
+  const values = new Map<string, string>();
+  const storage = {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+
+  writeAudioDevicePreferences(storage, {
+    inputDeviceId: "input-123",
+    outputDeviceId: "output-456",
+  });
+
+  assert.deepEqual(readAudioDevicePreferences(storage), {
+    inputDeviceId: "input-123",
+    outputDeviceId: "output-456",
+  });
+});
+
+test("ignores invalid persisted audio preferences", () => {
+  const storage = {
+    getItem: () => "not json",
+    setItem: () => undefined,
+  };
+
+  assert.deepEqual(readAudioDevicePreferences(storage), {
+    inputDeviceId: "",
+    outputDeviceId: "",
+  });
+});
+
+test("only retries capture failures caused by an unavailable selected device", () => {
+  assert.equal(shouldRetryWithDefaultDevice({ name: "OverconstrainedError" }), true);
+  assert.equal(shouldRetryWithDefaultDevice({ name: "NotFoundError" }), true);
+  assert.equal(shouldRetryWithDefaultDevice({ name: "NotAllowedError" }), false);
+  assert.equal(shouldRetryWithDefaultDevice(new Error("unknown")), false);
+});

--- a/audio-devices.test.ts
+++ b/audio-devices.test.ts
@@ -4,7 +4,6 @@ import {
   audioCaptureConstraint,
   deviceDisplayLabel,
   readAudioDevicePreferences,
-  resolveDeviceId,
   shouldRetryWithDefaultDevice,
   writeAudioDevicePreferences,
 } from "./audio-devices.ts";
@@ -17,15 +16,6 @@ test("requests a saved microphone by exact device id", () => {
   assert.deepEqual(audioCaptureConstraint("input-123"), {
     deviceId: { exact: "input-123" },
   });
-});
-
-test("falls back to the system default when a saved device disappears", () => {
-  const devices = [
-    { deviceId: "input-456", kind: "audioinput" as const, label: "Desk Mic" },
-  ];
-
-  assert.equal(resolveDeviceId("input-123", devices), "");
-  assert.equal(resolveDeviceId("input-456", devices), "input-456");
 });
 
 test("provides readable labels before browser permission reveals device names", () => {
@@ -46,15 +36,29 @@ test("persists browser-local audio preferences", () => {
     setItem: (key: string, value: string) => values.set(key, value),
   };
 
-  writeAudioDevicePreferences(storage, {
+  assert.equal(writeAudioDevicePreferences(storage, {
     inputDeviceId: "input-123",
     outputDeviceId: "output-456",
-  });
+  }), true);
 
   assert.deepEqual(readAudioDevicePreferences(storage), {
     inputDeviceId: "input-123",
     outputDeviceId: "output-456",
   });
+});
+
+test("keeps storage failures from breaking in-memory device selection", () => {
+  const storage = {
+    getItem: () => null,
+    setItem: () => {
+      throw new DOMException("Storage denied", "SecurityError");
+    },
+  };
+
+  assert.equal(writeAudioDevicePreferences(storage, {
+    inputDeviceId: "input-123",
+    outputDeviceId: "output-456",
+  }), false);
 });
 
 test("ignores invalid persisted audio preferences", () => {

--- a/audio-devices.ts
+++ b/audio-devices.ts
@@ -1,0 +1,64 @@
+export interface AudioDeviceLike {
+  deviceId: string;
+  kind: MediaDeviceKind;
+  label: string;
+}
+
+export interface AudioDevicePreferences {
+  inputDeviceId: string;
+  outputDeviceId: string;
+}
+
+interface PreferenceStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): unknown;
+}
+
+const STORAGE_KEY = "bb-realtime.audio-devices";
+const DEFAULT_PREFERENCES: AudioDevicePreferences = {
+  inputDeviceId: "",
+  outputDeviceId: "",
+};
+
+export function readAudioDevicePreferences(storage: PreferenceStorage): AudioDevicePreferences {
+  try {
+    const parsed = JSON.parse(storage.getItem(STORAGE_KEY) ?? "null") as Record<string, unknown> | null;
+    return {
+      inputDeviceId: typeof parsed?.inputDeviceId === "string" ? parsed.inputDeviceId : "",
+      outputDeviceId: typeof parsed?.outputDeviceId === "string" ? parsed.outputDeviceId : "",
+    };
+  } catch {
+    return { ...DEFAULT_PREFERENCES };
+  }
+}
+
+export function writeAudioDevicePreferences(
+  storage: PreferenceStorage,
+  preferences: AudioDevicePreferences,
+): void {
+  storage.setItem(STORAGE_KEY, JSON.stringify(preferences));
+}
+
+export function audioCaptureConstraint(deviceId: string): true | MediaTrackConstraints {
+  return deviceId ? { deviceId: { exact: deviceId } } : true;
+}
+
+export function resolveDeviceId(
+  preferredId: string,
+  devices: readonly AudioDeviceLike[],
+): string {
+  if (!preferredId) return "";
+  return devices.some((device) => device.deviceId === preferredId) ? preferredId : "";
+}
+
+export function shouldRetryWithDefaultDevice(error: unknown): boolean {
+  const name = typeof error === "object" && error !== null && "name" in error
+    ? String(error.name)
+    : "";
+  return name === "OverconstrainedError" || name === "NotFoundError";
+}
+
+export function deviceDisplayLabel(device: AudioDeviceLike, index: number): string {
+  if (device.label) return device.label;
+  return `${device.kind === "audioinput" ? "Microphone" : "Speaker"} ${index + 1}`;
+}

--- a/audio-devices.ts
+++ b/audio-devices.ts
@@ -14,7 +14,7 @@ interface PreferenceStorage {
   setItem(key: string, value: string): unknown;
 }
 
-const STORAGE_KEY = "bb-realtime.audio-devices";
+export const AUDIO_DEVICE_STORAGE_KEY = "bb-realtime.audio-devices";
 const DEFAULT_PREFERENCES: AudioDevicePreferences = {
   inputDeviceId: "",
   outputDeviceId: "",
@@ -22,7 +22,7 @@ const DEFAULT_PREFERENCES: AudioDevicePreferences = {
 
 export function readAudioDevicePreferences(storage: PreferenceStorage): AudioDevicePreferences {
   try {
-    const parsed = JSON.parse(storage.getItem(STORAGE_KEY) ?? "null") as Record<string, unknown> | null;
+    const parsed = JSON.parse(storage.getItem(AUDIO_DEVICE_STORAGE_KEY) ?? "null") as Record<string, unknown> | null;
     return {
       inputDeviceId: typeof parsed?.inputDeviceId === "string" ? parsed.inputDeviceId : "",
       outputDeviceId: typeof parsed?.outputDeviceId === "string" ? parsed.outputDeviceId : "",
@@ -35,20 +35,17 @@ export function readAudioDevicePreferences(storage: PreferenceStorage): AudioDev
 export function writeAudioDevicePreferences(
   storage: PreferenceStorage,
   preferences: AudioDevicePreferences,
-): void {
-  storage.setItem(STORAGE_KEY, JSON.stringify(preferences));
+): boolean {
+  try {
+    storage.setItem(AUDIO_DEVICE_STORAGE_KEY, JSON.stringify(preferences));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function audioCaptureConstraint(deviceId: string): true | MediaTrackConstraints {
   return deviceId ? { deviceId: { exact: deviceId } } : true;
-}
-
-export function resolveDeviceId(
-  preferredId: string,
-  devices: readonly AudioDeviceLike[],
-): string {
-  if (!preferredId) return "";
-  return devices.some((device) => device.deviceId === preferredId) ? preferredId : "";
 }
 
 export function shouldRetryWithDefaultDevice(error: unknown): boolean {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "test": "node --test audio-devices.test.ts",
+    "test": "node --test audio-devices.test.ts voice-agent.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "bb-plugin-realtime",
   "version": "0.1.0",
   "type": "module",
+  "scripts": {
+    "test": "node --test audio-devices.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
   "engines": {
     "bb": ">=0.40",
     "bbPluginSdk": ">=0.4.21"

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import type { rpcContract } from "./server";
 import { DEFAULT_MODEL, MODEL_OPTIONS, type RealtimeModel } from "./models";
 import { voiceAgent } from "./voice-agent";
+import { deviceDisplayLabel } from "./audio-devices";
 import { cn } from "@/lib/utils";
 
 interface SessionRow {
@@ -86,6 +87,147 @@ function ModelPicker() {
         ))}
       </select>
     </label>
+  );
+}
+
+export function AudioDeviceSettings() {
+  const preferences = useSyncExternalStore(
+    voiceAgent.subscribe,
+    voiceAgent.getAudioPreferences,
+  );
+  const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [deviceError, setDeviceError] = useState<string | null>(null);
+  const supportsSpeakerSelection =
+    typeof HTMLMediaElement !== "undefined" && "setSinkId" in HTMLMediaElement.prototype;
+
+  const refresh = useCallback(async () => {
+    if (!navigator.mediaDevices?.enumerateDevices) {
+      setDeviceError("Audio device discovery is not supported in this browser.");
+      setLoading(false);
+      return;
+    }
+    try {
+      setDevices(await navigator.mediaDevices.enumerateDevices());
+      setDeviceError(null);
+    } catch (cause) {
+      setDeviceError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    navigator.mediaDevices?.addEventListener?.("devicechange", refresh);
+    return () => navigator.mediaDevices?.removeEventListener?.("devicechange", refresh);
+  }, [refresh]);
+
+  const inputs = devices.filter(
+    (device) => device.kind === "audioinput" && device.deviceId,
+  );
+  const outputs = devices.filter(
+    (device) => device.kind === "audiooutput" && device.deviceId,
+  );
+  const labelsHidden = inputs.length > 0 && inputs.every((device) => !device.label);
+
+  async function allowAccess() {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      for (const track of stream.getTracks()) track.stop();
+      await refresh();
+    } catch (cause) {
+      setDeviceError(cause instanceof Error ? cause.message : String(cause));
+    }
+  }
+
+  function change(kind: "input" | "output", deviceId: string) {
+    voiceAgent.setAudioPreferences({
+      ...preferences,
+      [kind === "input" ? "inputDeviceId" : "outputDeviceId"]: deviceId,
+    });
+    toast.success("Audio device saved — applies to the next voice session");
+  }
+
+  return (
+    <details className="rounded-lg border border-border bg-card">
+      <summary className="cursor-pointer px-3 py-2.5 text-sm font-medium text-foreground">
+        Audio devices
+        <span className="ml-2 text-xs font-normal text-muted-foreground">
+          microphone and speaker
+        </span>
+      </summary>
+      <div className="grid gap-3 border-t border-border/50 p-3 sm:grid-cols-2">
+        <label className="space-y-1 text-xs text-muted-foreground">
+          <span>Microphone</span>
+          <select
+            value={preferences.inputDeviceId}
+            disabled={loading}
+            onChange={(event) => change("input", event.target.value)}
+            className="block w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm text-foreground"
+          >
+            <option value="">System default</option>
+            {preferences.inputDeviceId && !inputs.some((device) => device.deviceId === preferences.inputDeviceId) ? (
+              <option value={preferences.inputDeviceId}>Unavailable device</option>
+            ) : null}
+            {inputs.map((device, index) => (
+              <option key={device.deviceId} value={device.deviceId}>
+                {deviceDisplayLabel(device, index)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="space-y-1 text-xs text-muted-foreground">
+          <span>Speaker</span>
+          <select
+            value={supportsSpeakerSelection ? preferences.outputDeviceId : ""}
+            disabled={loading || !supportsSpeakerSelection}
+            onChange={(event) => change("output", event.target.value)}
+            className="block w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm text-foreground disabled:opacity-60"
+          >
+            <option value="">System default</option>
+            {preferences.outputDeviceId && !outputs.some((device) => device.deviceId === preferences.outputDeviceId) ? (
+              <option value={preferences.outputDeviceId}>Unavailable device</option>
+            ) : null}
+            {outputs.map((device, index) => (
+              <option key={device.deviceId} value={device.deviceId}>
+                {deviceDisplayLabel(device, index)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className="sm:col-span-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+          <span>
+            {!supportsSpeakerSelection
+              ? "This browser only supports the system-default speaker."
+              : labelsHidden
+                ? "Allow microphone access to reveal device names."
+                : "Selections are stored in this browser and apply to new sessions."}
+          </span>
+          <span className="flex shrink-0 items-center gap-2">
+            {labelsHidden ? (
+              <button
+                type="button"
+                onClick={() => void allowAccess()}
+                className="rounded-md border border-border px-2 py-1 hover:text-foreground"
+              >
+                Allow access
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => void refresh()}
+              className="rounded-md border border-border px-2 py-1 hover:text-foreground"
+            >
+              Refresh
+            </button>
+          </span>
+        </div>
+        {deviceError ? (
+          <p className="sm:col-span-2 text-xs text-destructive">{deviceError}</p>
+        ) : null}
+      </div>
+    </details>
   );
 }
 
@@ -476,6 +618,7 @@ export function SessionsPanel() {
                 <ModelPicker />
               </span>
             </div>
+            <AudioDeviceSettings />
             <PromptEditor />
             <ToolsSection />
             <div className="divide-y divide-border/50 rounded-lg border border-border bg-card">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
     "lib": [
       "ES2022",

--- a/voice-agent.test.ts
+++ b/voice-agent.test.ts
@@ -1,0 +1,152 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { VoiceAgent } from "./voice-agent.ts";
+import { writeAudioDevicePreferences } from "./audio-devices.ts";
+
+test("reloads audio preferences saved by another browser window", () => {
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const values = new Map<string, string>();
+  const storage = {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { localStorage: storage },
+  });
+
+  try {
+    const agent = new VoiceAgent();
+    writeAudioDevicePreferences(storage, {
+      inputDeviceId: "mic-from-window-a",
+      outputDeviceId: "speaker-from-window-a",
+    });
+
+    agent.refreshAudioPreferences();
+
+    assert.deepEqual(agent.getAudioPreferences(), {
+      inputDeviceId: "mic-from-window-a",
+      outputDeviceId: "speaker-from-window-a",
+    });
+  } finally {
+    if (originalWindow) Object.defineProperty(globalThis, "window", originalWindow);
+    else delete (globalThis as { window?: unknown }).window;
+  }
+});
+
+test("stopping during speaker routing closes the mic and cancels startup", async () => {
+  const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  const originalPeerConnection = Object.getOwnPropertyDescriptor(globalThis, "RTCPeerConnection");
+  const originalAudio = Object.getOwnPropertyDescriptor(globalThis, "Audio");
+  const track = {
+    enabled: true,
+    stopped: false,
+    stop() {
+      this.stopped = true;
+    },
+  };
+  const stream = {
+    getTracks: () => [track],
+    getAudioTracks: () => [track],
+  } as unknown as MediaStream;
+  let resolveSink!: () => void;
+  let announceSinkStarted!: () => void;
+  const sinkStarted = new Promise<void>((resolve) => {
+    announceSinkStarted = resolve;
+  });
+  const sinkPending = new Promise<void>((resolve) => {
+    resolveSink = resolve;
+  });
+  let peer: FakePeerConnection | null = null;
+
+  class FakePeerConnection {
+    iceGatheringState = "complete";
+    connectionState = "new";
+    localDescription: RTCSessionDescriptionInit | null = null;
+    closed = false;
+    createOfferCalls = 0;
+    ontrack: ((event: RTCTrackEvent) => void) | null = null;
+    onconnectionstatechange: (() => void) | null = null;
+
+    constructor() {
+      peer = this;
+    }
+
+    addTrack() {}
+    addEventListener() {}
+    removeEventListener() {}
+    close() {
+      this.closed = true;
+    }
+    createDataChannel() {
+      return { readyState: "connecting", close() {}, send() {}, onopen: null, onmessage: null };
+    }
+    async createOffer() {
+      this.createOfferCalls += 1;
+      return { type: "offer" as const, sdp: "offer" };
+    }
+    async setLocalDescription(description: RTCSessionDescriptionInit) {
+      this.localDescription = description;
+    }
+    async setRemoteDescription() {}
+  }
+
+  class FakeAudio {
+    autoplay = false;
+    srcObject: MediaStream | null = null;
+    async setSinkId() {
+      announceSinkStarted();
+      return sinkPending;
+    }
+    async play() {}
+    remove() {}
+  }
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: { mediaDevices: { getUserMedia: async () => stream } },
+  });
+  Object.defineProperty(globalThis, "RTCPeerConnection", {
+    configurable: true,
+    value: FakePeerConnection,
+  });
+  Object.defineProperty(globalThis, "Audio", {
+    configurable: true,
+    value: FakeAudio,
+  });
+
+  const agent = new VoiceAgent();
+  agent.bind({
+    rpc: {
+      call: (async (method: string) =>
+        method === "createCall" ? { sdp: "answer" } : { ok: true }) as never,
+    },
+    context: { threadId: null, projectId: null },
+    composer: { setText() {}, updateText() {} },
+    openNewThread() {},
+  });
+  agent.setAudioPreferences({ inputDeviceId: "", outputDeviceId: "speaker-1" });
+
+  try {
+    agent.toggle();
+    await sinkStarted;
+    agent.stop();
+
+    assert.equal(track.stopped, true);
+    assert.equal(peer?.closed, true);
+
+    resolveSink();
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(peer?.createOfferCalls, 0);
+    assert.equal(agent.getState(), "idle");
+  } finally {
+    resolveSink();
+    agent.stop();
+    if (originalNavigator) Object.defineProperty(globalThis, "navigator", originalNavigator);
+    else delete (globalThis as { navigator?: unknown }).navigator;
+    if (originalPeerConnection) Object.defineProperty(globalThis, "RTCPeerConnection", originalPeerConnection);
+    else delete (globalThis as { RTCPeerConnection?: unknown }).RTCPeerConnection;
+    if (originalAudio) Object.defineProperty(globalThis, "Audio", originalAudio);
+    else delete (globalThis as { Audio?: unknown }).Audio;
+  }
+});

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -4,6 +4,13 @@
 import { toast } from "sonner";
 import type { useRpc } from "@get-bb/plugin-sdk/app";
 import type { rpcContract } from "./server";
+import {
+  audioCaptureConstraint,
+  readAudioDevicePreferences,
+  shouldRetryWithDefaultDevice,
+  writeAudioDevicePreferences,
+  type AudioDevicePreferences,
+} from "./audio-devices";
 
 export type VoiceState = "idle" | "connecting" | "live" | "muted";
 
@@ -58,6 +65,10 @@ export class VoiceAgent {
   private listeners = new Set<() => void>();
   private bindings: Bindings | null = null;
   private nonce: string | null = null;
+  private audioPreferences: AudioDevicePreferences =
+    typeof localStorage === "undefined"
+      ? { inputDeviceId: "", outputDeviceId: "" }
+      : readAudioDevicePreferences(localStorage);
   /** Serializes tool executions so outputs are submitted in call order. */
   private toolChain: Promise<void> = Promise.resolve();
   /** True while the model is generating a response (response.created→done). */
@@ -78,13 +89,27 @@ export class VoiceAgent {
 
   readonly getState = (): VoiceState => this.state;
 
+  readonly getAudioPreferences = (): AudioDevicePreferences => this.audioPreferences;
+
   bind(bindings: Bindings) {
     this.bindings = bindings;
   }
 
   private setState(next: VoiceState) {
     this.state = next;
+    this.emitChange();
+  }
+
+  private emitChange() {
     for (const listener of this.listeners) listener();
+  }
+
+  setAudioPreferences(next: AudioDevicePreferences) {
+    this.audioPreferences = { ...next };
+    if (typeof localStorage !== "undefined") {
+      writeAudioDevicePreferences(localStorage, this.audioPreferences);
+    }
+    this.emitChange();
   }
 
   toggle() {
@@ -279,10 +304,34 @@ export class VoiceAgent {
     this.nonce = nonce;
     this.log("session.started", { ...bindings.context });
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      let stream: MediaStream;
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          audio: audioCaptureConstraint(this.audioPreferences.inputDeviceId),
+        });
+      } catch (error) {
+        if (
+          !this.audioPreferences.inputDeviceId ||
+          !shouldRetryWithDefaultDevice(error)
+        ) throw error;
+        this.setAudioPreferences({ ...this.audioPreferences, inputDeviceId: "" });
+        toast.info("Aide: selected microphone unavailable; using system default");
+        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      }
       const pc = new RTCPeerConnection();
       const audio = new Audio();
       audio.autoplay = true;
+      const setSinkId = (audio as HTMLAudioElement & {
+        setSinkId?: (deviceId: string) => Promise<void>;
+      }).setSinkId;
+      if (this.audioPreferences.outputDeviceId && setSinkId) {
+        try {
+          await setSinkId.call(audio, this.audioPreferences.outputDeviceId);
+        } catch {
+          this.setAudioPreferences({ ...this.audioPreferences, outputDeviceId: "" });
+          toast.info("Aide: selected speaker unavailable; using system default");
+        }
+      }
       const session: SessionHandle = { pc, stream, audio, dc: null };
       this.session = session;
 

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -10,7 +10,7 @@ import {
   shouldRetryWithDefaultDevice,
   writeAudioDevicePreferences,
   type AudioDevicePreferences,
-} from "./audio-devices";
+} from "./audio-devices.ts";
 
 export type VoiceState = "idle" | "connecting" | "live" | "muted";
 
@@ -35,6 +35,14 @@ interface SessionHandle {
   stream: MediaStream;
   audio: HTMLAudioElement;
   dc: RTCDataChannel | null;
+}
+
+function browserStorage(): Storage | null {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null;
+  }
 }
 
 /** Wait for ICE gathering to finish (bounded) so we send a complete offer. */
@@ -65,10 +73,11 @@ export class VoiceAgent {
   private listeners = new Set<() => void>();
   private bindings: Bindings | null = null;
   private nonce: string | null = null;
+  private storage = browserStorage();
   private audioPreferences: AudioDevicePreferences =
-    typeof localStorage === "undefined"
-      ? { inputDeviceId: "", outputDeviceId: "" }
-      : readAudioDevicePreferences(localStorage);
+    this.storage
+      ? readAudioDevicePreferences(this.storage)
+      : { inputDeviceId: "", outputDeviceId: "" };
   /** Serializes tool executions so outputs are submitted in call order. */
   private toolChain: Promise<void> = Promise.resolve();
   /** True while the model is generating a response (response.created→done). */
@@ -106,9 +115,18 @@ export class VoiceAgent {
 
   setAudioPreferences(next: AudioDevicePreferences) {
     this.audioPreferences = { ...next };
-    if (typeof localStorage !== "undefined") {
-      writeAudioDevicePreferences(localStorage, this.audioPreferences);
-    }
+    if (this.storage) writeAudioDevicePreferences(this.storage, this.audioPreferences);
+    this.emitChange();
+  }
+
+  refreshAudioPreferences() {
+    if (!this.storage) return;
+    const next = readAudioDevicePreferences(this.storage);
+    if (
+      next.inputDeviceId === this.audioPreferences.inputDeviceId &&
+      next.outputDeviceId === this.audioPreferences.outputDeviceId
+    ) return;
+    this.audioPreferences = next;
     this.emitChange();
   }
 
@@ -321,6 +339,8 @@ export class VoiceAgent {
       const pc = new RTCPeerConnection();
       const audio = new Audio();
       audio.autoplay = true;
+      const session: SessionHandle = { pc, stream, audio, dc: null };
+      this.session = session;
       const setSinkId = (audio as HTMLAudioElement & {
         setSinkId?: (deviceId: string) => Promise<void>;
       }).setSinkId;
@@ -328,12 +348,12 @@ export class VoiceAgent {
         try {
           await setSinkId.call(audio, this.audioPreferences.outputDeviceId);
         } catch {
+          if (this.session?.pc !== pc) return;
           this.setAudioPreferences({ ...this.audioPreferences, outputDeviceId: "" });
           toast.info("Aide: selected speaker unavailable; using system default");
         }
       }
-      const session: SessionHandle = { pc, stream, audio, dc: null };
-      this.session = session;
+      if (this.session?.pc !== pc) return;
 
       for (const track of stream.getTracks()) pc.addTrack(track, stream);
       pc.ontrack = (event) => {


### PR DESCRIPTION
## Summary
- add browser-local microphone and speaker selectors to Realtime settings and the sessions page
- apply selected devices to new WebRTC sessions with safe system-default fallback
- sync preferences across bb windows and prevent pending startup from leaking microphone capture after Stop

## Test plan
- [x] npm test (9 tests)
- [x] npm run typecheck
- [x] bb plugin types --check .
- [x] bb plugin build .
- [x] load through bb plugin dev and verify live rebuild/reload