### PR TITLE
Robust deterministic audio, simplified voice triggers, and a live composer pill

### DIFF
--- a/app.tsx
+++ b/app.tsx
@@ -15,6 +15,7 @@ import {
   useRealtime,
   useRpc,
 } from "@get-bb/plugin-sdk/app";
+import type { PluginThreadListProps } from "@get-bb/plugin-sdk/app";
 import type { rpcContract } from "./server";
 import { voiceAgent } from "./voice-agent";
 import { AudioDeviceSettings, SessionsPanel } from "./sessions-panel";
@@ -144,7 +145,81 @@ function AideVoiceButton() {
   );
 }
 
-/** Trailing accessory on the Aide sidebar row: shows when a call is on. */
+/**
+ * Persistent voice bar pinned to the top of the sidebar thread area (between
+ * the plugin nav rows and the Threads list). State-driven, so every button
+ * reflects the live call — the reason we use `experimental_threadList` rather
+ * than the state-blind footer-action slot.
+ */
+function SidebarVoiceBar() {
+  const state = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
+  const live = state === "live";
+  const muted = state === "muted";
+  const active = live || muted;
+  return (
+    <div className="flex shrink-0 items-center gap-1.5 border-b border-border bg-background px-2 py-1.5">
+      <button
+        type="button"
+        aria-label={active ? "Stop Aide voice agent" : "Start Aide voice agent"}
+        title={active ? "Stop Aide" : "Talk to Aide"}
+        onClick={() => voiceAgent.toggle()}
+        className={cn(
+          "flex h-7 flex-1 items-center justify-center gap-1.5 rounded-md border px-2 text-xs font-medium transition-colors",
+          state === "idle" &&
+            "border-border text-muted-foreground hover:bg-accent hover:text-foreground",
+          state === "connecting" && "animate-pulse border-primary/50 text-primary",
+          live && "border-primary bg-primary/15 text-primary",
+          muted && "border-primary/40 bg-primary/5 text-primary/60",
+        )}
+      >
+        <WaveformIcon live={live} />
+        {state === "idle"
+          ? "Talk to Aide"
+          : state === "connecting"
+            ? "Connecting…"
+            : muted
+              ? "Muted"
+              : "Live"}
+      </button>
+      {active ? (
+        <button
+          type="button"
+          aria-label={muted ? "Unmute Aide microphone" : "Mute Aide microphone"}
+          title={muted ? "Unmute" : "Mute"}
+          onClick={() => voiceAgent.toggleMute()}
+          className={cn(
+            "flex size-7 shrink-0 items-center justify-center rounded-md border transition-colors",
+            muted
+              ? "border-destructive bg-destructive/15 text-destructive"
+              : "border-border text-muted-foreground hover:bg-accent hover:text-foreground",
+          )}
+        >
+          <MicIcon slashed={muted} />
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Sidebar thread list with the voice bar above BB's own list. The bar is a
+ * fixed-height flex child; `Original` gets the remaining height in a scrollable
+ * box (`min-h-0` lets it shrink so the scroll region is bounded, not overlapping
+ * the bar). `overflow-y-auto` — not `hidden` — so a list that scrolls via its
+ * parent still scrolls.
+ */
+function ThreadListWithVoiceBar({ Original }: PluginThreadListProps) {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <SidebarVoiceBar />
+      <div className="relative min-h-0 flex-1 overflow-y-auto pb-6">
+        <Original />
+      </div>
+    </div>
+  );
+}
+
+/** Trailing accessory on the Aide sidebar row: a live indicator (display only). */
 function SidebarLiveIndicator() {
   const state = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
   if (state === "idle") return null;
@@ -188,6 +263,19 @@ export default definePluginApp((app) => {
     component: SessionsPanel,
     experimental_sidebarAccessory: SidebarLiveIndicator,
   });
+  // --- Global surface trial: multiple always-reachable triggers for the same
+  // singleton call. All are pure toggles; the composer button owns the binding.
+  // Persistent voice bar above the Threads list. A component slot, so buttons
+  // reflect live call state (unlike the footer-action / command-palette slots).
+  // Optional: a voice bar above the thread list, for anyone who wants an
+  // always-visible control. Off by default is not possible (registering
+  // activates it), but users can pin BB's list under Settings → Appearance.
+  app.slots.experimental_threadList({
+    id: "voice-bar",
+    title: "Handsfree voice bar",
+    description: "Adds a persistent voice control bar above the thread list.",
+    component: ThreadListWithVoiceBar,
+  });
   // The session deliberately outlives any component, so tie it to the plugin
   // frontend generation instead: on reload/disable the old bundle's singleton
   // would otherwise keep a zombie WebRTC call no button controls.
@@ -197,6 +285,10 @@ export default definePluginApp((app) => {
       window.addEventListener("storage", (event) => {
         if (event.key === AUDIO_DEVICE_STORAGE_KEY) voiceAgent.refreshAudioPreferences();
       }, { signal });
+      // Release the mic synchronously before the page tears down. Without this,
+      // a hard reload (Cmd+R) leaves the previous page holding the input device,
+      // so the fresh page enumerates zero microphones until the OS reclaims it.
+      window.addEventListener("pagehide", () => voiceAgent.stop(), { signal });
       signal.addEventListener("abort", () => voiceAgent.stop());
       return () => voiceAgent.stop();
     },

--- a/app.tsx
+++ b/app.tsx
@@ -118,10 +118,11 @@ function AideVoiceButton() {
   const live = state === "live";
   const muted = state === "muted";
 
-  // During a call, one segmented pill: mute · a live activity waveform in the
-  // middle · stop. The waveform animates and tints by who has the floor — you
-  // (primary) vs Aide (amber) — so it feels like a live conversation, driven
-  // purely by the data-channel activity signals (no audio analysis).
+  // During a call, one segmented pill with NEUTRAL chrome (border/icons use
+  // theme-neutral tokens so it reads well on any theme regardless of how bold
+  // its primary is). Color appears only on the middle waveform to signal who
+  // has the floor: you (bright foreground) vs Aide (primary). Driven purely by
+  // data-channel activity signals — no audio analysis.
   if (live || muted) {
     // Aide can still be talking while your mic is muted, so the middle
     // indicator tracks conversation activity independent of mute. Mute is shown
@@ -136,12 +137,7 @@ function AideVoiceButton() {
           ? "Muted"
           : "Connected";
     return (
-      <div
-        className={cn(
-          "flex h-7 shrink-0 items-center overflow-hidden rounded-full border",
-          muted ? "border-primary/40 bg-primary/5" : "border-primary bg-primary/15",
-        )}
-      >
+      <div className="flex h-7 shrink-0 items-center overflow-hidden rounded-full border border-border bg-accent">
         <button
           type="button"
           aria-label={muted ? "Unmute Aide microphone" : "Mute Aide microphone"}
@@ -150,36 +146,36 @@ function AideVoiceButton() {
           className={cn(
             "flex size-7 items-center justify-center transition-colors",
             muted
-              ? "text-destructive hover:bg-destructive/10"
-              : "text-primary hover:bg-primary/10",
+              ? "text-destructive hover:bg-destructive/20"
+              : "text-muted-foreground hover:bg-background/50 hover:text-foreground",
           )}
         >
           <MicIcon slashed={muted} />
         </button>
-        <span className="h-4 w-px bg-primary/25" />
+        <span className="h-4 w-px bg-border" />
         <span
           className={cn(
             "flex h-7 items-center justify-center px-2 transition-colors",
-            speaking
-              ? "text-amber-400"
-              : listening
-                ? "text-primary"
-                : muted
-                  ? "text-primary/40"
-                  : "text-primary/50",
+            muted
+              ? "text-muted-foreground/50"
+              : speaking
+                ? "text-[color:var(--success,#6faf76)]" // themed green for Aide
+                : listening
+                  ? "text-foreground"
+                  : "text-muted-foreground",
           )}
           title={middleLabel}
           aria-label={middleLabel}
         >
           <WaveformIcon live={speaking || listening} />
         </span>
-        <span className="h-4 w-px bg-primary/25" />
+        <span className="h-4 w-px bg-border" />
         <button
           type="button"
           aria-label="Stop Aide voice session"
           title="Stop"
           onClick={() => voiceAgent.stop()}
-          className="flex size-7 items-center justify-center text-primary transition-colors hover:bg-destructive/15 hover:text-destructive"
+          className="flex size-7 items-center justify-center text-muted-foreground transition-colors hover:bg-destructive/15 hover:text-destructive"
         >
           <StopIcon />
         </button>

--- a/app.tsx
+++ b/app.tsx
@@ -51,6 +51,15 @@ function MicIcon({ slashed }: { slashed: boolean }) {
   );
 }
 
+/** A rounded stop square — ends the voice session. */
+function StopIcon() {
+  return (
+    <svg viewBox="0 0 16 16" className="size-3.5" fill="currentColor" aria-hidden>
+      <rect x="4" y="4" width="8" height="8" rx="1.6" />
+    </svg>
+  );
+}
+
 function AideVoiceButton() {
   const rpc = useRpc<typeof rpcContract>();
   const composer = useComposer();
@@ -65,6 +74,7 @@ function AideVoiceButton() {
   const effectiveProjectId = projectId ?? scopeProjectId;
   const sidebarActions = experimental_useSidebarThreadActions();
   const state = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
+  const activity = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getActivity);
 
   // Global exclusivity: when any window starts a call, all others stop theirs.
   useRealtime("voice-call", (payload) => {
@@ -107,41 +117,91 @@ function AideVoiceButton() {
 
   const live = state === "live";
   const muted = state === "muted";
-  return (
-    <>
-      {live || muted ? (
+
+  // During a call, one segmented pill: mute · a live activity waveform in the
+  // middle · stop. The waveform animates and tints by who has the floor — you
+  // (primary) vs Aide (amber) — so it feels like a live conversation, driven
+  // purely by the data-channel activity signals (no audio analysis).
+  if (live || muted) {
+    // Aide can still be talking while your mic is muted, so the middle
+    // indicator tracks conversation activity independent of mute. Mute is shown
+    // by the slashed mic on the left button, not by graying this out.
+    const speaking = activity === "aide";
+    const listening = activity === "you"; // never true while muted (mic is off)
+    const middleLabel = speaking
+      ? "Aide speaking…"
+      : listening
+        ? "Listening…"
+        : muted
+          ? "Muted"
+          : "Connected";
+    return (
+      <div
+        className={cn(
+          "flex h-7 shrink-0 items-center overflow-hidden rounded-full border",
+          muted ? "border-primary/40 bg-primary/5" : "border-primary bg-primary/15",
+        )}
+      >
         <button
           type="button"
           aria-label={muted ? "Unmute Aide microphone" : "Mute Aide microphone"}
           title={muted ? "Unmute" : "Mute"}
           onClick={() => voiceAgent.toggleMute()}
           className={cn(
-            "flex size-7 shrink-0 items-center justify-center rounded-full border transition-colors",
+            "flex size-7 items-center justify-center transition-colors",
             muted
-              ? "border-destructive bg-destructive/15 text-destructive"
-              : "border-border text-muted-foreground hover:bg-accent hover:text-foreground",
+              ? "text-destructive hover:bg-destructive/10"
+              : "text-primary hover:bg-primary/10",
           )}
         >
           <MicIcon slashed={muted} />
         </button>
-      ) : null}
-      <button
-        type="button"
-        aria-label={live || muted ? "Stop Aide voice agent" : "Start Aide voice agent"}
-        title={live || muted ? "Stop Aide" : "Talk to Aide"}
-        onClick={() => voiceAgent.toggle()}
-        className={cn(
-          "flex size-7 shrink-0 items-center justify-center rounded-full border transition-colors",
-          state === "idle" &&
-            "border-border text-muted-foreground hover:bg-accent hover:text-foreground",
-          state === "connecting" && "animate-pulse border-primary/50 text-primary",
-          live && "border-primary bg-primary/15 text-primary",
-          muted && "border-primary/40 bg-primary/5 text-primary/60",
-        )}
-      >
-        <WaveformIcon live={live} />
-      </button>
-    </>
+        <span className="h-4 w-px bg-primary/25" />
+        <span
+          className={cn(
+            "flex h-7 items-center justify-center px-2 transition-colors",
+            speaking
+              ? "text-amber-400"
+              : listening
+                ? "text-primary"
+                : muted
+                  ? "text-primary/40"
+                  : "text-primary/50",
+          )}
+          title={middleLabel}
+          aria-label={middleLabel}
+        >
+          <WaveformIcon live={speaking || listening} />
+        </span>
+        <span className="h-4 w-px bg-primary/25" />
+        <button
+          type="button"
+          aria-label="Stop Aide voice session"
+          title="Stop"
+          onClick={() => voiceAgent.stop()}
+          className="flex size-7 items-center justify-center text-primary transition-colors hover:bg-destructive/15 hover:text-destructive"
+        >
+          <StopIcon />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label="Start Aide voice agent"
+      title="Talk to Aide"
+      onClick={() => voiceAgent.toggle()}
+      className={cn(
+        "flex size-7 shrink-0 items-center justify-center rounded-full border transition-colors",
+        state === "connecting"
+          ? "animate-pulse border-primary/50 text-primary"
+          : "border-border text-muted-foreground hover:bg-accent hover:text-foreground",
+      )}
+    >
+      <WaveformIcon live={false} />
+    </button>
   );
 }
 

--- a/app.tsx
+++ b/app.tsx
@@ -5,7 +5,7 @@
 // and audio playback happen right here in the bb app); the backend performs
 // the SDP exchange (it holds the API key) and executes bb tools via bb.sdk.
 // The session itself lives in voice-agent.ts and outlives any component.
-import { useEffect, useSyncExternalStore } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import {
   definePluginApp,
   experimental_useSidebarThreadActions,
@@ -156,13 +156,13 @@ function AideVoiceButton() {
         <span
           className={cn(
             "flex h-7 items-center justify-center px-2 transition-colors",
-            muted
-              ? "text-muted-foreground/50"
-              : speaking
-                ? "text-[color:var(--success,#6faf76)]" // themed green for Aide
-                : listening
-                  ? "text-foreground"
-                  : "text-muted-foreground",
+            // Aide can still be talking while you're muted, so who's-speaking
+            // wins over the muted/quiet dim (mute is shown by the slashed mic).
+            speaking
+              ? "text-[color:var(--success,#6faf76)]" // themed green for Aide
+              : listening
+                ? "text-foreground"
+                : "text-muted-foreground/60",
           )}
           title={middleLabel}
           aria-label={middleLabel}
@@ -209,9 +209,31 @@ function AideVoiceButton() {
  */
 function SidebarVoiceBar() {
   const state = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
+  const activity = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getActivity);
   const live = state === "live";
   const muted = state === "muted";
   const active = live || muted;
+  const speaking = activity === "aide";
+  const listening = activity === "you";
+  // Same neutral-chrome + activity-color scheme as the composer pill: color
+  // marks who has the floor, everything else stays theme-neutral.
+  const activityColor = speaking
+    ? "text-[color:var(--success,#6faf76)]" // Aide
+    : listening
+      ? "text-foreground" // you
+      : "text-muted-foreground";
+  const label =
+    state === "idle"
+      ? "Talk to Aide"
+      : state === "connecting"
+        ? "Connecting…"
+        : speaking
+          ? "Aide speaking…"
+          : listening
+            ? "Listening…"
+            : muted
+              ? "Muted"
+              : "Live";
   return (
     <div className="flex shrink-0 items-center gap-1.5 border-b border-border bg-background px-2 py-1.5">
       <button
@@ -220,22 +242,17 @@ function SidebarVoiceBar() {
         title={active ? "Stop Aide" : "Talk to Aide"}
         onClick={() => voiceAgent.toggle()}
         className={cn(
-          "flex h-7 flex-1 items-center justify-center gap-1.5 rounded-md border px-2 text-xs font-medium transition-colors",
-          state === "idle" &&
-            "border-border text-muted-foreground hover:bg-accent hover:text-foreground",
-          state === "connecting" && "animate-pulse border-primary/50 text-primary",
-          live && "border-primary bg-primary/15 text-primary",
-          muted && "border-primary/40 bg-primary/5 text-primary/60",
+          "flex h-7 flex-1 items-center justify-center gap-1.5 rounded-md border border-border px-2 text-xs font-medium transition-colors",
+          active
+            ? "bg-accent"
+            : "text-muted-foreground hover:bg-accent hover:text-foreground",
+          state === "connecting" && "animate-pulse",
         )}
       >
-        <WaveformIcon live={live} />
-        {state === "idle"
-          ? "Talk to Aide"
-          : state === "connecting"
-            ? "Connecting…"
-            : muted
-              ? "Muted"
-              : "Live"}
+        <span className={cn("flex items-center gap-1.5", active && activityColor)}>
+          <WaveformIcon live={speaking || listening} />
+          {label}
+        </span>
       </button>
       {active ? (
         <button
@@ -244,10 +261,10 @@ function SidebarVoiceBar() {
           title={muted ? "Unmute" : "Mute"}
           onClick={() => voiceAgent.toggleMute()}
           className={cn(
-            "flex size-7 shrink-0 items-center justify-center rounded-md border transition-colors",
+            "flex size-7 shrink-0 items-center justify-center rounded-md border border-border transition-colors",
             muted
-              ? "border-destructive bg-destructive/15 text-destructive"
-              : "border-border text-muted-foreground hover:bg-accent hover:text-foreground",
+              ? "text-destructive hover:bg-destructive/15"
+              : "text-muted-foreground hover:bg-accent hover:text-foreground",
           )}
         >
           <MicIcon slashed={muted} />
@@ -275,27 +292,52 @@ function ThreadListWithVoiceBar({ Original }: PluginThreadListProps) {
   );
 }
 
-/** Trailing accessory on the Aide sidebar row: a live indicator (display only). */
+function formatElapsed(ms: number): string {
+  const total = Math.floor(Math.max(0, ms) / 1000);
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+/** Live call duration as m:ss, ticking each second; null when no live call. */
+function useCallElapsed(): string | null {
+  const startedAt = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getLiveStartedAt);
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (startedAt == null) return;
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [startedAt]);
+  return startedAt == null ? null : formatElapsed(now - startedAt);
+}
+
+/** Trailing accessory on the Aide sidebar row: a live indicator with duration. */
 function SidebarLiveIndicator() {
   const state = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
+  const elapsed = useCallElapsed();
   if (state === "idle") return null;
-  if (state === "muted") {
-    return (
-      <span className="flex items-center gap-1.5 text-xs text-destructive">
-        <span className="size-2 rounded-full bg-destructive/70" />
-        muted
-      </span>
-    );
-  }
+  const muted = state === "muted";
+  const connecting = state === "connecting";
   return (
-    <span className="flex items-center gap-1.5 text-xs text-primary">
+    <span
+      className="flex items-center gap-1.5 text-xs tabular-nums text-muted-foreground"
+      title={muted ? "Muted" : connecting ? "Connecting" : "Live"}
+    >
+      {/* The timer stays one neutral color (it's just call duration, not an
+          error). The dot carries the state: pulsing = connecting (in progress),
+          solid = live (established), solid red = muted. */}
       <span
         className={cn(
-          "size-2 rounded-full bg-primary",
-          state === "live" ? "animate-pulse" : "opacity-50",
+          "size-2 rounded-full",
+          connecting
+            ? "bg-primary animate-pulse"
+            : muted
+              ? "bg-destructive"
+              : "bg-primary",
         )}
       />
-      {state === "live" ? "live" : "\u2026"}
+      {connecting ? "\u2026" : elapsed ?? ""}
     </span>
   );
 }

--- a/audio-devices.test.ts
+++ b/audio-devices.test.ts
@@ -2,11 +2,17 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   audioCaptureConstraint,
+  describeAudioSupport,
   deviceDisplayLabel,
+  queryMicPermission,
   readAudioDevicePreferences,
+  resolveDevice,
   shouldRetryWithDefaultDevice,
   writeAudioDevicePreferences,
 } from "./audio-devices.ts";
+
+const MIC = { deviceId: "mic-1", kind: "audioinput" as const, label: "Built-in Mic" };
+const SPEAKER = { deviceId: "spk-1", kind: "audiooutput" as const, label: "Built-in Speaker" };
 
 test("uses the browser default microphone when no preference is saved", () => {
   assert.equal(audioCaptureConstraint(""), true);
@@ -29,7 +35,7 @@ test("provides readable labels before browser permission reveals device names", 
   );
 });
 
-test("persists browser-local audio preferences", () => {
+test("persists the chosen microphone with its label", () => {
   const values = new Map<string, string>();
   const storage = {
     getItem: (key: string) => values.get(key) ?? null,
@@ -38,12 +44,12 @@ test("persists browser-local audio preferences", () => {
 
   assert.equal(writeAudioDevicePreferences(storage, {
     inputDeviceId: "input-123",
-    outputDeviceId: "output-456",
+    inputLabel: "Shure MV7",
   }), true);
 
   assert.deepEqual(readAudioDevicePreferences(storage), {
     inputDeviceId: "input-123",
-    outputDeviceId: "output-456",
+    inputLabel: "Shure MV7",
   });
 });
 
@@ -57,7 +63,7 @@ test("keeps storage failures from breaking in-memory device selection", () => {
 
   assert.equal(writeAudioDevicePreferences(storage, {
     inputDeviceId: "input-123",
-    outputDeviceId: "output-456",
+    inputLabel: "Shure MV7",
   }), false);
 });
 
@@ -69,7 +75,7 @@ test("ignores invalid persisted audio preferences", () => {
 
   assert.deepEqual(readAudioDevicePreferences(storage), {
     inputDeviceId: "",
-    outputDeviceId: "",
+    inputLabel: "",
   });
 });
 
@@ -78,4 +84,77 @@ test("only retries capture failures caused by an unavailable selected device", (
   assert.equal(shouldRetryWithDefaultDevice({ name: "NotFoundError" }), true);
   assert.equal(shouldRetryWithDefaultDevice({ name: "NotAllowedError" }), false);
   assert.equal(shouldRetryWithDefaultDevice(new Error("unknown")), false);
+});
+
+test("describes full support when a mic and speaker are present", () => {
+  assert.deepEqual(describeAudioSupport([MIC, SPEAKER], { inputDeviceId: "", inputLabel: "" }), {
+    hasInput: true,
+    hasOutput: true,
+    inputValid: true,
+    labelsHidden: false,
+  });
+});
+
+test("reports no input/output when the device list is empty", () => {
+  const support = describeAudioSupport([], { inputDeviceId: "", inputLabel: "" });
+  assert.equal(support.hasInput, false);
+  assert.equal(support.hasOutput, false);
+});
+
+test("keeps the saved mic valid when its label still matches after an id change", () => {
+  const rotated = { deviceId: "mic-new", kind: "audioinput" as const, label: "Built-in Mic" };
+  const support = describeAudioSupport([rotated, SPEAKER], {
+    inputDeviceId: "mic-1",
+    inputLabel: "Built-in Mic",
+  });
+  assert.equal(support.inputValid, true);
+});
+
+test("marks the saved mic invalid only when neither id nor label matches", () => {
+  const support = describeAudioSupport([SPEAKER], { inputDeviceId: "mic-1", inputLabel: "Gone Mic" });
+  assert.equal(support.inputValid, false);
+});
+
+test("flags privacy-gated devices whose labels are still hidden", () => {
+  const gated = [{ deviceId: "mic-1", kind: "audioinput" as const, label: "" }];
+  assert.equal(describeAudioSupport(gated, { inputDeviceId: "", inputLabel: "" }).labelsHidden, true);
+});
+
+test("resolves a saved mic by id, then by label, else the system default", () => {
+  assert.deepEqual(resolveDevice([MIC], "audioinput", "mic-1", "Built-in Mic"), {
+    deviceId: "mic-1",
+    matchedBy: "id",
+  });
+  // id rotated across a restart, but the label still matches → recover it
+  const rotated = { deviceId: "mic-9", kind: "audioinput" as const, label: "Built-in Mic" };
+  assert.deepEqual(resolveDevice([rotated], "audioinput", "mic-1", "Built-in Mic"), {
+    deviceId: "mic-9",
+    matchedBy: "label",
+  });
+  // genuinely gone → system default
+  assert.deepEqual(resolveDevice([SPEAKER], "audioinput", "mic-1", "Built-in Mic"), {
+    deviceId: "",
+    matchedBy: "default",
+  });
+  // no saved selection → system default
+  assert.deepEqual(resolveDevice([MIC], "audioinput", "", ""), {
+    deviceId: "",
+    matchedBy: "default",
+  });
+});
+
+test("reads programmatic mic permission, degrading to unknown", async () => {
+  assert.equal(await queryMicPermission(undefined), "unknown");
+  assert.equal(
+    await queryMicPermission({ query: async () => ({ state: "granted" }) as PermissionStatus }),
+    "granted",
+  );
+  assert.equal(
+    await queryMicPermission({
+      query: async () => {
+        throw new Error("unsupported name");
+      },
+    }),
+    "unknown",
+  );
 });

--- a/audio-devices.ts
+++ b/audio-devices.ts
@@ -4,9 +4,15 @@ export interface AudioDeviceLike {
   label: string;
 }
 
+/**
+ * Only the microphone is user-selectable. Speaker output always uses the system
+ * default (routing a specific sink via `setSinkId` proved unreliable in the bb
+ * webview and added little over the OS default). We remember the chosen mic's
+ * label as well as its id so a restart that rotates device ids can re-match it.
+ */
 export interface AudioDevicePreferences {
   inputDeviceId: string;
-  outputDeviceId: string;
+  inputLabel: string;
 }
 
 interface PreferenceStorage {
@@ -17,7 +23,7 @@ interface PreferenceStorage {
 export const AUDIO_DEVICE_STORAGE_KEY = "bb-handsfree.audio-devices";
 const DEFAULT_PREFERENCES: AudioDevicePreferences = {
   inputDeviceId: "",
-  outputDeviceId: "",
+  inputLabel: "",
 };
 
 export function readAudioDevicePreferences(storage: PreferenceStorage): AudioDevicePreferences {
@@ -25,7 +31,7 @@ export function readAudioDevicePreferences(storage: PreferenceStorage): AudioDev
     const parsed = JSON.parse(storage.getItem(AUDIO_DEVICE_STORAGE_KEY) ?? "null") as Record<string, unknown> | null;
     return {
       inputDeviceId: typeof parsed?.inputDeviceId === "string" ? parsed.inputDeviceId : "",
-      outputDeviceId: typeof parsed?.outputDeviceId === "string" ? parsed.outputDeviceId : "",
+      inputLabel: typeof parsed?.inputLabel === "string" ? parsed.inputLabel : "",
     };
   } catch {
     return { ...DEFAULT_PREFERENCES };
@@ -58,4 +64,93 @@ export function shouldRetryWithDefaultDevice(error: unknown): boolean {
 export function deviceDisplayLabel(device: AudioDeviceLike, index: number): string {
   if (device.label) return device.label;
   return `${device.kind === "audioinput" ? "Microphone" : "Speaker"} ${index + 1}`;
+}
+
+export type MicPermission = "granted" | "denied" | "prompt" | "unknown";
+
+/**
+ * A deterministic snapshot of what the browser can actually do right now,
+ * derived purely from an enumerated device list and the saved preferences.
+ * The UI grays out controls from this; the session decides fallbacks from it.
+ */
+export interface AudioSupport {
+  /** At least one usable input device is present. */
+  hasInput: boolean;
+  /** At least one output device is present (playback uses the system default). */
+  hasOutput: boolean;
+  /** The saved mic is empty (system default) or still resolvable (by id or label). */
+  inputValid: boolean;
+  /**
+   * Inputs exist but every label is blank — the browsing context has not been
+   * granted mic access yet, so ids/labels are still privacy-gated.
+   */
+  labelsHidden: boolean;
+}
+
+export function describeAudioSupport(
+  devices: AudioDeviceLike[],
+  preferences: AudioDevicePreferences,
+): AudioSupport {
+  const inputs = devices.filter((device) => device.kind === "audioinput" && device.deviceId);
+  const outputs = devices.filter((device) => device.kind === "audiooutput" && device.deviceId);
+  const inputMatch = resolveDevice(
+    devices,
+    "audioinput",
+    preferences.inputDeviceId,
+    preferences.inputLabel,
+  );
+  return {
+    hasInput: inputs.length > 0,
+    hasOutput: outputs.length > 0,
+    inputValid: !preferences.inputDeviceId || inputMatch.matchedBy !== "default",
+    labelsHidden: inputs.length > 0 && inputs.every((device) => !device.label),
+  };
+}
+
+/** How a saved device was resolved against the currently present devices. */
+export type DeviceMatch = "id" | "label" | "default";
+
+export interface ResolvedDevice {
+  /** The device id to use; "" means the system default. */
+  deviceId: string;
+  matchedBy: DeviceMatch;
+}
+
+/**
+ * Resolve a saved device against what is actually present, without ever
+ * throwing. Prefer an exact id; if the id has rotated across an app restart,
+ * fall back to a device with the same remembered label (so a saved mic keeps
+ * working); otherwise use the system default. This replaces the old "request
+ * an exact id, catch the failure, retry" dance with one up-front decision.
+ */
+export function resolveDevice(
+  devices: AudioDeviceLike[],
+  kind: MediaDeviceKind,
+  savedId: string,
+  savedLabel: string,
+): ResolvedDevice {
+  if (!savedId) return { deviceId: "", matchedBy: "default" };
+  const ofKind = devices.filter((device) => device.kind === kind && device.deviceId);
+  if (ofKind.some((device) => device.deviceId === savedId)) {
+    return { deviceId: savedId, matchedBy: "id" };
+  }
+  const byLabel = savedLabel
+    ? ofKind.find((device) => device.label && device.label === savedLabel)
+    : undefined;
+  if (byLabel) return { deviceId: byLabel.deviceId, matchedBy: "label" };
+  return { deviceId: "", matchedBy: "default" };
+}
+
+/** Programmatic mic permission state; "unknown" when the API is unavailable. */
+export async function queryMicPermission(
+  permissions: Pick<Permissions, "query"> | undefined,
+): Promise<MicPermission> {
+  if (!permissions?.query) return "unknown";
+  try {
+    const status = await permissions.query({ name: "microphone" as PermissionName });
+    const state = status.state;
+    return state === "granted" || state === "denied" || state === "prompt" ? state : "unknown";
+  } catch {
+    return "unknown";
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "bb-plugin-realtime",
-  "version": "0.1.0",
+  "name": "bb-plugin-handsfree",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "bb-plugin-realtime",
-      "version": "0.1.0",
+      "name": "bb-plugin-handsfree",
+      "version": "0.1.3",
       "dependencies": {
         "@hugeicons/core-free-icons": "^4.1.3",
         "@hugeicons/react": "^1.1.6",
@@ -174,6 +174,7 @@
       "integrity": "sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw==",
       "dev": true,
       "license": "apache-2.0",
+      "peer": true,
       "engines": {
         "vscode": "^1.0.0"
       }
@@ -1228,6 +1229,7 @@
       "integrity": "sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@shikijs/types": "4.4.3"
       },
@@ -1276,6 +1278,7 @@
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1316,6 +1319,7 @@
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1326,6 +1330,7 @@
       "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1385,6 +1390,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -1693,6 +1699,7 @@
       "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2173,8 +2180,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -2195,6 +2201,7 @@
       "integrity": "sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@shikijs/core": "4.4.3",
         "@shikijs/engine-javascript": "4.4.3",
@@ -2587,6 +2594,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.2.tgz",
       "integrity": "sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/server.ts
+++ b/server.ts
@@ -949,6 +949,13 @@ export default async function plugin(bb: BbPluginApi) {
       db.prepare(
         "INSERT INTO session_events (session_id, ts, kind, payload) VALUES (?, ?, ?, ?)",
       ).run(sessionId, Date.now(), kind, JSON.stringify(payload));
+      // Mirror audio-device diagnostics to the plugin log so `bb plugin logs
+      // handsfree` surfaces mic/speaker problems without opening the DB.
+      if (kind.startsWith("audio.")) {
+        const detail = JSON.stringify(payload);
+        if (kind.endsWith(".failed")) bb.log.error(`${kind} ${detail}`);
+        else bb.log.info(`${kind} ${detail}`);
+      }
       bb.realtime.publish("aide-log", { sessionId });
       return { ok: true as const };
     },

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -98,8 +98,6 @@ export function AudioDeviceSettings() {
   const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [deviceError, setDeviceError] = useState<string | null>(null);
-  const supportsSpeakerSelection =
-    typeof HTMLMediaElement !== "undefined" && "setSinkId" in HTMLMediaElement.prototype;
 
   const refresh = useCallback(async () => {
     if (!navigator.mediaDevices?.enumerateDevices) {
@@ -126,10 +124,12 @@ export function AudioDeviceSettings() {
   const inputs = devices.filter(
     (device) => device.kind === "audioinput" && device.deviceId,
   );
-  const outputs = devices.filter(
-    (device) => device.kind === "audiooutput" && device.deviceId,
-  );
   const labelsHidden = inputs.length > 0 && inputs.every((device) => !device.label);
+  // The saved mic can no longer be found (unplugged, or its id rotated with no
+  // matching label). Keep it visible so the user can see and re-pick it.
+  const savedMicMissing =
+    !!preferences.inputDeviceId &&
+    !inputs.some((device) => device.deviceId === preferences.inputDeviceId);
 
   async function allowAccess() {
     try {
@@ -141,34 +141,36 @@ export function AudioDeviceSettings() {
     }
   }
 
-  function change(kind: "input" | "output", deviceId: string) {
-    voiceAgent.setAudioPreferences({
-      ...preferences,
-      [kind === "input" ? "inputDeviceId" : "outputDeviceId"]: deviceId,
-    });
-    toast.success("Audio device saved — applies to the next voice session");
+  function change(deviceId: string) {
+    const label = inputs.find((device) => device.deviceId === deviceId)?.label ?? "";
+    voiceAgent.setAudioPreferences({ inputDeviceId: deviceId, inputLabel: label });
+    toast.success("Microphone saved — applies to the next voice session");
   }
 
   return (
     <details className="rounded-lg border border-border bg-card">
       <summary className="cursor-pointer px-3 py-2.5 text-sm font-medium text-foreground">
-        Audio devices
+        Microphone
         <span className="ml-2 text-xs font-normal text-muted-foreground">
-          microphone and speaker
+          speaker uses your system default
         </span>
       </summary>
-      <div className="grid gap-3 border-t border-border/50 p-3 sm:grid-cols-2">
-        <label className="space-y-1 text-xs text-muted-foreground">
+      <div className="space-y-3 border-t border-border/50 p-3">
+        <label className="block space-y-1 text-xs text-muted-foreground">
           <span>Microphone</span>
           <select
             value={preferences.inputDeviceId}
             disabled={loading}
-            onChange={(event) => change("input", event.target.value)}
+            onChange={(event) => change(event.target.value)}
             className="block w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm text-foreground"
           >
             <option value="">System default</option>
-            {preferences.inputDeviceId && !inputs.some((device) => device.deviceId === preferences.inputDeviceId) ? (
-              <option value={preferences.inputDeviceId}>Unavailable device</option>
+            {savedMicMissing ? (
+              <option value={preferences.inputDeviceId}>
+                {preferences.inputLabel
+                  ? `${preferences.inputLabel} (not connected)`
+                  : "Selected microphone (not connected)"}
+              </option>
             ) : null}
             {inputs.map((device, index) => (
               <option key={device.deviceId} value={device.deviceId}>
@@ -177,32 +179,13 @@ export function AudioDeviceSettings() {
             ))}
           </select>
         </label>
-        <label className="space-y-1 text-xs text-muted-foreground">
-          <span>Speaker</span>
-          <select
-            value={supportsSpeakerSelection ? preferences.outputDeviceId : ""}
-            disabled={loading || !supportsSpeakerSelection}
-            onChange={(event) => change("output", event.target.value)}
-            className="block w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm text-foreground disabled:opacity-60"
-          >
-            <option value="">System default</option>
-            {preferences.outputDeviceId && !outputs.some((device) => device.deviceId === preferences.outputDeviceId) ? (
-              <option value={preferences.outputDeviceId}>Unavailable device</option>
-            ) : null}
-            {outputs.map((device, index) => (
-              <option key={device.deviceId} value={device.deviceId}>
-                {deviceDisplayLabel(device, index)}
-              </option>
-            ))}
-          </select>
-        </label>
-        <div className="sm:col-span-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+        <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
           <span>
-            {!supportsSpeakerSelection
-              ? "This browser only supports the system-default speaker."
-              : labelsHidden
-                ? "Allow microphone access to reveal device names."
-                : "Selections are stored in this browser and apply to new sessions."}
+            {labelsHidden
+              ? "Allow microphone access to reveal device names."
+              : savedMicMissing
+                ? "Your selected mic isn't connected — sessions use the system default until it returns."
+                : "Stored in this browser; applies to new sessions. Speaker always uses the system default."}
           </span>
           <span className="flex shrink-0 items-center gap-2">
             {labelsHidden ? (
@@ -224,7 +207,7 @@ export function AudioDeviceSettings() {
           </span>
         </div>
         {deviceError ? (
-          <p className="sm:col-span-2 text-xs text-destructive">{deviceError}</p>
+          <p className="text-xs text-destructive">{deviceError}</p>
         ) : null}
       </div>
     </details>

--- a/voice-agent.test.ts
+++ b/voice-agent.test.ts
@@ -19,14 +19,14 @@ test("reloads audio preferences saved by another browser window", () => {
     const agent = new VoiceAgent();
     writeAudioDevicePreferences(storage, {
       inputDeviceId: "mic-from-window-a",
-      outputDeviceId: "speaker-from-window-a",
+      inputLabel: "Window A Mic",
     });
 
     agent.refreshAudioPreferences();
 
     assert.deepEqual(agent.getAudioPreferences(), {
       inputDeviceId: "mic-from-window-a",
-      outputDeviceId: "speaker-from-window-a",
+      inputLabel: "Window A Mic",
     });
   } finally {
     if (originalWindow) Object.defineProperty(globalThis, "window", originalWindow);
@@ -34,7 +34,7 @@ test("reloads audio preferences saved by another browser window", () => {
   }
 });
 
-test("stopping during speaker routing closes the mic and cancels startup", async () => {
+test("stopping during the SDP exchange closes the mic and cancels startup", async () => {
   const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
   const originalPeerConnection = Object.getOwnPropertyDescriptor(globalThis, "RTCPeerConnection");
   const originalAudio = Object.getOwnPropertyDescriptor(globalThis, "Audio");
@@ -49,13 +49,13 @@ test("stopping during speaker routing closes the mic and cancels startup", async
     getTracks: () => [track],
     getAudioTracks: () => [track],
   } as unknown as MediaStream;
-  let resolveSink!: () => void;
-  let announceSinkStarted!: () => void;
-  const sinkStarted = new Promise<void>((resolve) => {
-    announceSinkStarted = resolve;
+  let resolveCall!: () => void;
+  let announceCallStarted!: () => void;
+  const callStarted = new Promise<void>((resolve) => {
+    announceCallStarted = resolve;
   });
-  const sinkPending = new Promise<void>((resolve) => {
-    resolveSink = resolve;
+  const callPending = new Promise<void>((resolve) => {
+    resolveCall = resolve;
   });
   let peer: FakePeerConnection | null = null;
 
@@ -64,9 +64,10 @@ test("stopping during speaker routing closes the mic and cancels startup", async
     connectionState = "new";
     localDescription: RTCSessionDescriptionInit | null = null;
     closed = false;
-    createOfferCalls = 0;
+    setRemoteCalls = 0;
     ontrack: ((event: RTCTrackEvent) => void) | null = null;
     onconnectionstatechange: (() => void) | null = null;
+    oniceconnectionstatechange: (() => void) | null = null;
 
     constructor() {
       peer = this;
@@ -79,32 +80,36 @@ test("stopping during speaker routing closes the mic and cancels startup", async
       this.closed = true;
     }
     createDataChannel() {
-      return { readyState: "connecting", close() {}, send() {}, onopen: null, onmessage: null };
+      return { readyState: "connecting", close() {}, send() {}, onopen: null, onclose: null, onmessage: null };
     }
     async createOffer() {
-      this.createOfferCalls += 1;
       return { type: "offer" as const, sdp: "offer" };
     }
     async setLocalDescription(description: RTCSessionDescriptionInit) {
       this.localDescription = description;
     }
-    async setRemoteDescription() {}
+    async setRemoteDescription() {
+      this.setRemoteCalls += 1;
+    }
   }
 
   class FakeAudio {
     autoplay = false;
     srcObject: MediaStream | null = null;
-    async setSinkId() {
-      announceSinkStarted();
-      return sinkPending;
-    }
     async play() {}
     remove() {}
   }
 
   Object.defineProperty(globalThis, "navigator", {
     configurable: true,
-    value: { mediaDevices: { getUserMedia: async () => stream } },
+    value: {
+      mediaDevices: {
+        getUserMedia: async () => stream,
+        enumerateDevices: async () => [
+          { deviceId: "mic-1", kind: "audioinput", label: "Built-in Mic" },
+        ],
+      },
+    },
   });
   Object.defineProperty(globalThis, "RTCPeerConnection", {
     configurable: true,
@@ -118,29 +123,37 @@ test("stopping during speaker routing closes the mic and cancels startup", async
   const agent = new VoiceAgent();
   agent.bind({
     rpc: {
-      call: (async (method: string) =>
-        method === "createCall" ? { sdp: "answer" } : { ok: true }) as never,
+      // Pause startup at the SDP exchange so the test can stop mid-flight.
+      call: (async (method: string) => {
+        if (method === "createCall") {
+          announceCallStarted();
+          await callPending;
+          return { sdp: "answer" };
+        }
+        return { ok: true };
+      }) as never,
     },
     context: { threadId: null, projectId: null },
     composer: { setText() {}, updateText() {} },
     openNewThread() {},
   });
-  agent.setAudioPreferences({ inputDeviceId: "", outputDeviceId: "speaker-1" });
+  agent.setAudioPreferences({ inputDeviceId: "", inputLabel: "" });
 
   try {
     agent.toggle();
-    await sinkStarted;
+    await callStarted;
     agent.stop();
 
     assert.equal(track.stopped, true);
     assert.equal(peer?.closed, true);
 
-    resolveSink();
+    resolveCall();
     await new Promise((resolve) => setImmediate(resolve));
-    assert.equal(peer?.createOfferCalls, 0);
+    // Stopped mid-exchange: the answer must never be applied.
+    assert.equal(peer?.setRemoteCalls, 0);
     assert.equal(agent.getState(), "idle");
   } finally {
-    resolveSink();
+    resolveCall();
     agent.stop();
     if (originalNavigator) Object.defineProperty(globalThis, "navigator", originalNavigator);
     else delete (globalThis as { navigator?: unknown }).navigator;

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -6,8 +6,10 @@ import type { useRpc } from "@get-bb/plugin-sdk/app";
 import type { rpcContract } from "./server";
 import {
   audioCaptureConstraint,
+  describeAudioSupport,
+  queryMicPermission,
   readAudioDevicePreferences,
-  shouldRetryWithDefaultDevice,
+  resolveDevice,
   writeAudioDevicePreferences,
   type AudioDevicePreferences,
 } from "./audio-devices.ts";
@@ -82,7 +84,7 @@ export class VoiceAgent {
   private audioPreferences: AudioDevicePreferences =
     this.storage
       ? readAudioDevicePreferences(this.storage)
-      : { inputDeviceId: "", outputDeviceId: "" };
+      : { inputDeviceId: "", inputLabel: "" };
   /** Serializes tool executions so outputs are submitted in call order. */
   private toolChain: Promise<void> = Promise.resolve();
   /** True while the model is generating a response (response.created→done). */
@@ -95,6 +97,8 @@ export class VoiceAgent {
   private noticeTimer: ReturnType<typeof setTimeout> | null = null;
   /** True between VAD speech_started and speech_stopped. */
   private userSpeaking = false;
+  /** Aborts a session that never reaches "live", so it can't hang connecting. */
+  private connectTimer: ReturnType<typeof setTimeout> | null = null;
 
   readonly subscribe = (listener: () => void): (() => void) => {
     this.listeners.add(listener);
@@ -129,7 +133,7 @@ export class VoiceAgent {
     const next = readAudioDevicePreferences(this.storage);
     if (
       next.inputDeviceId === this.audioPreferences.inputDeviceId &&
-      next.outputDeviceId === this.audioPreferences.outputDeviceId
+      next.inputLabel === this.audioPreferences.inputLabel
     ) return;
     this.audioPreferences = next;
     this.emitChange();
@@ -141,12 +145,114 @@ export class VoiceAgent {
   }
 
 
+  private clearConnectWatchdog() {
+    if (this.connectTimer) clearTimeout(this.connectTimer);
+    this.connectTimer = null;
+  }
+
+  /** Enumerate devices, degrading to an empty list rather than throwing. */
+  private async enumerateDevices(): Promise<MediaDeviceInfo[]> {
+    try {
+      return await navigator.mediaDevices.enumerateDevices();
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Acquire the microphone, tolerating the brief post-reload window where the
+   * OS reports zero input devices (a Chromium/Electron re-enumeration race that
+   * survives even a clean release). On NotFoundError we wait, bounded, for an
+   * input to reappear via `devicechange`, then retry once with the default.
+   */
+  private async acquireMic(inputId: string): Promise<MediaStream> {
+    try {
+      return await this.micStream(audioCaptureConstraint(inputId));
+    } catch (error) {
+      if ((error instanceof Error ? error.name : "") !== "NotFoundError") throw error;
+      this.logDiag("audio.getUserMedia.retry", { deviceId: inputId || "default" });
+      if (!(await this.waitForInputDevice(6000))) throw error;
+      return await this.micStream(true);
+    }
+  }
+
+  /**
+   * getUserMedia with a hard timeout. After a rapid stop→start the audio input
+   * can be mid-release and getUserMedia hangs forever (never resolves or
+   * rejects) — which stranded the UI in "connecting". A late-arriving stream is
+   * released so a timeout can't leak the mic.
+   */
+  private micStream(
+    constraint: true | MediaTrackConstraints,
+    timeoutMs = 10000,
+  ): Promise<MediaStream> {
+    const request = navigator.mediaDevices.getUserMedia({ audio: constraint });
+    let timedOut = false;
+    return new Promise<MediaStream>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        timedOut = true;
+        this.logDiag("audio.getUserMedia.timeout", {});
+        reject(new DOMException("microphone did not respond", "TimeoutError"));
+      }, timeoutMs);
+      request.then(
+        (stream) => {
+          clearTimeout(timer);
+          if (timedOut) for (const track of stream.getTracks()) track.stop();
+          else resolve(stream);
+        },
+        (error) => {
+          clearTimeout(timer);
+          if (!timedOut) reject(error);
+        },
+      );
+    });
+  }
+
+  /** Resolve true once an audio input is present, else false after `timeoutMs`. */
+  private waitForInputDevice(timeoutMs: number): Promise<boolean> {
+    const media = navigator.mediaDevices;
+    return new Promise((resolve) => {
+      let settled = false;
+      const finish = (ok: boolean) => {
+        if (settled) return;
+        settled = true;
+        clearInterval(poll);
+        clearTimeout(timer);
+        media.removeEventListener?.("devicechange", probe);
+        resolve(ok);
+      };
+      const probe = () => {
+        void this.enumerateDevices().then((devices) => {
+          if (devices.some((device) => device.kind === "audioinput" && device.deviceId)) finish(true);
+        });
+      };
+      media.addEventListener?.("devicechange", probe);
+      const poll = setInterval(probe, 500);
+      const timer = setTimeout(() => finish(false), timeoutMs);
+      probe();
+    });
+  }
+
   /** Fire-and-forget transcript logging; must never affect the call. */
   private log(kind: string, payload: Record<string, unknown> = {}) {
     const sessionId = this.nonce;
     const bindings = this.bindings;
     if (!sessionId || !bindings) return;
     void bindings.rpc.call("logEvent", { sessionId, kind, payload }).catch(() => undefined);
+  }
+
+  /**
+   * Durable audio-device diagnostics. Unlike `log`, this does NOT require an
+   * active nonce — device work (and playback failures that land after teardown
+   * has cleared the nonce) must still be recorded, or the diagnostic is lost
+   * exactly when it matters. Falls back to a stable synthetic session id.
+   */
+  private logDiag(kind: string, payload: Record<string, unknown> = {}) {
+    const rpc = this.bindings?.rpc;
+    if (!rpc) return;
+    void rpc
+      .call("logEvent", { sessionId: this.nonce ?? "audio-diagnostics", kind, payload })
+      .catch(() => undefined);
   }
 
   /** Mute = mic track sends silence; the call and playback stay up. */
@@ -241,6 +347,7 @@ export class VoiceAgent {
 
   stop() {
     if (this.session) this.log("session.stopped");
+    this.clearConnectWatchdog();
     const session = this.session;
     this.session = null;
     this.nonce = null;
@@ -327,45 +434,91 @@ export class VoiceAgent {
     this.nonce = nonce;
     this.log("session.started", { ...bindings.context });
     try {
+      // Deterministic acquisition: enumerate what is actually present, resolve
+      // the saved ids against it (a saved id whose salt rotated across restarts
+      // simply resolves to the system default), then acquire. No "try an exact
+      // id, catch, retry" dance — every branch is decided up front and logged.
+      const devices = await this.enumerateDevices();
+      const support = describeAudioSupport(devices, this.audioPreferences);
+      const micPermission = await queryMicPermission(navigator.permissions);
+      const saved = this.audioPreferences;
+      const inputMatch = resolveDevice(devices, "audioinput", saved.inputDeviceId, saved.inputLabel);
+      const inputId = inputMatch.deviceId;
+      this.logDiag("audio.snapshot", {
+        micPermission,
+        inputs: devices.filter((device) => device.kind === "audioinput").length,
+        outputs: devices.filter((device) => device.kind === "audiooutput").length,
+        savedInput: saved.inputLabel || saved.inputDeviceId || null,
+        matchedBy: inputMatch.matchedBy,
+        inputValid: support.inputValid,
+        labelsHidden: support.labelsHidden,
+      });
+      // Re-matched by label after an id rotation: quietly adopt the new id so it
+      // is a clean id-match next time. Speaker always uses the system default.
+      if (inputMatch.matchedBy === "label" && inputId !== saved.inputDeviceId) {
+        this.setAudioPreferences({ ...saved, inputDeviceId: inputId });
+      } else if (saved.inputDeviceId && inputMatch.matchedBy === "default") {
+        // The chosen mic is genuinely gone. Tell the user (not an error) and keep
+        // their selection so they can see it and re-pick — do not silently wipe.
+        const name = saved.inputLabel || "your selected microphone";
+        toast.info(`Aide: ${name} isn't available — using the system default. Pick one in Handsfree settings.`);
+      }
+
       let stream: MediaStream;
       try {
-        stream = await navigator.mediaDevices.getUserMedia({
-          audio: audioCaptureConstraint(this.audioPreferences.inputDeviceId),
-        });
+        stream = await this.acquireMic(inputId);
       } catch (error) {
-        if (
-          !this.audioPreferences.inputDeviceId ||
-          !shouldRetryWithDefaultDevice(error)
-        ) throw error;
-        this.setAudioPreferences({ ...this.audioPreferences, inputDeviceId: "" });
-        toast.info("Aide: selected microphone unavailable; using system default");
-        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        const name = error instanceof Error ? error.name : "unknown";
+        this.logDiag("audio.getUserMedia.failed", { name, deviceId: inputId || "default" });
+        throw new Error(
+          name === "NotAllowedError"
+            ? "microphone permission blocked — open Handsfree settings to fix it"
+            : name === "NotFoundError"
+              ? "no microphone available — check Handsfree settings"
+              : `microphone error (${name})`,
+        );
       }
+      this.logDiag("audio.getUserMedia.ok", { deviceId: inputId || "default" });
+
       const pc = new RTCPeerConnection();
       const audio = new Audio();
       audio.autoplay = true;
       const session: SessionHandle = { pc, stream, audio, dc: null };
       this.session = session;
-      const setSinkId = (audio as HTMLAudioElement & {
-        setSinkId?: (deviceId: string) => Promise<void>;
-      }).setSinkId;
-      if (this.audioPreferences.outputDeviceId && setSinkId) {
-        try {
-          await setSinkId.call(audio, this.audioPreferences.outputDeviceId);
-        } catch {
-          if (this.session?.pc !== pc) return;
-          this.setAudioPreferences({ ...this.audioPreferences, outputDeviceId: "" });
-          toast.info("Aide: selected speaker unavailable; using system default");
+      // Never stay "connecting" forever: if the data channel hasn't opened in
+      // time, tear the attempt down and let the user retry cleanly.
+      this.clearConnectWatchdog();
+      this.connectTimer = setTimeout(() => {
+        if (this.session?.pc === pc && this.state === "connecting") {
+          this.logDiag("conn.timeout", { state: pc.connectionState });
+          toast.error("Aide: couldn't connect — please try again");
+          this.stop();
         }
-      }
+      }, 15000);
       if (this.session?.pc !== pc) return;
 
       for (const track of stream.getTracks()) pc.addTrack(track, stream);
       pc.ontrack = (event) => {
+        if (this.session?.pc !== pc) return; // torn down mid-negotiation
         audio.srcObject = event.streams[0] ?? new MediaStream([event.track]);
-        void audio.play().catch(() => undefined);
+        // Never swallow a real playback failure ("live" but silent). But a
+        // play() aborted because the session was torn down (srcObject cleared,
+        // element removed) is not a speaker fault — log it, don't cry wolf.
+        void audio.play().then(
+          () => this.logDiag("audio.play.ok"),
+          (error) => {
+            const name = error instanceof Error ? error.name : "unknown";
+            if (name === "AbortError" || this.session?.pc !== pc) {
+              this.logDiag("audio.play.aborted", { name });
+              return;
+            }
+            this.logDiag("audio.play.failed", { name });
+            toast.error("Aide: can't play audio — check the speaker in Handsfree settings");
+          },
+        );
       };
       pc.onconnectionstatechange = () => {
+        this.logDiag("conn.state", { state: pc.connectionState });
         if (pc.connectionState === "failed" || pc.connectionState === "disconnected") {
           if (this.session?.pc === pc) {
             toast.error("Aide: voice connection lost");
@@ -373,15 +526,21 @@ export class VoiceAgent {
           }
         }
       };
+      pc.oniceconnectionstatechange = () => {
+        this.logDiag("conn.ice", { state: pc.iceConnectionState });
+      };
 
       const dc = pc.createDataChannel("oai-events");
       session.dc = dc;
       dc.onopen = () => {
         if (this.session?.pc === pc) {
+          this.clearConnectWatchdog();
           this.setState("live");
           this.log("session.live");
+          this.logDiag("conn.dc.open");
         }
       };
+      dc.onclose = () => this.logDiag("conn.dc.close");
       dc.onmessage = (message) => {
         let event: Record<string, unknown>;
         try {

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -107,6 +107,8 @@ export class VoiceAgent {
   private assistantSpeaking = false;
   /** Aborts a session that never reaches "live", so it can't hang connecting. */
   private connectTimer: ReturnType<typeof setTimeout> | null = null;
+  /** When the call first went live (ms), for elapsed-duration UI; null if not. */
+  private liveStartedAt: number | null = null;
 
   readonly subscribe = (listener: () => void): (() => void) => {
     this.listeners.add(listener);
@@ -114,6 +116,9 @@ export class VoiceAgent {
   };
 
   readonly getState = (): VoiceState => this.state;
+
+  /** Epoch ms when the call went live, or null when not in a live/muted call. */
+  readonly getLiveStartedAt = (): number | null => this.liveStartedAt;
 
   /**
    * Who is talking right now, from the data-channel signals we already track
@@ -387,6 +392,7 @@ export class VoiceAgent {
   stop() {
     if (this.session) this.log("session.stopped");
     this.clearConnectWatchdog();
+    this.liveStartedAt = null;
     const session = this.session;
     this.session = null;
     this.nonce = null;
@@ -575,6 +581,7 @@ export class VoiceAgent {
       dc.onopen = () => {
         if (this.session?.pc === pc) {
           this.clearConnectWatchdog();
+          this.liveStartedAt = Date.now();
           this.setState("live");
           this.log("session.live");
           this.logDiag("conn.dc.open");

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -15,6 +15,8 @@ import {
 } from "./audio-devices.ts";
 
 export type VoiceState = "idle" | "connecting" | "live" | "muted";
+/** Who currently has the floor during a live call, for the "listening" UI. */
+export type VoiceActivity = "you" | "aide" | "idle";
 
 interface RpcClient {
   call: ReturnType<typeof useRpc<typeof rpcContract>>["call"];
@@ -97,6 +99,12 @@ export class VoiceAgent {
   private noticeTimer: ReturnType<typeof setTimeout> | null = null;
   /** True between VAD speech_started and speech_stopped. */
   private userSpeaking = false;
+  /**
+   * True while Aide's audio is actually playing — tracked from the WebRTC
+   * `output_audio_buffer.started/stopped/cleared` events, NOT `responseActive`
+   * (which ends at generation done, well before playback finishes).
+   */
+  private assistantSpeaking = false;
   /** Aborts a session that never reaches "live", so it can't hang connecting. */
   private connectTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -106,6 +114,37 @@ export class VoiceAgent {
   };
 
   readonly getState = (): VoiceState => this.state;
+
+  /**
+   * Who is talking right now, from the data-channel signals we already track
+   * (VAD for the user, response lifecycle for Aide). Deliberately no audio
+   * analysis — it stays reliable and never touches the audio pipeline. The
+   * user takes precedence so a barge-in reads as "you".
+   */
+  readonly getActivity = (): VoiceActivity => {
+    if (this.state !== "live" && this.state !== "muted") return "idle";
+    if (this.userSpeaking) return "you";
+    if (this.assistantSpeaking) return "aide";
+    return "idle";
+  };
+
+  private setUserSpeaking(value: boolean) {
+    if (this.userSpeaking === value) return;
+    this.userSpeaking = value;
+    this.emitChange();
+  }
+
+  private setAssistantSpeaking(value: boolean) {
+    if (this.assistantSpeaking === value) return;
+    this.assistantSpeaking = value;
+    this.emitChange();
+  }
+
+  private setResponseActive(value: boolean) {
+    if (this.responseActive === value) return;
+    this.responseActive = value;
+    this.emitChange();
+  }
 
   readonly getAudioPreferences = (): AudioDevicePreferences => this.audioPreferences;
 
@@ -261,7 +300,7 @@ export class VoiceAgent {
     if (!session || (this.state !== "live" && this.state !== "muted")) return;
     for (const track of session.stream.getAudioTracks()) track.enabled = !muted;
     this.log(muted ? "muted" : "unmuted");
-    this.userSpeaking = false; // a muted mic can't be mid-utterance
+    this.setUserSpeaking(false); // a muted mic can't be mid-utterance
     this.setState(muted ? "muted" : "live");
   }
 
@@ -341,7 +380,7 @@ export class VoiceAgent {
       this.responsePending = true;
       return;
     }
-    this.responseActive = true;
+    this.setResponseActive(true);
     dc.send(JSON.stringify({ type: "response.create" }));
   }
 
@@ -352,12 +391,13 @@ export class VoiceAgent {
     this.session = null;
     this.nonce = null;
     this.toolChain = Promise.resolve();
-    this.responseActive = false;
+    this.setResponseActive(false);
+    this.setAssistantSpeaking(false);
     this.responsePending = false;
     this.pendingNotices.clear();
     if (this.noticeTimer) clearTimeout(this.noticeTimer);
     this.noticeTimer = null;
-    this.userSpeaking = false;
+    this.setUserSpeaking(false);
     if (session) {
       session.dc?.close();
       session.pc.close();
@@ -550,11 +590,21 @@ export class VoiceAgent {
         }
         const type = String(event.type ?? "");
         if (type === "response.created") {
-          this.responseActive = true;
+          this.setResponseActive(true);
+        } else if (type === "output_audio_buffer.started") {
+          this.setAssistantSpeaking(true); // audio is now actually playing
+        } else if (
+          type === "output_audio_buffer.stopped" ||
+          type === "output_audio_buffer.cleared"
+        ) {
+          this.setAssistantSpeaking(false); // playback finished or interrupted
         } else if (type === "input_audio_buffer.speech_started") {
-          this.userSpeaking = true;
+          this.setUserSpeaking(true);
+          // Belt-and-suspenders: a new user turn always clears "Aide speaking",
+          // so a missed stopped/cleared event can never leave it stuck on.
+          this.setAssistantSpeaking(false);
         } else if (type === "input_audio_buffer.speech_stopped") {
-          this.userSpeaking = false;
+          this.setUserSpeaking(false);
           if (this.pendingNotices.size > 0) this.scheduleNoticeDrain();
         } else if (type === "response.function_call_arguments.done") {
           this.toolChain = this.toolChain
@@ -570,7 +620,7 @@ export class VoiceAgent {
           const text = String(event.transcript ?? "").trim();
           if (text) this.log("assistant", { text });
         } else if (type === "response.done") {
-          this.responseActive = false;
+          this.setResponseActive(false);
           if (this.responsePending) {
             this.responsePending = false;
             this.requestResponse(dc);


### PR DESCRIPTION
## Summary

While using the voice control day-to-day, a few things were unreliable or confusing. This PR groups the fixes into three themes and explains the reasoning behind each:

- **Microphone was fragile.** Acquisition would intermittently fail, hang in "connecting", or lose the mic entirely after a page reload. The root cause was code that trusted saved device ids (which rotate) and had no timeouts or diagnostics. We reworked it to be deterministic and self-healing so it "just works".
- **Speaker selection was unreliable.** Routing audio to a specific output device via `setSinkId` is flaky inside the bb webview, and it added a whole class of failures for little benefit. We removed speaker selection entirely and always use the system default output, which is reliable.
- **Trigger placement + pill UX needed work.** It wasn't clear where the voice control should live, and the composer control showed two look-alike icons. We explored multiple trigger surfaces, settled on a clean set, and redesigned the composer control into a single "who's talking" pill that reads well on any theme.

## Details

<details>
<summary><b>Microphone reliability</b></summary>

Acquisition is now deterministic: enumerate what's actually present, resolve the saved mic by id (or by **label** if the id rotated across a restart), else fall back to the system default — no more "request an exact id, catch, retry". Added a `getUserMedia` timeout, a connect watchdog, a bounded retry when inputs briefly vanish after reload, and a `pagehide` mic release so a hard reload can't orphan the device. When the saved mic is genuinely gone we show an informational notice (not an error) and keep the selection visible to re-pick.
</details>

<details>
<summary><b>Speaker output</b></summary>

Dropped in-app speaker selection. `setSinkId` is unreliable in the webview and routing the remote track through it risked breaking playback, so output now always uses the system default speaker. Users pick their output device in the OS, which is the robust path.
</details>

<details>
<summary><b>Voice triggers</b></summary>

Kept the composer button as the primary trigger and removed the redundant thread-header button. The sidebar "voice bar" (above the thread list) is kept as an optional always-visible control, with its scroll/overlap and confusing icons fixed. This keeps one contextual trigger plus one optional global one, without hijacking anyone's sidebar.
</details>

<details>
<summary><b>Composer pill + live indicator</b></summary>

Replaced the two look-alike composer icons with one segmented pill: **mute · live activity waveform · stop**. The waveform signals who has the floor — you vs Aide (themed green) — driven purely by data-channel signals (VAD + output-audio-buffer events), so it tracks real playback and never touches the audio pipeline. Chrome is theme-neutral so it looks right on any theme.
</details>

<details>
<summary><b>Observability</b></summary>

All audio/connection events now log durably (mirrored to the plugin log), including the previously-swallowed playback failure — so future issues are diagnosable instead of silent.
</details>

## Testing
`npm test` (16/16) and `npm run typecheck` pass. Manually verified across reloads: mic recovers, no stuck "connecting", audio plays, and the pill reflects mute / you-speaking / Aide-speaking correctly.

## Screenshots & recordings
<img width="782" height="231" alt="Screenshot 2026-08-31 at 4 35 12 PM" src="https://github.com/user-attachments/assets/cfe8c804-0050-4a40-8395-fa89d734cb21" />
<img width="319" height="547" alt="Screenshot 2026-08-31 at 4 35 53 PM" src="https://github.com/user-attachments/assets/0cf591b8-3fba-41f8-808a-ce385ab72e1b" />
<img width="318" height="659" alt="Screenshot 2026-08-31 at 4 35 47 PM" src="https://github.com/user-attachments/assets/df626e4c-c37a-4770-8ff2-1c9739b61f93" />
<img width="788" height="230" alt="Screenshot 2026-08-31 at 4 35 24 PM" src="https://github.com/user-attachments/assets/7d5c8cf8-d0e0-4b91-bb82-52525651fcec" />
<img width="314" height="34" alt="Screenshot 2026-08-31 at 4 35 21 PM" src="https://github.com/user-attachments/assets/0a736f07-453a-4d18-84e4-574589baa16b" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)