### PR TITLE
Redesign Handsfree settings into curated, consistent sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,21 +67,30 @@ skill.
 
 ## Settings
 
-| Setting | Default | |
-|---|---|---|
-| `openaiApiKey` | — | Secret; stored in bb's plugin secret store. Falls back to `OPENAI_API_KEY` in the bb server's environment. |
-| `model` | `gpt-realtime-2` | OpenAI Realtime model |
-| `voice` | `marin` | Assistant voice |
-| `pluginCommands` | `all` | Which installed plugins' `bb` commands the voice agent may run via its `run_plugin_command` tool: `all`, `none`, or comma-separated plugin ids (e.g. `automation,connect`) |
+Open the Handsfree plugin settings for curated sections:
 
-Microphone and speaker choices are available under **Audio devices** in the
-Handsfree plugin settings and on the Handsfree page. They are stored in the
-current browser and apply to the next voice session. If a selected device is
-disconnected, Handsfree falls back to the system default. Speaker selection
-depends on browser support for audio output routing.
+- **Models & voice** — the OpenAI Realtime model, the assistant voice (marin
+  and cedar are the highest-quality options), and a badge showing which
+  credential Aide will use.
+- **Behavior** — whether Aide announces thread events, and which installed
+  plugins' `bb` commands it may run (all / none / a specific list).
+- **Audio** — pick and test the microphone with a live input-level meter. The
+  chosen mic is stored in the current browser and applies to the next voice
+  session; if it disconnects, Handsfree falls back to the system default.
+  Playback always uses your system-default speaker (change it in your OS Sound
+  settings).
 
-Change with `bb plugin config handsfree set <key> <value>`, then
-`bb plugin reload aide`.
+The only credential is the **OpenAI API key**, a secret stored in bb's plugin
+secret store (0600 file, never in the db or frontend). It's optional: leave it
+blank to use your ChatGPT subscription (`codex login`), or set `OPENAI_API_KEY`
+in the bb server's environment. Set it in the settings field, or via the CLI:
+
+```
+bb plugin config handsfree set openaiApiKey <your-openai-key>
+```
+
+Model, voice, and behavior are configured from the settings sections above (no
+longer via `bb plugin config`).
 
 ## Troubleshooting
 

--- a/app.tsx
+++ b/app.tsx
@@ -18,7 +18,8 @@ import {
 import type { PluginThreadListProps } from "@get-bb/plugin-sdk/app";
 import type { rpcContract } from "./server";
 import { voiceAgent } from "./voice-agent";
-import { AudioDeviceSettings, SessionsPanel } from "./sessions-panel";
+import { SessionsPanel } from "./sessions-panel";
+import { AudioSettings, BehaviorSettings, ModelsSettings } from "./settings-sections";
 import { cn } from "@/lib/utils";
 import { AUDIO_DEVICE_STORAGE_KEY } from "./audio-devices";
 import "./app.css";
@@ -344,10 +345,19 @@ function SidebarLiveIndicator() {
 
 export default definePluginApp((app) => {
   app.slots.settingsSection({
-    id: "audio-devices",
-    title: "Audio devices",
-    description: "Choose the microphone and speaker used by new Handsfree voice sessions.",
-    component: AudioDeviceSettings,
+    id: "models",
+    title: "Model & voice",
+    component: ModelsSettings,
+  });
+  app.slots.settingsSection({
+    id: "behavior",
+    title: "Behavior",
+    component: BehaviorSettings,
+  });
+  app.slots.settingsSection({
+    id: "audio",
+    title: "Audio",
+    component: AudioSettings,
   });
   app.composer.customize({
     id: "aide-voice",

--- a/models.ts
+++ b/models.ts
@@ -2,3 +2,30 @@
 export const MODEL_OPTIONS = ["gpt-realtime-2.1", "gpt-realtime-2.1-mini"] as const;
 export type RealtimeModel = (typeof MODEL_OPTIONS)[number];
 export const DEFAULT_MODEL: RealtimeModel = "gpt-realtime-2.1";
+
+// OpenAI Realtime voices. marin and cedar are the high-quality voices shipped
+// with gpt-realtime; the rest are the classic set. Listed recommended-first so
+// the picker leads with the best options.
+export const VOICE_OPTIONS = [
+  "marin",
+  "cedar",
+  "alloy",
+  "ash",
+  "ballad",
+  "coral",
+  "echo",
+  "sage",
+  "shimmer",
+  "verse",
+] as const;
+export type Voice = (typeof VOICE_OPTIONS)[number];
+export const DEFAULT_VOICE: Voice = "marin";
+// Voices we surface as "Recommended" in the picker.
+export const RECOMMENDED_VOICES: readonly Voice[] = ["marin", "cedar"];
+
+export function isVoice(value: unknown): value is Voice {
+  return typeof value === "string" && (VOICE_OPTIONS as readonly string[]).includes(value);
+}
+export function isModel(value: unknown): value is RealtimeModel {
+  return typeof value === "string" && (MODEL_OPTIONS as readonly string[]).includes(value);
+}

--- a/server.ts
+++ b/server.ts
@@ -9,7 +9,16 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { defineRpcContract, type BbPluginApi } from "@get-bb/plugin-sdk";
 import { z } from "zod";
-import { DEFAULT_MODEL, MODEL_OPTIONS } from "./models";
+import {
+  DEFAULT_MODEL,
+  DEFAULT_VOICE,
+  MODEL_OPTIONS,
+  VOICE_OPTIONS,
+  isModel,
+  isVoice,
+  type RealtimeModel,
+  type Voice,
+} from "./models";
 
 export const rpcContract = defineRpcContract({
   /** Exchange a WebRTC SDP offer with OpenAI Realtime. Returns the answer. */
@@ -90,10 +99,70 @@ export const rpcContract = defineRpcContract({
       .strict(),
     output: z.object({ ok: z.literal(true) }).strict(),
   },
-  /** Switch the realtime model used by new voice sessions. */
-  setModel: {
-    input: z.object({ model: z.enum(MODEL_OPTIONS) }).strict(),
+  /** Effective non-secret config for new voice sessions (kv-backed). */
+  getConfig: {
+    input: z.null(),
+    output: z
+      .object({
+        model: z.enum(MODEL_OPTIONS),
+        voice: z.enum(VOICE_OPTIONS),
+        notifications: z.boolean(),
+        pluginCommands: z.string(),
+        credentialPreference: z.enum(["auto", "apiKey", "subscription"]),
+      })
+      .strict(),
+  },
+  /** Update one or more config fields for new voice sessions. */
+  setConfig: {
+    input: z
+      .object({
+        model: z.enum(MODEL_OPTIONS).optional(),
+        voice: z.enum(VOICE_OPTIONS).optional(),
+        notifications: z.boolean().optional(),
+        pluginCommands: z.string().max(2000).optional(),
+        credentialPreference: z.enum(["auto", "apiKey", "subscription"]).optional(),
+      })
+      .strict(),
+    output: z
+      .object({
+        model: z.enum(MODEL_OPTIONS),
+        voice: z.enum(VOICE_OPTIONS),
+        notifications: z.boolean(),
+        pluginCommands: z.string(),
+        credentialPreference: z.enum(["auto", "apiKey", "subscription"]),
+      })
+      .strict(),
+  },
+  /** Clear the stored OpenAI API key (falls back to env / subscription). */
+  clearApiKey: {
+    input: z.null(),
     output: z.object({ ok: z.literal(true) }).strict(),
+  },
+  /** Installed plugins that expose a bb command the voice agent could run. */
+  listPlugins: {
+    input: z.null(),
+    output: z
+      .object({
+        plugins: z.array(
+          z.object({ id: z.string(), name: z.string(), summary: z.string() }).strict(),
+        ),
+      })
+      .strict(),
+  },
+  /** Which credential the backend will use for new voice sessions. */
+  getCredentialStatus: {
+    input: z.null(),
+    output: z
+      .object({
+        /** The credential apiKey() will actually pick right now. */
+        effective: z.enum(["apiKey", "env", "subscription", "none"]),
+        /** The user's stored preference; "auto" follows precedence. */
+        preference: z.enum(["auto", "apiKey", "subscription"]),
+        hasApiKey: z.boolean(),
+        envKeyPresent: z.boolean(),
+        subscriptionAvailable: z.boolean(),
+      })
+      .strict(),
   },
   /** Append one event to a voice session's transcript log. */
   logEvent: {
@@ -290,26 +359,81 @@ export default async function plugin(bb: BbPluginApi) {
     )`,
   ]);
 
+  // The API key is the ONE declarative setting: secrets must live here to get
+  // 0600-file storage that never touches the db or the frontend. Everything
+  // else the user configures — model, voice, behavior — is kv-backed below and
+  // rendered by our own polished settings sections, so the host's auto-form
+  // stays a single clean field instead of a flat dump.
   const settings = bb.settings.define({
-    openaiApiKey: { type: "string", label: "OpenAI API key", secret: true },
-    model: {
-      type: "select",
-      label: "Realtime model",
-      options: [...MODEL_OPTIONS],
-      default: DEFAULT_MODEL,
-    },
-    voice: { type: "string", label: "Voice", default: "marin" },
-    notifications: {
-      type: "boolean",
-      label: "Announce thread events in voice sessions",
-      default: true,
-    },
-    pluginCommands: {
+    openaiApiKey: {
       type: "string",
-      label: 'Plugin commands exposed to the voice agent: "all", "none", or comma-separated plugin ids',
-      default: "all",
+      label: "OpenAI API key (optional)",
+      secret: true,
+      description: "Leave blank to use your ChatGPT subscription instead (run `codex login`).",
     },
   });
+
+  // ---- kv-backed voice-session config (model / voice / behavior) ----
+  // "auto" keeps the historical precedence (key → env → subscription); the
+  // user can pin it to one credential when more than one is available.
+  type CredentialPreference = "auto" | "apiKey" | "subscription";
+  const CREDENTIAL_PREFERENCES: readonly CredentialPreference[] = ["auto", "apiKey", "subscription"];
+  const isCredentialPreference = (value: unknown): value is CredentialPreference =>
+    typeof value === "string" && (CREDENTIAL_PREFERENCES as readonly string[]).includes(value);
+
+  interface VoiceConfig {
+    model: RealtimeModel;
+    voice: Voice;
+    notifications: boolean;
+    pluginCommands: string;
+    credentialPreference: CredentialPreference;
+  }
+  const CONFIG_KEY = "config";
+  const CONFIG_DEFAULTS: VoiceConfig = {
+    model: DEFAULT_MODEL,
+    voice: DEFAULT_VOICE,
+    notifications: true,
+    pluginCommands: "all",
+    credentialPreference: "auto",
+  };
+  async function readConfig(): Promise<VoiceConfig> {
+    const stored = (await bb.storage.kv.get<Partial<VoiceConfig>>(CONFIG_KEY)) ?? {};
+    return {
+      model: isModel(stored.model) ? stored.model : CONFIG_DEFAULTS.model,
+      voice: isVoice(stored.voice) ? stored.voice : CONFIG_DEFAULTS.voice,
+      notifications:
+        typeof stored.notifications === "boolean" ? stored.notifications : CONFIG_DEFAULTS.notifications,
+      pluginCommands:
+        typeof stored.pluginCommands === "string" ? stored.pluginCommands : CONFIG_DEFAULTS.pluginCommands,
+      credentialPreference: isCredentialPreference(stored.credentialPreference)
+        ? stored.credentialPreference
+        : CONFIG_DEFAULTS.credentialPreference,
+    };
+  }
+  async function writeConfig(patch: Partial<VoiceConfig>): Promise<VoiceConfig> {
+    const next = { ...(await readConfig()), ...patch };
+    await bb.storage.kv.set(CONFIG_KEY, next);
+    return next;
+  }
+
+  // One-time migration: earlier versions stored model/voice/notifications/
+  // pluginCommands as declarative settings. Carry any customized values into
+  // kv so removing those descriptors doesn't silently reset them.
+  if (!(await bb.storage.kv.get<boolean>("config.migrated"))) {
+    try {
+      const legacy = await bb.sdk.plugins.getSettings({ pluginId: bb.pluginId });
+      const v = (legacy?.values ?? {}) as Record<string, unknown>;
+      const patch: Partial<VoiceConfig> = {};
+      if (isModel(v.model)) patch.model = v.model;
+      if (isVoice(v.voice)) patch.voice = v.voice;
+      if (typeof v.notifications === "boolean") patch.notifications = v.notifications;
+      if (typeof v.pluginCommands === "string") patch.pluginCommands = v.pluginCommands;
+      if (Object.keys(patch).length > 0) await writeConfig(patch);
+    } catch (error) {
+      bb.log.warn(`config migration skipped: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    await bb.storage.kv.set("config.migrated", true);
+  }
 
   // ---- plugin-command exposure ----
   // Other installed plugins contribute `bb` CLI commands. The voice agent
@@ -317,7 +441,7 @@ export default async function plugin(bb: BbPluginApi) {
   // run_plugin_command tool; the pluginCommands setting curates which
   // plugins are exposed (all / none / allowlist of plugin ids).
   async function exposedPluginCommands(): Promise<PluginCommandInfo[]> {
-    const { pluginCommands } = await settings.get();
+    const { pluginCommands } = await readConfig();
     const filter = (pluginCommands ?? "all").trim().toLowerCase();
     if (filter === "none") return [];
     const allow =
@@ -352,7 +476,7 @@ export default async function plugin(bb: BbPluginApi) {
   // queues and digests these (never interrupting speech or an active
   // response); this side only decides WHETHER to publish.
   async function publishThreadEvent(kind: "idle" | "failed", thread: { id: string; title: string | null; visibility: string }, detail: string | null) {
-    const { notifications } = await settings.get();
+    const { notifications } = await readConfig();
     if (!notifications || thread.visibility === "hidden") return;
     bb.realtime.publish("aide-thread-event", {
       kind,
@@ -440,12 +564,21 @@ export default async function plugin(bb: BbPluginApi) {
 
   async function apiKey(): Promise<string> {
     const { openaiApiKey } = await settings.get();
+    const { credentialPreference } = await readConfig();
     const key = openaiApiKey || process.env.OPENAI_API_KEY;
-    if (key) return key;
-    const codex = await codexToken();
-    if (codex) return codex;
+    // When the user pinned the subscription, try it first and only fall back to
+    // a key. Otherwise (auto / apiKey) a key wins, then the subscription.
+    if (credentialPreference === "subscription") {
+      const codex = await codexToken();
+      if (codex) return codex;
+      if (key) return key;
+    } else {
+      if (key) return key;
+      const codex = await codexToken();
+      if (codex) return codex;
+    }
     throw new Error(
-      "No OpenAI credentials. Set an API key with `bb plugin config handsfree set openaiApiKey <key>`, or sign in with `codex login` to use your ChatGPT subscription.",
+      "No OpenAI credentials. Set an API key in the Handsfree settings, or sign in with `codex login` to use your ChatGPT subscription.",
     );
   }
 
@@ -881,7 +1014,7 @@ export default async function plugin(bb: BbPluginApi) {
   bb.rpc.register(rpcContract, {
     async createCall({ sdp, threadId, projectId, onNewThreadScreen, nonce }) {
       const key = await apiKey();
-      const { model, voice } = await settings.get();
+      const { model, voice } = await readConfig();
       const pluginCommands = await exposedPluginCommands();
       const pluginSection =
         pluginCommands.length === 0
@@ -940,10 +1073,64 @@ export default async function plugin(bb: BbPluginApi) {
       savePromptVersion(content, source, note);
       return { ok: true as const };
     },
-    async setModel({ model }) {
-      await bb.sdk.plugins.updateSettings({ pluginId: bb.pluginId, values: { model } });
-      bb.log.info(`realtime model switched to ${model}`);
+    async getConfig() {
+      return await readConfig();
+    },
+    async setConfig(patch) {
+      const next = await writeConfig(patch);
+      bb.log.info(`voice config updated: ${JSON.stringify(patch)}`);
+      // Every open window refetches, so the settings sections and the nav-panel
+      // quick-switch stay in sync across windows.
+      bb.realtime.publish("config-changed", {});
+      return next;
+    },
+    async clearApiKey() {
+      // null (not "") actually removes the secret, so the settings field shows
+      // "not set" again rather than an empty-but-present value.
+      await bb.sdk.plugins.updateSettings({ pluginId: bb.pluginId, values: { openaiApiKey: null } });
+      bb.log.info("OpenAI API key cleared");
+      bb.realtime.publish("config-changed", {});
       return { ok: true as const };
+    },
+    async listPlugins() {
+      try {
+        const { plugins } = await bb.sdk.plugins.list();
+        return {
+          plugins: plugins
+            .filter(
+              (plugin) =>
+                plugin.enabled &&
+                plugin.status === "running" &&
+                plugin.cliCommand !== null &&
+                plugin.id !== bb.pluginId,
+            )
+            .map((plugin) => ({
+              id: plugin.id,
+              name: plugin.cliCommand?.name ?? plugin.id,
+              summary: plugin.cliCommand?.summary ?? "",
+            }))
+            .sort((a, b) => a.name.localeCompare(b.name)),
+        };
+      } catch (error) {
+        bb.log.warn(`could not list plugins: ${error instanceof Error ? error.message : String(error)}`);
+        return { plugins: [] };
+      }
+    },
+    async getCredentialStatus() {
+      const { openaiApiKey } = await settings.get();
+      const { credentialPreference: preference } = await readConfig();
+      const hasApiKey = !!openaiApiKey;
+      const envKeyPresent = !!process.env.OPENAI_API_KEY;
+      const subscriptionAvailable = !!(await codexToken());
+      const keySource = hasApiKey ? ("apiKey" as const) : envKeyPresent ? ("env" as const) : null;
+      // Mirror apiKey() so the badge shows what a session will actually use.
+      const effective =
+        preference === "subscription"
+          ? subscriptionAvailable
+            ? ("subscription" as const)
+            : (keySource ?? ("none" as const))
+          : keySource ?? (subscriptionAvailable ? ("subscription" as const) : ("none" as const));
+      return { effective, preference, hasApiKey, envKeyPresent, subscriptionAvailable };
     },
     async logEvent({ sessionId, kind, payload }) {
       db.prepare(
@@ -992,7 +1179,7 @@ export default async function plugin(bb: BbPluginApi) {
       const inDetails = (usage.input_token_details ?? {}) as Record<string, unknown>;
       const outDetails = (usage.output_token_details ?? {}) as Record<string, unknown>;
       const cachedDetails = (inDetails.cached_tokens_details ?? {}) as Record<string, unknown>;
-      const { model: configuredModel } = await settings.get();
+      const { model: configuredModel } = await readConfig();
       db.prepare(
         `INSERT INTO usage_events (ts, model, session_id, input_text, input_audio, cached_text, cached_audio, output_text, output_audio)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -3,12 +3,11 @@
 // a live-updating transcript: what you said, what Aide said, every tool call
 // with arguments and result, and errors.
 import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
-import { useRealtime, useRpc, useSettings } from "@get-bb/plugin-sdk/app";
+import { useRealtime, useRpc } from "@get-bb/plugin-sdk/app";
 import { toast } from "sonner";
 import type { rpcContract } from "./server";
-import { DEFAULT_MODEL, MODEL_OPTIONS, type RealtimeModel } from "./models";
 import { voiceAgent } from "./voice-agent";
-import { deviceDisplayLabel } from "./audio-devices";
+import { AudioSettings } from "./settings-sections";
 import { cn } from "@/lib/utils";
 
 interface SessionRow {
@@ -51,167 +50,6 @@ function parsePayload(raw: string): Record<string, unknown> {
   } catch {
     return {};
   }
-}
-
-function ModelPicker() {
-  const rpc = useRpc<typeof rpcContract>();
-  const { values, isLoading } = useSettings();
-  const [model, setModel] = useState<RealtimeModel | null>(null);
-  const configured = typeof values?.model === "string" ? values.model : DEFAULT_MODEL;
-  const current = model ?? (MODEL_OPTIONS.includes(configured as RealtimeModel) ? (configured as RealtimeModel) : DEFAULT_MODEL);
-
-  async function change(next: RealtimeModel) {
-    setModel(next);
-    try {
-      await rpc.call("setModel", { model: next });
-      toast.success(`Voice model: ${next} (applies to the next session)`);
-    } catch (cause) {
-      setModel(null);
-      toast.error(`Could not switch model: ${cause instanceof Error ? cause.message : String(cause)}`);
-    }
-  }
-
-  return (
-    <label className="flex items-center gap-2 text-sm text-muted-foreground">
-      Model
-      <select
-        value={current}
-        disabled={isLoading}
-        onChange={(event) => void change(event.target.value as RealtimeModel)}
-        className="rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground"
-      >
-        {MODEL_OPTIONS.map((option) => (
-          <option key={option} value={option}>
-            {option}
-          </option>
-        ))}
-      </select>
-    </label>
-  );
-}
-
-export function AudioDeviceSettings() {
-  const preferences = useSyncExternalStore(
-    voiceAgent.subscribe,
-    voiceAgent.getAudioPreferences,
-  );
-  const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [deviceError, setDeviceError] = useState<string | null>(null);
-
-  const refresh = useCallback(async () => {
-    if (!navigator.mediaDevices?.enumerateDevices) {
-      setDeviceError("Audio device discovery is not supported in this browser.");
-      setLoading(false);
-      return;
-    }
-    try {
-      setDevices(await navigator.mediaDevices.enumerateDevices());
-      setDeviceError(null);
-    } catch (cause) {
-      setDeviceError(cause instanceof Error ? cause.message : String(cause));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    void refresh();
-    navigator.mediaDevices?.addEventListener?.("devicechange", refresh);
-    return () => navigator.mediaDevices?.removeEventListener?.("devicechange", refresh);
-  }, [refresh]);
-
-  const inputs = devices.filter(
-    (device) => device.kind === "audioinput" && device.deviceId,
-  );
-  const labelsHidden = inputs.length > 0 && inputs.every((device) => !device.label);
-  // The saved mic can no longer be found (unplugged, or its id rotated with no
-  // matching label). Keep it visible so the user can see and re-pick it.
-  const savedMicMissing =
-    !!preferences.inputDeviceId &&
-    !inputs.some((device) => device.deviceId === preferences.inputDeviceId);
-
-  async function allowAccess() {
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      for (const track of stream.getTracks()) track.stop();
-      await refresh();
-    } catch (cause) {
-      setDeviceError(cause instanceof Error ? cause.message : String(cause));
-    }
-  }
-
-  function change(deviceId: string) {
-    const label = inputs.find((device) => device.deviceId === deviceId)?.label ?? "";
-    voiceAgent.setAudioPreferences({ inputDeviceId: deviceId, inputLabel: label });
-    toast.success("Microphone saved — applies to the next voice session");
-  }
-
-  return (
-    <details className="rounded-lg border border-border bg-card">
-      <summary className="cursor-pointer px-3 py-2.5 text-sm font-medium text-foreground">
-        Microphone
-        <span className="ml-2 text-xs font-normal text-muted-foreground">
-          speaker uses your system default
-        </span>
-      </summary>
-      <div className="space-y-3 border-t border-border/50 p-3">
-        <label className="block space-y-1 text-xs text-muted-foreground">
-          <span>Microphone</span>
-          <select
-            value={preferences.inputDeviceId}
-            disabled={loading}
-            onChange={(event) => change(event.target.value)}
-            className="block w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm text-foreground"
-          >
-            <option value="">System default</option>
-            {savedMicMissing ? (
-              <option value={preferences.inputDeviceId}>
-                {preferences.inputLabel
-                  ? `${preferences.inputLabel} (not connected)`
-                  : "Selected microphone (not connected)"}
-              </option>
-            ) : null}
-            {inputs.map((device, index) => (
-              <option key={device.deviceId} value={device.deviceId}>
-                {deviceDisplayLabel(device, index)}
-              </option>
-            ))}
-          </select>
-        </label>
-        <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
-          <span>
-            {labelsHidden
-              ? "Allow microphone access to reveal device names."
-              : savedMicMissing
-                ? "Your selected mic isn't connected — sessions use the system default until it returns."
-                : "Stored in this browser; applies to new sessions. Speaker always uses the system default."}
-          </span>
-          <span className="flex shrink-0 items-center gap-2">
-            {labelsHidden ? (
-              <button
-                type="button"
-                onClick={() => void allowAccess()}
-                className="rounded-md border border-border px-2 py-1 hover:text-foreground"
-              >
-                Allow access
-              </button>
-            ) : null}
-            <button
-              type="button"
-              onClick={() => void refresh()}
-              className="rounded-md border border-border px-2 py-1 hover:text-foreground"
-            >
-              Refresh
-            </button>
-          </span>
-        </div>
-        {deviceError ? (
-          <p className="text-xs text-destructive">{deviceError}</p>
-        ) : null}
-      </div>
-    </details>
-  );
 }
 
 /** Live session controls: state, mute/unmute, stop — right on the page. */
@@ -598,10 +436,19 @@ export function SessionsPanel() {
               <p className="text-sm text-muted-foreground">Aide Voice Session Transcripts</p>
               <span className="flex items-center gap-4">
                 <SessionControls />
-                <ModelPicker />
               </span>
             </div>
-            <AudioDeviceSettings />
+            <details className="rounded-lg border border-border bg-card">
+              <summary className="cursor-pointer px-3 py-2.5 text-sm font-medium text-foreground">
+                Audio
+                <span className="ml-2 text-xs font-normal text-muted-foreground">
+                  microphone · speaker uses your system default
+                </span>
+              </summary>
+              <div className="border-t border-border/50 p-3">
+                <AudioSettings />
+              </div>
+            </details>
             <PromptEditor />
             <ToolsSection />
             <div className="divide-y divide-border/50 rounded-lg border border-border bg-card">

--- a/settings-sections.tsx
+++ b/settings-sections.tsx
@@ -1,0 +1,853 @@
+// bb-plugin-handsfree — polished settings sections.
+//
+// The host renders a single declarative field (the secret OpenAI API key) and
+// then these custom sections below it. Everything the user tunes day-to-day —
+// which model and voice to use, whether Aide announces thread events, and the
+// microphone — lives here as curated sections instead of a flat auto-form.
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
+import { useRealtime, useRpc } from "@get-bb/plugin-sdk/app";
+import { toast } from "sonner";
+import type { rpcContract } from "./server";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
+import {
+  DEFAULT_MODEL,
+  DEFAULT_VOICE,
+  MODEL_OPTIONS,
+  VOICE_OPTIONS,
+  isModel,
+  isVoice,
+  type RealtimeModel,
+  type Voice,
+} from "./models";
+import { voiceAgent } from "./voice-agent";
+import { deviceDisplayLabel } from "./audio-devices";
+import { cn } from "@/lib/utils";
+
+type CredentialPreference = "auto" | "apiKey" | "subscription";
+
+interface VoiceConfig {
+  model: RealtimeModel;
+  voice: Voice;
+  notifications: boolean;
+  pluginCommands: string;
+  credentialPreference: CredentialPreference;
+}
+
+/**
+ * Shared kv-backed config, fetched over rpc and kept live across windows via
+ * the `config-changed` signal. `update` is optimistic and reconciles with the
+ * authoritative value the backend returns.
+ */
+function useVoiceConfig() {
+  const rpc = useRpc<typeof rpcContract>();
+  const [config, setConfig] = useState<VoiceConfig | null>(null);
+
+  const refetch = useCallback(() => {
+    rpc.call("getConfig", null).then(setConfig, () => undefined);
+  }, [rpc]);
+  useEffect(refetch, [refetch]);
+  useRealtime("config-changed", refetch);
+
+  const update = useCallback(
+    async (patch: Partial<VoiceConfig>) => {
+      setConfig((prev) => (prev ? { ...prev, ...patch } : prev));
+      try {
+        setConfig(await rpc.call("setConfig", patch));
+        return true;
+      } catch (cause) {
+        refetch();
+        toast.error(`Could not save: ${cause instanceof Error ? cause.message : String(cause)}`);
+        return false;
+      }
+    },
+    [rpc, refetch],
+  );
+
+  return { config, update };
+}
+
+function voiceLabel(voice: Voice): string {
+  return voice.charAt(0).toUpperCase() + voice.slice(1);
+}
+
+const selectClass =
+  "block w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm text-foreground disabled:opacity-60";
+
+function RefreshIcon() {
+  return (
+    <svg viewBox="0 0 16 16" className="size-4" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9" />
+      <path d="M13.7 2.5V5H11.2" />
+    </svg>
+  );
+}
+
+/**
+ * A labelled sub-group: a title-case heading (matching the host's section
+ * headings, never all-caps) and an optional one-line explanation, then the
+ * control. Used across every section so the page reads consistently.
+ */
+function Group({ label, hint, children }: { label: string; hint?: string; children: ReactNode }) {
+  return (
+    <div className="space-y-2 border-t border-border/50 pt-4 first:border-t-0 first:pt-0">
+      <div>
+        <span className="block text-sm font-medium text-foreground">{label}</span>
+        {hint ? <span className="mt-0.5 block text-xs text-muted-foreground">{hint}</span> : null}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Models: credential status + realtime model + voice.
+// ---------------------------------------------------------------------------
+
+interface CredentialStatus {
+  effective: "apiKey" | "env" | "subscription" | "none";
+  preference: CredentialPreference;
+  hasApiKey: boolean;
+  envKeyPresent: boolean;
+  subscriptionAvailable: boolean;
+}
+
+/**
+ * Shows which credential Aide is using, and — only when both an API key and a
+ * ChatGPT subscription are available — lets the user pick between them.
+ */
+function CredentialCard() {
+  const rpc = useRpc<typeof rpcContract>();
+  const [status, setStatus] = useState<CredentialStatus | null>(null);
+
+  const refetch = useCallback(() => {
+    rpc.call("getCredentialStatus", null).then(setStatus, () => undefined);
+  }, [rpc]);
+  useEffect(refetch, [refetch]);
+  useRealtime("config-changed", refetch);
+  // Adding the key above is a host settings save with no plugin signal we can
+  // hook, so poll while this page is open. That's why entering a key here
+  // surfaces the credential picker on its own within a couple of seconds.
+  useEffect(() => {
+    const id = setInterval(refetch, 2500);
+    return () => clearInterval(id);
+  }, [refetch]);
+
+  const statusText = (() => {
+    switch (status?.effective) {
+      case "apiKey":
+      case "env":
+        return "Using your OpenAI API key";
+      case "subscription":
+        return "Using your ChatGPT subscription";
+      default:
+        return "No credentials yet";
+    }
+  })();
+
+  const canChoose = !!status && status.hasApiKey && status.subscriptionAvailable;
+  const chooserValue: "apiKey" | "subscription" =
+    status?.preference === "subscription" ? "subscription" : "apiKey";
+
+  async function choose(preference: "apiKey" | "subscription") {
+    setStatus((prev) => (prev ? { ...prev, preference } : prev));
+    try {
+      await rpc.call("setConfig", { credentialPreference: preference });
+    } catch {
+      refetch();
+    }
+  }
+
+  async function removeKey() {
+    try {
+      await rpc.call("clearApiKey", null);
+      refetch();
+      toast.success("API key removed");
+    } catch (cause) {
+      toast.error(`Could not remove key: ${cause instanceof Error ? cause.message : String(cause)}`);
+    }
+  }
+
+  // Both credentials present: pick which one Aide uses. The dropdown speaks for
+  // itself, so no hint.
+  if (canChoose) {
+    return (
+      <div className="space-y-1.5">
+        <span className="text-sm font-medium text-foreground">Credential</span>
+        <select
+          value={chooserValue}
+          onChange={(event) => void choose(event.target.value as "apiKey" | "subscription")}
+          className={selectClass}
+        >
+          <option value="subscription">ChatGPT subscription</option>
+          <option value="apiKey">OpenAI API key</option>
+        </select>
+        <div>
+          <Button type="button" variant="outline" size="sm" onClick={() => void removeKey()}>
+            Remove API key
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // A single credential (or none): a status line plus an italic helper — the
+  // auth method, or the next step when nothing is set.
+  const helper =
+    status?.effective === "subscription"
+      ? "Signed in with codex login."
+      : status?.effective === "none"
+        ? "Add an API key above, or run codex login to use your ChatGPT subscription."
+        : null;
+  return (
+    <div className="space-y-1 rounded-md border border-border bg-muted/30 px-3 py-2">
+      <div className="flex items-center justify-between gap-3">
+        <span className="flex items-center gap-2">
+          <span
+            className={cn(
+              "size-2 shrink-0 rounded-full",
+              status && status.effective !== "none" ? "bg-primary" : "bg-destructive/80",
+            )}
+          />
+          <span className="text-sm text-foreground">{status ? statusText : "Checking…"}</span>
+        </span>
+        {status?.hasApiKey ? (
+          <Button type="button" variant="outline" size="sm" onClick={() => void removeKey()}>
+            Remove API key
+          </Button>
+        ) : null}
+      </div>
+      {helper ? <p className="text-xs italic text-muted-foreground">{helper}</p> : null}
+    </div>
+  );
+}
+
+export function ModelsSettings() {
+  const { config, update } = useVoiceConfig();
+  const model = config?.model ?? DEFAULT_MODEL;
+  const voice = config?.voice ?? DEFAULT_VOICE;
+  const loading = config === null;
+
+  return (
+    <div className="space-y-4">
+      <CredentialCard />
+      <label className="block space-y-1">
+        <span className="text-sm font-medium text-foreground">Model</span>
+        <select
+          value={model}
+          disabled={loading}
+          onChange={(event) => {
+            const next = event.target.value;
+            if (isModel(next)) void update({ model: next });
+          }}
+          className={selectClass}
+        >
+          {MODEL_OPTIONS.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="block space-y-1">
+        <span className="text-sm font-medium text-foreground">Voice</span>
+        <select
+          value={voice}
+          disabled={loading}
+          onChange={(event) => {
+            const next = event.target.value;
+            if (isVoice(next)) void update({ voice: next });
+          }}
+          className={selectClass}
+        >
+          {VOICE_OPTIONS.map((option) => (
+            <option key={option} value={option}>
+              {voiceLabel(option)}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Behavior: the prompt (how Aide acts), thread announcements, and which
+// plugins it may use.
+// ---------------------------------------------------------------------------
+
+export function BehaviorSettings() {
+  const { config, update } = useVoiceConfig();
+  const loading = config === null;
+  const notifications = config?.notifications ?? true;
+  const pluginCommands = (config?.pluginCommands ?? "all").trim();
+
+  const exposure: "all" | "none" | "custom" =
+    pluginCommands.toLowerCase() === "all" || pluginCommands === ""
+      ? "all"
+      : pluginCommands.toLowerCase() === "none"
+        ? "none"
+        : "custom";
+  // "custom" with an empty selection reads back as "none", so a local flag
+  // keeps the picker open while the user has chosen nothing yet.
+  const [customMode, setCustomMode] = useState(false);
+  const showCustom = customMode || exposure === "custom";
+
+  return (
+    <div className="space-y-5">
+      <PromptEditor />
+
+      <Group label="Announcements">
+        <label className="flex items-center justify-between gap-3">
+          <span className="text-sm text-foreground">When a thread finishes or fails</span>
+          <input
+            type="checkbox"
+            checked={notifications}
+            disabled={loading}
+            onChange={(event) => void update({ notifications: event.target.checked })}
+            className="size-4 shrink-0 accent-primary"
+          />
+        </label>
+      </Group>
+
+      <Group label="Plugins" hint="Aide always has its built-in tools for driving bb by voice; plugins let it also run your other installed plugins.">
+        <select
+          value={showCustom ? "custom" : exposure}
+          disabled={loading}
+          onChange={(event) => {
+            const next = event.target.value;
+            if (next === "all") {
+              setCustomMode(false);
+              void update({ pluginCommands: "all" });
+            } else if (next === "none") {
+              setCustomMode(false);
+              void update({ pluginCommands: "none" });
+            } else {
+              // Entering custom: start from a clean slate unless a real list
+              // was already saved, then let the picker turn plugins on.
+              setCustomMode(true);
+              if (exposure !== "custom") void update({ pluginCommands: "none" });
+            }
+          }}
+          className={selectClass}
+        >
+          <option value="all">Built-in tools + all plugins</option>
+          <option value="none">Built-in tools only</option>
+          <option value="custom">Built-in tools + chosen plugins…</option>
+        </select>
+        {showCustom ? (
+          <PluginPicker
+            value={pluginCommands}
+            disabled={loading}
+            onChange={(csv) => void update({ pluginCommands: csv || "none" })}
+          />
+        ) : null}
+        <BuiltInToolsLink />
+      </Group>
+    </div>
+  );
+}
+
+const linkClass =
+  "text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline";
+
+/** A small link that opens a read-only list of Aide's built-in tools. */
+function BuiltInToolsLink() {
+  const rpc = useRpc<typeof rpcContract>();
+  const [open, setOpen] = useState(false);
+  const [tools, setTools] = useState<{ name: string; description: string }[] | null>(null);
+
+  useEffect(() => {
+    if (!open || tools) return;
+    rpc.call("getTools", null).then(
+      (result) => setTools(result.tools.filter((tool) => tool.name !== "run_plugin_command")),
+      () => setTools([]),
+    );
+  }, [open, tools, rpc]);
+
+  return (
+    <>
+      <button type="button" className={linkClass} onClick={() => setOpen(true)}>
+        View built-in tools
+      </button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Built-in tools</DialogTitle>
+          </DialogHeader>
+          <p className="text-xs text-muted-foreground">
+            These are always available — Aide uses them to navigate bb, start and steer threads, read
+            output, and show diffs by voice.
+          </p>
+          <div className="max-h-80 divide-y divide-border/50 overflow-auto rounded-md border border-border/70">
+            {tools === null ? (
+              <p className="px-3 py-3 text-sm text-muted-foreground">Loading…</p>
+            ) : (
+              tools.map((tool) => (
+                <div key={tool.name} className="px-3 py-2">
+                  <code className="text-xs font-medium text-foreground">{tool.name}</code>
+                  <p className="mt-0.5 text-xs text-muted-foreground">{tool.description}</p>
+                </div>
+              ))
+            )}
+          </div>
+          <DialogFooter>
+            <Button type="button" onClick={() => setOpen(false)}>
+              Done
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+interface PluginInfo {
+  id: string;
+  name: string;
+  summary: string;
+}
+
+/** A modal checklist of installed plugins; the selection is stored as a csv. */
+function PluginPicker({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: string;
+  onChange: (csv: string) => void;
+  disabled?: boolean;
+}) {
+  const rpc = useRpc<typeof rpcContract>();
+  const [open, setOpen] = useState(false);
+  const [plugins, setPlugins] = useState<PluginInfo[] | null>(null);
+
+  useEffect(() => {
+    if (!open || plugins) return;
+    rpc.call("listPlugins", null).then((result) => setPlugins(result.plugins), () => setPlugins([]));
+  }, [open, plugins, rpc]);
+
+  const selected = new Set(
+    value
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry && entry !== "all" && entry !== "none"),
+  );
+
+  function toggle(id: string, on: boolean) {
+    const next = new Set(selected);
+    if (on) next.add(id);
+    else next.delete(id);
+    onChange(Array.from(next).join(","));
+  }
+
+  const summary =
+    selected.size === 0
+      ? "No plugins chosen yet."
+      : Array.from(selected)
+          .map((id) => plugins?.find((plugin) => plugin.id === id)?.name ?? id)
+          .join(", ");
+
+  return (
+    <div className="space-y-1.5 pt-1">
+      <div className="flex items-center gap-2">
+        <Button type="button" variant="outline" size="sm" disabled={disabled} onClick={() => setOpen(true)}>
+          Choose plugins
+        </Button>
+        <span className="text-xs text-muted-foreground">{selected.size} selected</span>
+      </div>
+      <p className="truncate text-xs text-muted-foreground">{summary}</p>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Plugins Aide can use</DialogTitle>
+          </DialogHeader>
+          <div className="max-h-80 space-y-0.5 overflow-auto">
+            {plugins === null ? (
+              <p className="px-2 py-3 text-sm text-muted-foreground">Loading…</p>
+            ) : plugins.length === 0 ? (
+              <p className="px-2 py-3 text-sm text-muted-foreground">
+                No other installed plugins expose a command.
+              </p>
+            ) : (
+              plugins.map((plugin) => (
+                <label
+                  key={plugin.id}
+                  className="flex cursor-pointer items-start gap-2.5 rounded-md px-2 py-1.5 hover:bg-state-hover"
+                >
+                  <Checkbox
+                    checked={selected.has(plugin.id)}
+                    onCheckedChange={(checked) => toggle(plugin.id, checked === true)}
+                    className="mt-0.5"
+                  />
+                  <span className="min-w-0">
+                    <span className="block text-sm text-foreground">{plugin.name}</span>
+                    {plugin.summary ? (
+                      <span className="block truncate text-xs text-muted-foreground">{plugin.summary}</span>
+                    ) : null}
+                  </span>
+                </label>
+              ))
+            )}
+          </div>
+          <DialogFooter>
+            <Button type="button" onClick={() => setOpen(false)}>
+              Done
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Prompt editor — used inside Behavior. View / preview the prompt, edit and
+// save your own, or reset to the default.
+// ---------------------------------------------------------------------------
+
+function PromptEditor() {
+  const rpc = useRpc<typeof rpcContract>();
+  const [active, setActive] = useState("");
+  const [defaultContent, setDefaultContent] = useState("");
+  const [mode, setMode] = useState<"view" | "preview" | "edit">("view");
+  const [draft, setDraft] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const refetch = useCallback(() => {
+    rpc.call("getPrompt", null).then((result) => {
+      setActive(result.content);
+      setDefaultContent(result.defaultContent);
+    }, () => undefined);
+  }, [rpc]);
+  useEffect(refetch, [refetch]);
+  useRealtime("prompt-changed", refetch);
+
+  const isCustom = active.trim() !== defaultContent.trim();
+
+  async function save(content: string, note: string) {
+    if (content.trim().length === 0) return;
+    setBusy(true);
+    try {
+      await rpc.call("setPrompt", { content, source: "user", note });
+      setMode("view");
+      toast.success("Prompt saved");
+    } catch (cause) {
+      toast.error(`Could not save prompt: ${cause instanceof Error ? cause.message : String(cause)}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const changed = draft.trim() !== active.trim();
+  const stateText = isCustom ? "Currently using a custom prompt" : "Currently using the default prompt";
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-sm font-medium text-foreground">Prompt</span>
+        {mode === "edit" ? null : (
+          <span className="flex shrink-0 items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setMode((prev) => (prev === "preview" ? "view" : "preview"))}
+            >
+              {mode === "preview" ? "Hide" : "Preview"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setDraft(active);
+                setMode("edit");
+              }}
+            >
+              Edit
+            </Button>
+          </span>
+        )}
+      </div>
+
+      {mode === "edit" ? (
+        <div className="space-y-2">
+          <textarea
+            value={draft}
+            autoFocus
+            spellCheck={false}
+            rows={16}
+            onChange={(event) => setDraft(event.target.value)}
+            className="w-full resize-y rounded-md border border-border bg-background p-2 font-mono text-xs leading-relaxed text-foreground"
+          />
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              disabled={busy || !changed || draft.trim().length === 0}
+              onClick={() => void save(draft, "edited in settings")}
+            >
+              Save
+            </Button>
+            <Button type="button" variant="outline" size="sm" disabled={busy} onClick={() => setMode("view")}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span>{stateText}</span>
+            {isCustom ? (
+              <button type="button" className={linkClass} disabled={busy} onClick={() => void save(defaultContent, "reset to built-in default")}>
+                Reset to default
+              </button>
+            ) : null}
+          </div>
+          {mode === "preview" ? (
+            <pre className="max-h-72 overflow-auto whitespace-pre-wrap rounded-md border border-border bg-muted/30 p-3 font-mono text-xs leading-relaxed text-foreground">
+              {active}
+            </pre>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Audio: microphone picker + a live level meter to test it, and a read-only
+// view of the system-default speaker (output is never routed in-app).
+// ---------------------------------------------------------------------------
+
+/** Live RMS of the selected mic, 0..1, while `active`. Cleans up fully on stop. */
+function MicLevelMeter({ deviceId, active }: { deviceId: string; active: boolean }) {
+  const [level, setLevel] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!active) {
+      setLevel(0);
+      return;
+    }
+    let stream: MediaStream | null = null;
+    let context: AudioContext | null = null;
+    let raf = 0;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          audio: deviceId ? { deviceId: { exact: deviceId } } : true,
+        });
+        if (cancelled) return;
+        context = new AudioContext();
+        const source = context.createMediaStreamSource(stream);
+        const analyser = context.createAnalyser();
+        analyser.fftSize = 512;
+        source.connect(analyser);
+        const data = new Uint8Array(analyser.fftSize);
+        const tick = () => {
+          analyser.getByteTimeDomainData(data);
+          let sum = 0;
+          for (const sample of data) {
+            const centered = (sample - 128) / 128;
+            sum += centered * centered;
+          }
+          const rms = Math.sqrt(sum / data.length);
+          // Light compression so speech visibly fills the bar.
+          setLevel(Math.min(1, rms * 3));
+          raf = requestAnimationFrame(tick);
+        };
+        tick();
+      } catch (cause) {
+        if (!cancelled) setError(cause instanceof Error ? cause.message : String(cause));
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf);
+      stream?.getTracks().forEach((track) => track.stop());
+      void context?.close();
+      setLevel(0);
+    };
+  }, [deviceId, active]);
+
+  if (!active) return null;
+  if (error) return <p className="text-xs text-destructive">Mic test failed: {error}</p>;
+
+  const segments = 20;
+  const lit = Math.round(level * segments);
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex h-3 flex-1 items-stretch gap-0.5">
+        {Array.from({ length: segments }, (_, index) => (
+          <span
+            key={index}
+            className={cn(
+              "flex-1 rounded-[1px] transition-colors",
+              index < lit
+                ? index > segments * 0.85
+                  ? "bg-destructive"
+                  : "bg-primary"
+                : "bg-muted",
+            )}
+          />
+        ))}
+      </div>
+      <span className="w-8 shrink-0 text-right text-[10px] tabular-nums text-muted-foreground">
+        {Math.round(level * 100)}%
+      </span>
+    </div>
+  );
+}
+
+export function AudioSettings() {
+  const preferences = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getAudioPreferences);
+  const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [deviceError, setDeviceError] = useState<string | null>(null);
+  const [testing, setTesting] = useState(false);
+  const testingRef = useRef(false);
+  testingRef.current = testing;
+
+  const refresh = useCallback(async () => {
+    if (!navigator.mediaDevices?.enumerateDevices) {
+      setDeviceError("Audio device discovery is not supported in this browser.");
+      setLoading(false);
+      return;
+    }
+    try {
+      setDevices(await navigator.mediaDevices.enumerateDevices());
+      setDeviceError(null);
+    } catch (cause) {
+      setDeviceError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    navigator.mediaDevices?.addEventListener?.("devicechange", refresh);
+    return () => navigator.mediaDevices?.removeEventListener?.("devicechange", refresh);
+  }, [refresh]);
+
+  const inputs = devices.filter((device) => device.kind === "audioinput" && device.deviceId);
+  const outputs = devices.filter((device) => device.kind === "audiooutput" && device.deviceId);
+  const labelsHidden = inputs.length > 0 && inputs.every((device) => !device.label);
+  const savedMicMissing =
+    !!preferences.inputDeviceId &&
+    !inputs.some((device) => device.deviceId === preferences.inputDeviceId);
+
+  // Best-effort system-default output: the entry whose id is "default", else
+  // the first output. Its label reads e.g. "Default - MacBook Pro Speakers".
+  const defaultOutput =
+    outputs.find((device) => device.deviceId === "default") ?? outputs[0] ?? null;
+  const speakerName = defaultOutput?.label
+    ? defaultOutput.label.replace(/^Default\s*-\s*/i, "")
+    : null;
+
+  async function allowAccess() {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      for (const track of stream.getTracks()) track.stop();
+      await refresh();
+    } catch (cause) {
+      setDeviceError(cause instanceof Error ? cause.message : String(cause));
+    }
+  }
+
+  function change(deviceId: string) {
+    const label = inputs.find((device) => device.deviceId === deviceId)?.label ?? "";
+    voiceAgent.setAudioPreferences({ inputDeviceId: deviceId, inputLabel: label });
+    toast.success("Microphone saved");
+  }
+
+  return (
+    <div className="space-y-5">
+      <Group label="Microphone">
+        <div className="flex items-center gap-2">
+          <select
+            value={preferences.inputDeviceId}
+            disabled={loading}
+            onChange={(event) => change(event.target.value)}
+            className={cn(selectClass, "flex-1")}
+          >
+            <option value="">System default</option>
+            {savedMicMissing ? (
+              <option value={preferences.inputDeviceId}>
+                {preferences.inputLabel
+                  ? `${preferences.inputLabel} (not connected)`
+                  : "Selected microphone (not connected)"}
+              </option>
+            ) : null}
+            {inputs.map((device, index) => (
+              <option key={device.deviceId} value={device.deviceId}>
+                {deviceDisplayLabel(device, index)}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={() => void refresh()}
+            aria-label="Refresh devices"
+            title="Refresh devices"
+            className="flex size-9 shrink-0 items-center justify-center rounded-md border border-border text-muted-foreground hover:bg-state-hover hover:text-foreground"
+          >
+            <RefreshIcon />
+          </button>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant={testing ? "secondary" : "outline"}
+            size="sm"
+            onClick={() => setTesting((prev) => !prev)}
+          >
+            {testing ? "Stop test" : "Test microphone"}
+          </Button>
+          {labelsHidden ? (
+            <Button type="button" variant="outline" size="sm" onClick={() => void allowAccess()}>
+              Allow access
+            </Button>
+          ) : null}
+        </div>
+
+        {testing ? (
+          <div className="rounded-md border border-border bg-muted/30 px-3 py-2">
+            <MicLevelMeter deviceId={savedMicMissing ? "" : preferences.inputDeviceId} active={testing} />
+            <p className="mt-1.5 text-[11px] text-muted-foreground">Speak — the bar should move with your voice.</p>
+          </div>
+        ) : null}
+
+        {labelsHidden ? (
+          <p className="text-xs text-muted-foreground">Allow mic access to see device names and test it.</p>
+        ) : savedMicMissing ? (
+          <p className="text-xs text-muted-foreground">This mic isn't connected, so Aide falls back to your default.</p>
+        ) : null}
+        {deviceError ? <p className="text-xs text-destructive">{deviceError}</p> : null}
+      </Group>
+
+      <Group label="Speaker">
+        <div className="cursor-not-allowed rounded-md border border-border bg-muted/40 px-2 py-1.5 text-sm text-muted-foreground">
+          {labelsHidden || !speakerName ? "System default" : speakerName}
+        </div>
+        <p className="text-xs italic text-muted-foreground">
+          Switching speakers in the app isn't supported yet — change your output in your system sound settings.
+        </p>
+      </Group>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the flat auto-generated plugin settings form with polished, curated sections. The secret **OpenAI API key** stays the one declarative field (secure 0600 storage, never in the DB or frontend); everything else moves to kv-backed config rendered by our own components, so the page reads as one consistent system instead of a dumped field list.

## Sections

- **Model & voice** — a credential status card that shows what Aide is using and, when you have *both* an API key and a ChatGPT subscription, lets you choose between them; a **Remove API key** action that truly clears the secret (writes `null`, so the field reads "not set" again). Full voice list, `marin` default.
- **Behavior** — the **prompt** (preview / edit / reset to default), a thread-finish **announcement** toggle, and a **plugin picker modal** (checklist of your installed plugins) for which plugins Aide may run, plus a **View built-in tools** list so "built-in" isn't a mystery.
- **Audio** — microphone picker with a **live input-level meter** to test it, an inline refresh control, and a read-only system-default speaker (in-app output routing isn't supported).

## Under the hood

- Non-secret config (`model`, `voice`, `notifications`, `pluginCommands`, `credentialPreference`) moves out of `bb.settings.define` into kv storage, with a one-time migration from the old declarative values.
- New RPCs: `getConfig` / `setConfig`, `getCredentialStatus`, `clearApiKey`, `listPlugins`. `apiKey()` now honors the credential preference.
- Consistent title-case headings, shared `Button` / `Group` primitives, and crisp copy throughout.

## Testing

`npm run typecheck` and `npm test` (16/16) pass. Verified against a running plugin: config round-trips, credential detection/chooser, key removal, and the plugin/tools modals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)