### PR TITLE
Handsfree: redesign the page + reliable voice across surfaces and mobile

### DIFF
--- a/app.tsx
+++ b/app.tsx
@@ -40,6 +40,7 @@ function AideVoiceButton() {
   const sidebarActions = experimental_useSidebarThreadActions();
   const state = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
   const activity = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getActivity);
+  const micSuspended = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getMicSuspended);
 
   // Global exclusivity: when any window starts a call, all others stop theirs.
   useRealtime("voice-call", (payload) => {
@@ -104,13 +105,17 @@ function AideVoiceButton() {
     // by the slashed mic on the left button, not by graying this out.
     const speaking = activity === "aide";
     const listening = activity === "you"; // never true while muted (mic is off)
-    const middleLabel = speaking
-      ? "Aide speaking…"
-      : listening
-        ? "Listening…"
-        : muted
-          ? "Muted"
-          : "Connected";
+    // A suspended mic (iOS backgrounding) means Aide can't hear you — say so
+    // rather than showing a reassuring "Connected".
+    const middleLabel = micSuspended
+      ? "Mic paused"
+      : speaking
+        ? "Aide speaking…"
+        : listening
+          ? "Listening…"
+          : muted
+            ? "Muted"
+            : "Connected";
     return (
       <div className="flex h-7 shrink-0 items-center overflow-hidden rounded-full border border-border bg-accent">
         <button
@@ -133,11 +138,13 @@ function AideVoiceButton() {
             "flex h-7 items-center justify-center px-2 transition-colors",
             // Aide can still be talking while you're muted, so who's-speaking
             // wins over the muted/quiet dim (mute is shown by the slashed mic).
-            speaking
-              ? "text-[color:var(--success,#6faf76)]" // themed green for Aide
-              : listening
-                ? "text-foreground"
-                : "text-muted-foreground/60",
+            micSuspended
+              ? "text-destructive" // uplink down — surface it, don't reassure
+              : speaking
+                ? "text-[color:var(--success,#6faf76)]" // themed green for Aide
+                : listening
+                  ? "text-foreground"
+                  : "text-muted-foreground/60",
           )}
           title={middleLabel}
           aria-label={middleLabel}

--- a/app.tsx
+++ b/app.tsx
@@ -57,6 +57,11 @@ function AideVoiceButton() {
   // reflects it, and relay stop/mute back to whichever realm owns the call.
   useRealtime("voice-presence", (payload) => voiceAgent.ingestPresence(payload));
   useRealtime("voice-command", (payload) => voiceAgent.applyVoiceCommand(payload));
+  useRealtime("voice-presence-query", () => voiceAgent.answerPresenceQuery());
+
+  // Catch up immediately when this surface mounts (e.g. a realm rebuilt after
+  // navigation), rather than waiting up to a heartbeat to learn a call is live.
+  useEffect(() => voiceAgent.requestPresence(), []);
 
   // Thread-event notifications (digested; disabled via `notifications` setting).
   useRealtime("aide-thread-event", (payload) => {

--- a/app.tsx
+++ b/app.tsx
@@ -5,7 +5,7 @@
 // and audio playback happen right here in the bb app); the backend performs
 // the SDP exchange (it holds the API key) and executes bb tools via bb.sdk.
 // The session itself lives in voice-agent.ts and outlives any component.
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 import {
   definePluginApp,
   experimental_useSidebarThreadActions,
@@ -22,44 +22,8 @@ import { SessionsPanel } from "./sessions-panel";
 import { AudioSettings, BehaviorSettings, ModelsSettings } from "./settings-sections";
 import { cn } from "@/lib/utils";
 import { AUDIO_DEVICE_STORAGE_KEY } from "./audio-devices";
+import { MicIcon, StopIcon, WaveformIcon, useCallElapsed } from "./voice-chrome";
 import "./app.css";
-
-
-function WaveformIcon({ live }: { live: boolean }) {
-  return (
-    <svg
-      viewBox="0 0 16 16"
-      className={cn("size-4", live && "aide-wave-live")}
-      fill="currentColor"
-      aria-hidden
-    >
-      <rect className="aide-bar" x="1.5" y="6" width="1.8" height="4" rx="0.9" />
-      <rect className="aide-bar" x="4.9" y="3.5" width="1.8" height="9" rx="0.9" />
-      <rect className="aide-bar" x="8.3" y="1.5" width="1.8" height="13" rx="0.9" />
-      <rect className="aide-bar" x="11.7" y="4.5" width="1.8" height="7" rx="0.9" />
-    </svg>
-  );
-}
-
-function MicIcon({ slashed }: { slashed: boolean }) {
-  return (
-    <svg viewBox="0 0 16 16" className="size-4" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" aria-hidden>
-      <rect x="6" y="1.8" width="4" height="7" rx="2" fill="currentColor" stroke="none" />
-      <path d="M3.5 7.5a4.5 4.5 0 0 0 9 0" />
-      <path d="M8 12v2.2" />
-      {slashed ? <path d="M2.5 2.5l11 11" strokeWidth="1.6" /> : null}
-    </svg>
-  );
-}
-
-/** A rounded stop square — ends the voice session. */
-function StopIcon() {
-  return (
-    <svg viewBox="0 0 16 16" className="size-3.5" fill="currentColor" aria-hidden>
-      <rect x="4" y="4" width="8" height="8" rx="1.6" />
-    </svg>
-  );
-}
 
 function AideVoiceButton() {
   const rpc = useRpc<typeof rpcContract>();
@@ -291,26 +255,6 @@ function ThreadListWithVoiceBar({ Original }: PluginThreadListProps) {
       </div>
     </div>
   );
-}
-
-function formatElapsed(ms: number): string {
-  const total = Math.floor(Math.max(0, ms) / 1000);
-  const minutes = Math.floor(total / 60);
-  const seconds = total % 60;
-  return `${minutes}:${String(seconds).padStart(2, "0")}`;
-}
-
-/** Live call duration as m:ss, ticking each second; null when no live call. */
-function useCallElapsed(): string | null {
-  const startedAt = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getLiveStartedAt);
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    if (startedAt == null) return;
-    setNow(Date.now());
-    const id = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(id);
-  }, [startedAt]);
-  return startedAt == null ? null : formatElapsed(now - startedAt);
 }
 
 /** Trailing accessory on the Aide sidebar row: a live indicator with duration. */

--- a/app.tsx
+++ b/app.tsx
@@ -53,6 +53,11 @@ function AideVoiceButton() {
     if (typeof muted === "boolean") voiceAgent.setMuted(muted);
   });
 
+  // Cross-surface presence: mirror a call owned by another realm so this pill
+  // reflects it, and relay stop/mute back to whichever realm owns the call.
+  useRealtime("voice-presence", (payload) => voiceAgent.ingestPresence(payload));
+  useRealtime("voice-command", (payload) => voiceAgent.applyVoiceCommand(payload));
+
   // Thread-event notifications (digested; disabled via `notifications` setting).
   useRealtime("aide-thread-event", (payload) => {
     const event = payload as { kind?: unknown; threadId?: unknown; title?: unknown } | null;
@@ -107,7 +112,7 @@ function AideVoiceButton() {
           type="button"
           aria-label={muted ? "Unmute Aide microphone" : "Mute Aide microphone"}
           title={muted ? "Unmute" : "Mute"}
-          onClick={() => voiceAgent.toggleMute()}
+          onClick={() => voiceAgent.toggleMuteFromSurface()}
           className={cn(
             "flex size-7 items-center justify-center transition-colors",
             muted
@@ -139,7 +144,7 @@ function AideVoiceButton() {
           type="button"
           aria-label="Stop Aide voice session"
           title="Stop"
-          onClick={() => voiceAgent.stop()}
+          onClick={() => voiceAgent.stopFromSurface()}
           className="flex size-7 items-center justify-center text-muted-foreground transition-colors hover:bg-destructive/15 hover:text-destructive"
         >
           <StopIcon />
@@ -153,7 +158,7 @@ function AideVoiceButton() {
       type="button"
       aria-label="Start Aide voice agent"
       title="Talk to Aide"
-      onClick={() => voiceAgent.toggle()}
+      onClick={() => voiceAgent.toggleFromSurface()}
       className={cn(
         "flex size-7 shrink-0 items-center justify-center rounded-full border transition-colors",
         state === "connecting"
@@ -205,7 +210,7 @@ function SidebarVoiceBar() {
         type="button"
         aria-label={active ? "Stop Aide voice agent" : "Start Aide voice agent"}
         title={active ? "Stop Aide" : "Talk to Aide"}
-        onClick={() => voiceAgent.toggle()}
+        onClick={() => voiceAgent.toggleFromSurface()}
         className={cn(
           "flex h-7 flex-1 items-center justify-center gap-1.5 rounded-md border border-border px-2 text-xs font-medium transition-colors",
           active
@@ -224,7 +229,7 @@ function SidebarVoiceBar() {
           type="button"
           aria-label={muted ? "Unmute Aide microphone" : "Mute Aide microphone"}
           title={muted ? "Unmute" : "Mute"}
-          onClick={() => voiceAgent.toggleMute()}
+          onClick={() => voiceAgent.toggleMuteFromSurface()}
           className={cn(
             "flex size-7 shrink-0 items-center justify-center rounded-md border border-border transition-colors",
             muted

--- a/client-identity.ts
+++ b/client-identity.ts
@@ -49,3 +49,95 @@ export const realmId = randomId();
 export function identityTag(): { client: string; realm: string } {
   return { client: clientId, realm: realmId };
 }
+
+/**
+ * A human-recognizable description of THIS device/runtime, captured once (on
+ * `client.hello`) and keyed to `clientId`. Coarse label for scanning + the raw
+ * UA for truth (first-party, local-only). Best-effort: every field degrades to
+ * "" / a default when the API is missing (e.g. tests without navigator/window).
+ */
+export interface ClientDescriptor {
+  platform: string;
+  mobile: boolean;
+  browser: string;
+  displayMode: string;
+  runtime: string;
+  label: string;
+  ua: string;
+}
+
+function detectDisplayMode(): string {
+  try {
+    if (typeof window !== "undefined" && window.matchMedia) {
+      for (const mode of ["standalone", "fullscreen", "minimal-ui"]) {
+        if (window.matchMedia(`(display-mode: ${mode})`).matches) return mode;
+      }
+    }
+    // iOS Safari "Add to Home Screen" reports here rather than via matchMedia.
+    if (typeof navigator !== "undefined" && (navigator as { standalone?: boolean }).standalone) {
+      return "standalone";
+    }
+  } catch {
+    /* ignore */
+  }
+  return "browser";
+}
+
+function describeClient(): ClientDescriptor {
+  const nav = typeof navigator !== "undefined" ? navigator : undefined;
+  const ua = nav?.userAgent ?? "";
+  const uaData = (nav as { userAgentData?: { platform?: string; mobile?: boolean; brands?: { brand: string }[] } } | undefined)
+    ?.userAgentData;
+
+  const platform =
+    uaData?.platform ||
+    (/\b(iPhone|iPad|iPod)\b/.test(ua)
+      ? "iOS"
+      : /\bMacintosh\b/.test(ua)
+        ? "macOS"
+        : /\bWindows\b/.test(ua)
+          ? "Windows"
+          : /\bAndroid\b/.test(ua)
+            ? "Android"
+            : /\bLinux\b/.test(ua)
+              ? "Linux"
+              : "");
+
+  const mobile = uaData?.mobile ?? /\b(Mobi|iPhone|iPod|Android)\b/.test(ua);
+
+  const brand = uaData?.brands?.map((b) => b.brand).find((b) => b && !/Not.?A.?Brand/i.test(b));
+  const browser =
+    brand ||
+    (/\bElectron\b/i.test(ua)
+      ? "Electron"
+      : /\bEdg\//.test(ua)
+        ? "Edge"
+        : /\bOPR\/|Opera\b/.test(ua)
+          ? "Opera"
+          : /\bFirefox\//.test(ua)
+            ? "Firefox"
+            : /\bCriOS\/|Chrome\//.test(ua)
+              ? "Chrome"
+              : /\bSafari\//.test(ua)
+                ? "Safari"
+                : "");
+
+  const displayMode = detectDisplayMode();
+
+  const win = typeof window !== "undefined" ? (window as { process?: { versions?: { electron?: string } }; webkit?: { messageHandlers?: unknown } }) : undefined;
+  const runtime =
+    /\bElectron\b/i.test(ua) || win?.process?.versions?.electron
+      ? "electron"
+      : win?.webkit?.messageHandlers
+        ? "native-webview" // best-effort: a WKWebView with a native bridge (e.g. the bb iOS app)
+        : displayMode === "standalone"
+          ? "pwa"
+          : "browser";
+
+  const label = [platform || "?", browser].filter(Boolean).join(" · ") + (mobile ? " (mobile)" : "");
+
+  return { platform, mobile, browser, displayMode, runtime, label, ua };
+}
+
+/** Computed once at module load; stable for this realm. */
+export const clientDescriptor: ClientDescriptor = describeClient();

--- a/client-identity.ts
+++ b/client-identity.ts
@@ -1,0 +1,51 @@
+// Stable identity for observability across bb's per-surface realms and connect
+// clients. The plugin SDK exposes no client/device/connection id (BbContext is
+// just { projectId, threadId }), so we mint our own and stamp it onto events and
+// presence — this is how we can finally see "which client / which realm is this
+// happening from" when a call is mirrored and controlled across surfaces and
+// devices.
+//
+//   - clientId: persisted in localStorage → stable per browser/device. Survives
+//     reloads and navigation; shared by same-origin surfaces on one device, so
+//     it reads as "this client/device". Different on a phone viewing over connect.
+//   - realmId:  fresh per module load → identifies THIS realm/surface instance.
+//     A single device holds several (composer, sidebar, page), so this is what
+//     exposes the multi-realm behavior behind the mobile call bugs.
+//
+// Both are best-effort: no localStorage or no crypto simply degrades to an
+// in-memory id (still useful within a session).
+
+const CLIENT_ID_KEY = "bb-handsfree:client-id";
+
+function randomId(): string {
+  try {
+    return crypto.randomUUID();
+  } catch {
+    return `r-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+  }
+}
+
+function readOrMintClientId(): string {
+  try {
+    const store = typeof window === "undefined" ? null : window.localStorage;
+    if (!store) return randomId();
+    const existing = store.getItem(CLIENT_ID_KEY);
+    if (existing) return existing;
+    const minted = randomId();
+    store.setItem(CLIENT_ID_KEY, minted);
+    return minted;
+  } catch {
+    return randomId();
+  }
+}
+
+/** Stable per browser/device (localStorage-backed). */
+export const clientId = readOrMintClientId();
+
+/** Fresh per realm/surface load (in-memory). */
+export const realmId = randomId();
+
+/** Compact identity to merge into event/presence payloads. */
+export function identityTag(): { client: string; realm: string } {
+  return { client: clientId, realm: realmId };
+}

--- a/client-identity.ts
+++ b/client-identity.ts
@@ -141,3 +141,15 @@ function describeClient(): ClientDescriptor {
 
 /** Computed once at module load; stable for this realm. */
 export const clientDescriptor: ClientDescriptor = describeClient();
+
+/** Compact device summary to stamp on session.started (no raw UA). */
+export function deviceSummary(): {
+  label: string;
+  mobile: boolean;
+  platform: string;
+  browser: string;
+  runtime: string;
+} {
+  const d = clientDescriptor;
+  return { label: d.label, mobile: d.mobile, platform: d.platform, browser: d.browser, runtime: d.runtime };
+}

--- a/docs/handsfree-voice-architecture.md
+++ b/docs/handsfree-voice-architecture.md
@@ -44,7 +44,7 @@ Surfaces are separate realms even on one device (observed: distinct realmIds per
 client), so a plain module singleton is **not** shared across them — each surface
 gets its own instance.
 
-## Cross-surface state (HF-1)
+## Cross-surface state
 
 The only channel across realms is bb's realtime bus. The plugin **backend** can
 `bb.realtime.publish(channel, payload)` to every connected client; a surface can
@@ -76,7 +76,7 @@ Voice input is always the **owner client's microphone**. Another client can mirr
 and control the call but cannot become its microphone; to talk from a different
 device you start a new call there (exclusivity ends the old one).
 
-## The mobile constraint (HF-2)
+## The mobile constraint
 
 When the owner realm is backgrounded on iOS (e.g. the app navigates away), the OS:
 
@@ -85,14 +85,14 @@ When the owner realm is backgrounded on iOS (e.g. the app navigates away), the O
 - **freezes inbound messages** — the realm stops receiving relayed commands,
 - **still fires timers occasionally** — so it keeps emitting presence heartbeats.
 
-Before HF-2 this produced a one-way zombie: you hear Aide, Aide can't hear you,
+Left unhandled, this is a one-way zombie: you hear Aide, Aide can't hear you,
 every surface shows "live", and no stop reaches the frozen owner.
 
 A webview cannot hold the microphone in the background — only a native app with
 background-audio entitlements can, and we run inside bb's webviews. So a
-backgrounded call cannot survive on mobile. HF-2 therefore does not try to keep it
-alive; it **prevents** the backgrounding where it can and **ends cleanly** (and
-recoverably) where it can't.
+backgrounded call cannot survive on mobile. The plugin therefore does not try to
+keep it alive; it **prevents** the backgrounding where it can and **ends cleanly**
+(and recoverably) where it can't.
 
 Desktop (Electron) does not suspend the mic on in-app navigation — audio may pause
 while the panel is hidden, but the mic isn't suspended and the call resumes — so
@@ -108,8 +108,8 @@ things follow from it:
 - `threads.open` **delivers to every connected window**, not just the caller — so
   navigating from the phone also moves the desktop.
 
-HF-2 handles these per tool (see scenarios). Per-client navigation targeting is a
-bb-native gap (HF-4).
+The plugin handles these per tool (see scenarios). Per-client navigation
+targeting is a bb-native gap (see Known limitations).
 
 ## Observability
 
@@ -120,7 +120,7 @@ event is then attributable to a device and surface — which is how the mobile b
 were diagnosed. Suspensions log `mic.suspend.teardown {cause}` naming the tool
 that triggered them, so a mis-classified navigating tool self-reports.
 
-## Known bb-native limits (HF-4)
+## Known limitations
 
 - **No shared/background realm** for plugins — the call is trapped in a
   backgroundable surface. A shared context would remove the need for nav-gating.

--- a/docs/handsfree-voice-architecture.md
+++ b/docs/handsfree-voice-architecture.md
@@ -1,0 +1,128 @@
+# Handsfree voice — architecture & terminology
+
+Aide is a voice operator for bb: you talk, it drives bb (focuses threads, starts
+work, reads output, edits the composer). The call is WebRTC to the OpenAI
+Realtime API — microphone capture and audio playback happen in the bb app (a
+webview); the plugin backend holds the API key, does the SDP exchange, and runs
+tools via the bb SDK.
+
+This is the shared vocabulary and how it actually works. For behaviors, see
+[scenarios](./handsfree-voice-scenarios.md).
+
+## Terminology
+
+- **Realm** — an isolated JavaScript world (own globals and memory), like a
+  browser tab. Two realms share nothing directly.
+- **Surface** — a place the plugin renders: the composer button, the sidebar
+  bar, the Handsfree page. bb renders each surface in its **own realm**.
+- **Client** — one connected bb app instance: the desktop app, or a phone
+  viewing over bb-connect. One client hosts several surfaces/realms.
+- **WebRTC call** — the live audio connection between one client's microphone and
+  OpenAI. Held by the realm that created it.
+- **Owner** — the realm that physically holds the call: its `RTCPeerConnection`,
+  mic capture, and audio element.
+- **Mirror** — a realm that only reflects a call it doesn't own and relays
+  controls to the owner.
+- **Presence** — coarse call state (connecting / live / muted / idle + duration)
+  broadcast so every surface can mirror it.
+- **Command** — a control intent (stop / mute / unmute) relayed to the owner,
+  addressed by nonce.
+- **Nonce** — a per-call id; also the session id the transcript is logged under.
+  Addresses presence and commands to one specific call.
+- **clientId / realmId** — ids we mint for observability. `clientId` persists in
+  localStorage (stable per device/browser); `realmId` is fresh per realm load
+  (identifies one surface instance).
+
+## One call, one realm
+
+A WebRTC call is three physical things — a network connection, the microphone, an
+audio element — held by JS objects in a single realm. They can't move to another
+realm. So the surface you press "start" on owns the call; other surfaces can only
+watch it and relay control. This one fact drives everything below.
+
+Surfaces are separate realms even on one device (observed: distinct realmIds per
+client), so a plain module singleton is **not** shared across them — each surface
+gets its own instance.
+
+## Cross-surface state (HF-1)
+
+The only channel across realms is bb's realtime bus. The plugin **backend** can
+`bb.realtime.publish(channel, payload)` to every connected client; a surface can
+only **subscribe** (`useRealtime`). There is no client-to-client publish, so a
+surface "broadcasts" by calling an RPC that publishes.
+
+- The owner publishes **presence** on each coarse transition and on a ~10s
+  heartbeat.
+- Every other realm mirrors it. A mirror older than ~25s (two missed heartbeats)
+  is treated as gone — so a vanished owner never leaves a ghost "live".
+- Controls from a non-owner relay as **commands** addressed by nonce; only the
+  realm holding that nonce acts.
+- Result: composer pill, sidebar, and page all reflect and control the one live
+  call, whichever surface started it.
+
+Coarse only: who's-speaking isn't broadcast (too chatty); it shows on the owner
+surface.
+
+## Client, device, and realtime scope
+
+`bb.realtime.publish` reaches "every connected client" of one plugin backend —
+one bb app instance and everything attached to it (the local view plus remote
+bb-connect views). It is **not** cross-machine: a separate, independent bb app has
+its own backend, bus, and database. In our setup the phone is a bb-connect client
+of the desktop-hosted app, which is why the desktop can see and control a call the
+phone owns.
+
+Voice input is always the **owner client's microphone**. Another client can mirror
+and control the call but cannot become its microphone; to talk from a different
+device you start a new call there (exclusivity ends the old one).
+
+## The mobile constraint (HF-2)
+
+When the owner realm is backgrounded on iOS (e.g. the app navigates away), the OS:
+
+- **suspends the microphone** — the uplink dies (the mic track fires `mute` while
+  the page is `hidden`),
+- **freezes inbound messages** — the realm stops receiving relayed commands,
+- **still fires timers occasionally** — so it keeps emitting presence heartbeats.
+
+Before HF-2 this produced a one-way zombie: you hear Aide, Aide can't hear you,
+every surface shows "live", and no stop reaches the frozen owner.
+
+A webview cannot hold the microphone in the background — only a native app with
+background-audio entitlements can, and we run inside bb's webviews. So a
+backgrounded call cannot survive on mobile. HF-2 therefore does not try to keep it
+alive; it **prevents** the backgrounding where it can and **ends cleanly** (and
+recoverably) where it can't.
+
+Desktop (Electron) does not suspend the mic on in-app navigation — audio may pause
+while the panel is hidden, but the mic isn't suspended and the call resumes — so
+the mobile-only paths below don't trigger there.
+
+## Navigation
+
+`bb.sdk.threads.open` is the navigation primitive (bring a thread on screen). Two
+things follow from it:
+
+- `start_thread` **also** navigates — its handler does `spawn()` then
+  `threads.open()`.
+- `threads.open` **delivers to every connected window**, not just the caller — so
+  navigating from the phone also moves the desktop.
+
+HF-2 handles these per tool (see scenarios). Per-client navigation targeting is a
+bb-native gap (HF-4).
+
+## Observability
+
+The SDK exposes no client/device id, so we mint our own and stamp it on events and
+presence: `clientId` (device), `realmId` (surface), plus a one-time device
+descriptor (platform, browser, runtime, raw user-agent) on `client.hello`. Every
+event is then attributable to a device and surface — which is how the mobile bugs
+were diagnosed. Suspensions log `mic.suspend.teardown {cause}` naming the tool
+that triggered them, so a mis-classified navigating tool self-reports.
+
+## Known bb-native limits (HF-4)
+
+- **No shared/background realm** for plugins — the call is trapped in a
+  backgroundable surface. A shared context would remove the need for nav-gating.
+- **No per-client navigation targeting** — `threads.open` hits all windows.
+  Needed for the "phone is the mic, desktop is the driven screen" handoff model.

--- a/docs/handsfree-voice-scenarios.md
+++ b/docs/handsfree-voice-scenarios.md
@@ -34,10 +34,9 @@ You ask Aide to open a thread. It doesn't navigate; it says "tap Live threads,
 then select …".
 
 - **Ideal:** the call stays alive; you're told where to tap.
-- **Under the hood:** `focus_thread` is in the mobile nav block-list (measured to
-  background the owner). During a live mobile call it's refused with guidance
-  instead of run. Verified: a multi-minute call survived two blocked focus
-  requests.
+- **Under the hood:** `focus_thread` is in the mobile nav block-list (it
+  backgrounds the owner realm). During a live mobile call it's refused with
+  guidance instead of run, so the call keeps running.
 
 ## 4. Agent starts a new thread — `start_thread` *(mobile)*
 
@@ -55,8 +54,8 @@ nothing navigates. Aide says "started — tap it in your list to view."
 Runs normally.
 
 - **Ideal:** no effect on the call.
-- **Under the hood:** measured safe (three consecutive calls, no backgrounding) —
-  pane actions don't replace the full-screen surface on mobile. Not gated.
+- **Under the hood:** pane actions don't replace the full-screen surface on
+  mobile, so they don't background the owner. Not gated.
 
 ## 6. You background the app mid-call *(mobile)*
 
@@ -77,14 +76,15 @@ it.
 - **Under the hood:** `forceStop` is server-side and doesn't need the owner to act.
   Any surface's stop clears presence everywhere and marks the session stopped.
 
-## 8. Starting a thread from the phone moves the desktop (known)
+## 8. Navigation targets all windows (known limitation)
 
-Before scenario 4's fix, starting a thread from the phone also navigated the idle
-desktop.
+`threads.open` delivers to every connected window, so a thread brought on screen
+appears on all of them — focusing from the phone also moves the desktop.
 
-- **Now:** fixed for `start_thread` via suppressed focus.
-- **Open:** `threads.open` delivers to all connected windows; per-client targeting
-  is a bb-native gap tracked in HF-4.
+- **Handled:** `start_thread` avoids this on a mobile call by suppressing focus
+  (scenario 4), so it doesn't move other windows.
+- **Open:** a general fix — targeting navigation at one specific client — is a
+  bb-native gap.
 
 ## How a mis-classified navigating tool self-reports
 

--- a/docs/handsfree-voice-scenarios.md
+++ b/docs/handsfree-voice-scenarios.md
@@ -1,0 +1,94 @@
+# Handsfree voice — behaviors & scenarios
+
+Each behavior, paired with what happens under the hood. For vocabulary and the
+underlying model, see [architecture](./handsfree-voice-architecture.md).
+
+Format: **what you do → what happens → ideal outcome**, then **under the hood**.
+Behaviors marked *(mobile)* apply to a mobile client (`clientDescriptor.mobile`)
+in a live call; on desktop the call survives navigation and these don't trigger.
+
+## 1. Use one call across surfaces (one device)
+
+Start a call on the Handsfree page, then move to a thread. The composer pill and
+sidebar show the same live call with a ticking duration, and can mute/stop it.
+
+- **Ideal:** every surface reflects and controls the one call.
+- **Under the hood:** the page realm owns the call; other realms mirror its
+  presence broadcast and relay controls by nonce. On one device the microphone is
+  shared hardware, so you keep talking regardless of which surface is on screen.
+
+## 2. Control a call from another surface or device
+
+Press stop or mute on a surface that didn't start the call — including the desktop
+for a phone-owned call.
+
+- **Ideal:** it takes effect and never gets stuck.
+- **Under the hood:** stopping a mirrored call goes through server-authoritative
+  `forceStop(nonce)` — it marks the session stopped and broadcasts idle + stop, so
+  it works even if the owner realm is frozen. Mute/unmute relay as commands the
+  owner applies.
+
+## 3. Agent opens an existing thread — `focus_thread` *(mobile)*
+
+You ask Aide to open a thread. It doesn't navigate; it says "tap Live threads,
+then select …".
+
+- **Ideal:** the call stays alive; you're told where to tap.
+- **Under the hood:** `focus_thread` is in the mobile nav block-list (measured to
+  background the owner). During a live mobile call it's refused with guidance
+  instead of run. Verified: a multi-minute call survived two blocked focus
+  requests.
+
+## 4. Agent starts a new thread — `start_thread` *(mobile)*
+
+You ask Aide to start a thread and let it run. It starts it, the call keeps going,
+nothing navigates. Aide says "started — tap it in your list to view."
+
+- **Ideal:** the work starts without dropping the call or moving any screen.
+- **Under the hood:** `start_thread` normally spawns then calls `threads.open`
+  (navigation, all windows). On a mobile client in a live call the client passes
+  `focus:false`; the server spawns **without** `open()`. The thread runs; no realm
+  is backgrounded.
+
+## 5. Agent spotlights/maximizes a pane — `set_pane` *(mobile)*
+
+Runs normally.
+
+- **Ideal:** no effect on the call.
+- **Under the hood:** measured safe (three consecutive calls, no backgrounding) —
+  pane actions don't replace the full-screen surface on mobile. Not gated.
+
+## 6. You background the app mid-call *(mobile)*
+
+You switch apps or go home during a call. The call ends with "call ended — the app
+moved to the background", and every surface goes idle.
+
+- **Ideal:** an honest end, not a silent one-way zombie.
+- **Under the hood:** the mic track fires `mute` while `hidden`; the owner ends the
+  call right then — `forceStop` first (server-enforced, survives the imminent
+  freeze) then local teardown. The session logs `session.stopped`; no zombie.
+
+## 7. A call gets stuck anyway
+
+Rare now, but if a call is stranded in a frozen owner, stop from any surface clears
+it.
+
+- **Ideal:** no force-quit, no manual cleanup.
+- **Under the hood:** `forceStop` is server-side and doesn't need the owner to act.
+  Any surface's stop clears presence everywhere and marks the session stopped.
+
+## 8. Starting a thread from the phone moves the desktop (known)
+
+Before scenario 4's fix, starting a thread from the phone also navigated the idle
+desktop.
+
+- **Now:** fixed for `start_thread` via suppressed focus.
+- **Open:** `threads.open` delivers to all connected windows; per-client targeting
+  is a bb-native gap tracked in HF-4.
+
+## How a mis-classified navigating tool self-reports
+
+The nav block-list (currently just `focus_thread`) is small on purpose. If any
+other tool ever backgrounds a call, it isn't a silent failure: the call ends
+cleanly and the logs record `mic.suspend.teardown {cause: <tool>}` naming it, so
+it can be added to the list from evidence rather than guesswork.

--- a/server.ts
+++ b/server.ts
@@ -1192,7 +1192,12 @@ export default async function plugin(bb: BbPluginApi) {
           startedAt: row.startedAt,
           lastEventAt: row.lastEventAt,
           events: row.events,
-          ended: row.stopped > 0,
+          // Ended if it logged session.stopped, OR it went quiet long ago: a
+          // call that dies uncleanly (page unload, torn-down WebRTC on
+          // navigation, app killed on mobile) never logs session.stopped, so
+          // without this stale check every crashed session shows "live" forever.
+          // The active window overrides this to keep a genuinely live call live.
+          ended: row.stopped > 0 || Date.now() - row.lastEventAt > 300_000,
           costUsd: Number(
             (costStmt.all(row.id) as UsageRow[]).reduce((sum, usage) => sum + costUsd(usage), 0).toFixed(4),
           ),

--- a/server.ts
+++ b/server.ts
@@ -177,7 +177,7 @@ export const rpcContract = defineRpcContract({
   },
   /** List voice sessions, newest first, with counts and estimated cost. */
   listSessions: {
-    input: z.null(),
+    input: z.object({ offset: z.number().int().min(0) }).strict().nullable(),
     output: z
       .object({
         sessions: z.array(
@@ -192,6 +192,7 @@ export const rpcContract = defineRpcContract({
             })
             .strict(),
         ),
+        hasMore: z.boolean(),
       })
       .strict(),
   },
@@ -1146,17 +1147,24 @@ export default async function plugin(bb: BbPluginApi) {
       bb.realtime.publish("aide-log", { sessionId });
       return { ok: true as const };
     },
-    async listSessions() {
+    async listSessions(input) {
+      // Page through grouped sessions newest-first. Fetch one extra row past the
+      // page to tell the client whether a "Load more" is worthwhile, then drop it.
+      const pageSize = 30;
+      const offset = input?.offset ?? 0;
       const rows = db
         .prepare(
           `SELECT session_id AS id, MIN(ts) AS startedAt, MAX(ts) AS lastEventAt, COUNT(*) AS events,
                   SUM(CASE WHEN kind = 'session.stopped' THEN 1 ELSE 0 END) AS stopped
-           FROM session_events GROUP BY session_id ORDER BY startedAt DESC LIMIT 100`,
+           FROM session_events GROUP BY session_id ORDER BY startedAt DESC LIMIT ? OFFSET ?`,
         )
-        .all() as { id: string; startedAt: number; lastEventAt: number; events: number; stopped: number }[];
+        .all(pageSize + 1, offset) as { id: string; startedAt: number; lastEventAt: number; events: number; stopped: number }[];
+      const hasMore = rows.length > pageSize;
+      const page = hasMore ? rows.slice(0, pageSize) : rows;
       const costStmt = db.prepare("SELECT * FROM usage_events WHERE session_id = ?");
       return {
-        sessions: rows.map((row) => ({
+        hasMore,
+        sessions: page.map((row) => ({
           id: row.id,
           startedAt: row.startedAt,
           lastEventAt: row.lastEventAt,

--- a/server.ts
+++ b/server.ts
@@ -177,6 +177,35 @@ export const rpcContract = defineRpcContract({
       .strict(),
     output: z.object({ ok: z.literal(true) }).strict(),
   },
+  /**
+   * Broadcast a live call's coarse presence to every surface/realm. The owning
+   * realm (the one holding the WebRTC session) publishes on each state change
+   * and on a heartbeat; other realms mirror it so their composer pill / sidebar
+   * bar reflect the call they don't own. Pure pass-through to realtime.
+   */
+  publishPresence: {
+    input: z
+      .object({
+        nonce: z.string().min(1),
+        phase: z.enum(["connecting", "live", "muted", "idle"]),
+        startedAt: z.number().nullable(),
+      })
+      .strict(),
+    output: z.object({ ok: z.literal(true) }).strict(),
+  },
+  /**
+   * Relay a control intent (stop/mute/unmute) from a surface that does NOT own
+   * the call to the realm that does. Only the owner (matching nonce) acts on it.
+   */
+  sendVoiceCommand: {
+    input: z
+      .object({
+        nonce: z.string().min(1),
+        action: z.enum(["stop", "mute", "unmute"]),
+      })
+      .strict(),
+    output: z.object({ ok: z.literal(true) }).strict(),
+  },
   /** List voice sessions, newest first, with counts and estimated cost. */
   listSessions: {
     input: z.object({ offset: z.number().int().min(0) }).strict().nullable(),
@@ -1150,6 +1179,14 @@ export default async function plugin(bb: BbPluginApi) {
         else bb.log.info(`${kind} ${detail}`);
       }
       bb.realtime.publish("aide-log", { sessionId });
+      return { ok: true as const };
+    },
+    async publishPresence({ nonce, phase, startedAt }) {
+      bb.realtime.publish("voice-presence", { nonce, phase, startedAt });
+      return { ok: true as const };
+    },
+    async sendVoiceCommand({ nonce, action }) {
+      bb.realtime.publish("voice-command", { nonce, action });
       return { ok: true as const };
     },
     async listSessions(input) {

--- a/server.ts
+++ b/server.ts
@@ -249,6 +249,16 @@ export const rpcContract = defineRpcContract({
               costUsd: z.number(),
               preview: z.string(),
               hasError: z.boolean(),
+              /** Which device the call came through (from session.started); null for old sessions. */
+              device: z
+                .object({
+                  label: z.string(),
+                  mobile: z.boolean(),
+                  platform: z.string(),
+                  browser: z.string(),
+                  runtime: z.string(),
+                })
+                .nullable(),
             })
             .strict(),
         ),
@@ -1281,6 +1291,27 @@ export default async function plugin(bb: BbPluginApi) {
       const errorStmt = db.prepare(
         "SELECT 1 FROM session_events WHERE session_id = ? AND kind = 'error' LIMIT 1",
       );
+      const deviceStmt = db.prepare(
+        "SELECT payload FROM session_events WHERE session_id = ? AND kind = 'session.started' ORDER BY ts LIMIT 1",
+      );
+      const device = (sessionId: string) => {
+        const found = deviceStmt.get(sessionId) as { payload: string } | undefined;
+        if (!found) return null;
+        try {
+          const d = (JSON.parse(found.payload) as { device?: unknown }).device;
+          if (!d || typeof d !== "object") return null;
+          const o = d as Record<string, unknown>;
+          return {
+            label: String(o.label ?? ""),
+            mobile: Boolean(o.mobile),
+            platform: String(o.platform ?? ""),
+            browser: String(o.browser ?? ""),
+            runtime: String(o.runtime ?? ""),
+          };
+        } catch {
+          return null;
+        }
+      };
       const preview = (sessionId: string): string => {
         const found = previewStmt.get(sessionId) as { payload: string } | undefined;
         if (!found) return "";
@@ -1309,6 +1340,7 @@ export default async function plugin(bb: BbPluginApi) {
           ),
           preview: preview(row.id),
           hasError: errorStmt.get(row.id) !== undefined,
+          device: device(row.id),
         })),
       };
     },

--- a/server.ts
+++ b/server.ts
@@ -979,7 +979,13 @@ export default async function plugin(bb: BbPluginApi) {
             ? { environmentId, target: "all", mergeBaseBranch }
             : { environmentId, target: "uncommitted" },
         );
-        await bb.sdk.threads.open({ threadId, file: null }).catch(() => undefined);
+        // Like start_thread, show_diff both computes something useful AND
+        // navigates (threads.open). Skip the navigation when the client asks
+        // (focus:false) so a live mobile call isn't backgrounded — the diff
+        // summary is still returned either way.
+        if (args.focus !== false) {
+          await bb.sdk.threads.open({ threadId, file: null }).catch(() => undefined);
+        }
         if (diff.outcome !== "available") return `Diff not available (${diff.outcome}).`;
         const files = diff.files.map((f) => ({ path: f.path, additions: f.additions, deletions: f.deletions }));
         return JSON.stringify({ shortstat: diff.shortstat, files: files.slice(0, 50) });

--- a/server.ts
+++ b/server.ts
@@ -194,6 +194,16 @@ export const rpcContract = defineRpcContract({
     output: z.object({ ok: z.literal(true) }).strict(),
   },
   /**
+   * Ask whoever owns a live call to re-announce its presence right now. A
+   * freshly mounted surface (e.g. a page realm rebuilt after mobile navigation)
+   * fires this so it catches up immediately instead of waiting up to a full
+   * heartbeat — otherwise it briefly shows "idle" over a call that is live.
+   */
+  requestPresence: {
+    input: z.null(),
+    output: z.object({ ok: z.literal(true) }).strict(),
+  },
+  /**
    * Relay a control intent (stop/mute/unmute) from a surface that does NOT own
    * the call to the realm that does. Only the owner (matching nonce) acts on it.
    */
@@ -1183,6 +1193,10 @@ export default async function plugin(bb: BbPluginApi) {
     },
     async publishPresence({ nonce, phase, startedAt }) {
       bb.realtime.publish("voice-presence", { nonce, phase, startedAt });
+      return { ok: true as const };
+    },
+    async requestPresence() {
+      bb.realtime.publish("voice-presence-query", {});
       return { ok: true as const };
     },
     async sendVoiceCommand({ nonce, action }) {

--- a/server.ts
+++ b/server.ts
@@ -222,6 +222,17 @@ export const rpcContract = defineRpcContract({
       .strict(),
     output: z.object({ ok: z.literal(true) }).strict(),
   },
+  /**
+   * End a call authoritatively, without needing its owner realm to act — the
+   * owner may be a frozen, backgrounded mobile webview that can no longer receive
+   * commands. Marks the session stopped (so the list stops showing it live) and
+   * broadcasts idle + a stop so every surface clears and the owner tears down if
+   * it ever thaws. This is what makes stop reliable against the navigation zombie.
+   */
+  forceStop: {
+    input: z.object({ nonce: z.string().min(1) }).strict(),
+    output: z.object({ ok: z.literal(true) }).strict(),
+  },
   /** List voice sessions, newest first, with counts and estimated cost. */
   listSessions: {
     input: z.object({ offset: z.number().int().min(0) }).strict().nullable(),
@@ -1213,6 +1224,17 @@ export default async function plugin(bb: BbPluginApi) {
     },
     async sendVoiceCommand({ nonce, action, client, realm }) {
       bb.realtime.publish("voice-command", { nonce, action, client, realm });
+      return { ok: true as const };
+    },
+    async forceStop({ nonce }) {
+      // Durable end-marker so listSessions stops showing it live even if the
+      // owner realm never logs its own session.stopped (count > 0 is enough).
+      db.prepare(
+        "INSERT INTO session_events (session_id, ts, kind, payload) VALUES (?, ?, ?, ?)",
+      ).run(nonce, Date.now(), "session.stopped", JSON.stringify({ _forced: true }));
+      bb.realtime.publish("voice-presence", { nonce, phase: "idle", startedAt: null });
+      bb.realtime.publish("voice-command", { nonce, action: "stop" });
+      bb.realtime.publish("aide-log", { sessionId: nonce });
       return { ok: true as const };
     },
     async listSessions(input) {

--- a/server.ts
+++ b/server.ts
@@ -144,7 +144,9 @@ export const rpcContract = defineRpcContract({
     output: z
       .object({
         plugins: z.array(
-          z.object({ id: z.string(), name: z.string(), summary: z.string() }).strict(),
+          z
+            .object({ id: z.string(), name: z.string(), summary: z.string(), iconUrl: z.string().nullable() })
+            .strict(),
         ),
       })
       .strict(),
@@ -189,6 +191,8 @@ export const rpcContract = defineRpcContract({
               events: z.number(),
               ended: z.boolean(),
               costUsd: z.number(),
+              preview: z.string(),
+              hasError: z.boolean(),
             })
             .strict(),
         ),
@@ -1109,6 +1113,7 @@ export default async function plugin(bb: BbPluginApi) {
               id: plugin.id,
               name: plugin.cliCommand?.name ?? plugin.id,
               summary: plugin.cliCommand?.summary ?? "",
+              iconUrl: plugin.iconUrl ?? null,
             }))
             .sort((a, b) => a.name.localeCompare(b.name)),
         };
@@ -1162,6 +1167,24 @@ export default async function plugin(bb: BbPluginApi) {
       const hasMore = rows.length > pageSize;
       const page = hasMore ? rows.slice(0, pageSize) : rows;
       const costStmt = db.prepare("SELECT * FROM usage_events WHERE session_id = ?");
+      // First thing the user said, as a scannable preview; fall back to Aide's
+      // opening line so a row is never blank.
+      const previewStmt = db.prepare(
+        "SELECT payload FROM session_events WHERE session_id = ? AND kind IN ('user', 'assistant') ORDER BY (kind = 'assistant'), ts, id LIMIT 1",
+      );
+      const errorStmt = db.prepare(
+        "SELECT 1 FROM session_events WHERE session_id = ? AND kind = 'error' LIMIT 1",
+      );
+      const preview = (sessionId: string): string => {
+        const found = previewStmt.get(sessionId) as { payload: string } | undefined;
+        if (!found) return "";
+        try {
+          const text = (JSON.parse(found.payload) as { text?: unknown }).text;
+          return typeof text === "string" ? text.slice(0, 140) : "";
+        } catch {
+          return "";
+        }
+      };
       return {
         hasMore,
         sessions: page.map((row) => ({
@@ -1173,6 +1196,8 @@ export default async function plugin(bb: BbPluginApi) {
           costUsd: Number(
             (costStmt.all(row.id) as UsageRow[]).reduce((sum, usage) => sum + costUsd(usage), 0).toFixed(4),
           ),
+          preview: preview(row.id),
+          hasError: errorStmt.get(row.id) !== undefined,
         })),
       };
     },

--- a/server.ts
+++ b/server.ts
@@ -1181,9 +1181,10 @@ export default async function plugin(bb: BbPluginApi) {
       db.prepare(
         "INSERT INTO session_events (session_id, ts, kind, payload) VALUES (?, ?, ?, ?)",
       ).run(sessionId, Date.now(), kind, JSON.stringify(payload));
-      // Mirror audio-device diagnostics to the plugin log so `bb plugin logs
-      // handsfree` surfaces mic/speaker problems without opening the DB.
-      if (kind.startsWith("audio.")) {
+      // Mirror audio/mic lifecycle diagnostics to the plugin log so `bb plugin
+      // logs handsfree` surfaces mic/speaker/backgrounding problems (HF-2)
+      // without opening the DB.
+      if (kind.startsWith("audio.") || kind.startsWith("mic.") || kind.startsWith("page.")) {
         const detail = JSON.stringify(payload);
         if (kind.endsWith(".failed")) bb.log.error(`${kind} ${detail}`);
         else bb.log.info(`${kind} ${detail}`);

--- a/server.ts
+++ b/server.ts
@@ -189,6 +189,9 @@ export const rpcContract = defineRpcContract({
         nonce: z.string().min(1),
         phase: z.enum(["connecting", "live", "muted", "idle"]),
         startedAt: z.number().nullable(),
+        /** Which client/realm owns this call (observability; see client-identity). */
+        client: z.string().optional(),
+        realm: z.string().optional(),
       })
       .strict(),
     output: z.object({ ok: z.literal(true) }).strict(),
@@ -212,6 +215,9 @@ export const rpcContract = defineRpcContract({
       .object({
         nonce: z.string().min(1),
         action: z.enum(["stop", "mute", "unmute"]),
+        /** Which client/realm issued the command (observability). */
+        client: z.string().optional(),
+        realm: z.string().optional(),
       })
       .strict(),
     output: z.object({ ok: z.literal(true) }).strict(),
@@ -1184,7 +1190,12 @@ export default async function plugin(bb: BbPluginApi) {
       // Mirror audio/mic lifecycle diagnostics to the plugin log so `bb plugin
       // logs handsfree` surfaces mic/speaker/backgrounding problems (HF-2)
       // without opening the DB.
-      if (kind.startsWith("audio.") || kind.startsWith("mic.") || kind.startsWith("page.")) {
+      if (
+        kind.startsWith("audio.") ||
+        kind.startsWith("mic.") ||
+        kind.startsWith("page.") ||
+        kind.startsWith("client.")
+      ) {
         const detail = JSON.stringify(payload);
         if (kind.endsWith(".failed")) bb.log.error(`${kind} ${detail}`);
         else bb.log.info(`${kind} ${detail}`);
@@ -1192,16 +1203,16 @@ export default async function plugin(bb: BbPluginApi) {
       bb.realtime.publish("aide-log", { sessionId });
       return { ok: true as const };
     },
-    async publishPresence({ nonce, phase, startedAt }) {
-      bb.realtime.publish("voice-presence", { nonce, phase, startedAt });
+    async publishPresence({ nonce, phase, startedAt, client, realm }) {
+      bb.realtime.publish("voice-presence", { nonce, phase, startedAt, client, realm });
       return { ok: true as const };
     },
     async requestPresence() {
       bb.realtime.publish("voice-presence-query", {});
       return { ok: true as const };
     },
-    async sendVoiceCommand({ nonce, action }) {
-      bb.realtime.publish("voice-command", { nonce, action });
+    async sendVoiceCommand({ nonce, action, client, realm }) {
+      bb.realtime.publish("voice-command", { nonce, action, client, realm });
       return { ok: true as const };
     },
     async listSessions(input) {

--- a/server.ts
+++ b/server.ts
@@ -895,8 +895,23 @@ export default async function plugin(bb: BbPluginApi) {
           prompt,
           ...(typeof args.title === "string" && args.title ? { title: args.title } : {}),
         });
-        await bb.sdk.threads.open({ threadId: thread.id, file: null }).catch(() => undefined);
-        return JSON.stringify({ started: (await withMachines([describeThread(thread)]))[0] });
+        // `threads.open` navigates every connected window — which backgrounds a
+        // live mobile call (and yanks other windows). The client sets focus:false
+        // when it must not navigate; the thread still spawns and runs.
+        const shouldFocus = args.focus !== false;
+        if (shouldFocus) {
+          await bb.sdk.threads.open({ threadId: thread.id, file: null }).catch(() => undefined);
+        }
+        const started = (await withMachines([describeThread(thread)]))[0];
+        return JSON.stringify(
+          shouldFocus
+            ? { started }
+            : {
+                started,
+                focused: false,
+                note: "Started and running, but NOT brought on screen (that would drop the live call on this phone). Tell the user in one short sentence that it's running and they can tap it in the thread list.",
+              },
+        );
       }
       case "stop_thread": {
         await bb.sdk.threads.stop({ threadId: str("thread_id") });

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -194,77 +194,220 @@ function CallConsole({ onViewTranscript }: { onViewTranscript: (sessionId: strin
   );
 }
 
-function EventLine({ event }: { event: EventRow }) {
-  const payload = parsePayload(event.payload);
-  const time = <span className="shrink-0 tabular-nums text-xs text-muted-foreground">{fmtTime(event.ts)}</span>;
-  switch (event.kind) {
-    case "user":
-      return (
-        <div className="flex gap-3 py-1.5">
-          {time}
-          <div className="text-sm">
-            <span className="font-medium text-foreground">You</span>{" "}
-            <span className="text-foreground/90">{String(payload.text ?? "")}</span>
-          </div>
-        </div>
-      );
-    case "assistant":
-      return (
-        <div className="flex gap-3 py-1.5">
-          {time}
-          <div className="text-sm">
-            <span className="font-medium text-primary">Aide</span>{" "}
-            <span className="text-foreground/90">{String(payload.text ?? "")}</span>
-          </div>
-        </div>
-      );
-    case "tool.call":
-      return (
-        <div className="flex gap-3 py-1">
-          {time}
-          <code className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-            → {String(payload.name ?? "?")}({JSON.stringify(payload.args ?? {})})
-          </code>
-        </div>
-      );
-    case "tool.result": {
-      const output = String(payload.output ?? "");
-      return (
-        <div className="flex gap-3 py-1">
-          {time}
-          <details className="min-w-0 flex-1">
-            <summary className="cursor-pointer truncate font-mono text-xs text-muted-foreground">
-              ← {String(payload.name ?? "?")}: {output.slice(0, 120)}
-            </summary>
-            <pre className="mt-1 overflow-x-auto whitespace-pre-wrap rounded bg-muted p-2 text-xs text-foreground/80">
-              {output}
-            </pre>
-          </details>
-        </div>
-      );
-    }
-    case "notice":
-      return (
-        <div className="flex gap-3 py-1.5">
-          {time}
-          <span className="text-sm italic text-muted-foreground">🔔 {String(payload.text ?? "")}</span>
-        </div>
-      );
-    case "error":
-      return (
-        <div className="flex gap-3 py-1.5">
-          {time}
-          <span className="text-sm text-destructive">{String(payload.message ?? "error")}</span>
-        </div>
-      );
-    default:
-      return (
-        <div className="flex gap-3 py-1">
-          {time}
-          <span className="text-xs italic text-muted-foreground">{event.kind.replace("session.", "session ")}</span>
-        </div>
-      );
+// ─── Transcript rendering ────────────────────────────────────────────────────
+// The transcript reads as a narrative, not a raw log: speech is attributed with
+// a speaker gutter + tint, and tool calls become human "action chips" (a paired
+// call+result resolved into one line) with the raw {args, output} always one
+// tap away. The action set is open-ended (built-ins + a dynamic
+// run_plugin_command), so known tools get crafted phrasing and everything else
+// falls through a generic humanizer — nothing is ever dropped or shown as junk.
+
+type ActionFamily = "inspect" | "navigate" | "mutate" | "compose" | "self" | "plugin" | "other";
+
+const ACTIONS: Record<string, { family: ActionFamily; verb: string }> = {
+  get_context: { family: "inspect", verb: "Read your context" },
+  list_projects: { family: "inspect", verb: "Listed projects" },
+  list_machines: { family: "inspect", verb: "Listed machines" },
+  list_live_threads: { family: "inspect", verb: "Listed live threads" },
+  list_threads: { family: "inspect", verb: "Listed threads" },
+  search_threads: { family: "inspect", verb: "Searched threads" },
+  read_thread: { family: "inspect", verb: "Read a thread" },
+  focus_thread: { family: "navigate", verb: "Focused a thread" },
+  set_pane: { family: "navigate", verb: "Changed the layout" },
+  show_diff: { family: "navigate", verb: "Opened a diff" },
+  send_to_thread: { family: "mutate", verb: "Sent a message" },
+  start_thread: { family: "mutate", verb: "Started a thread" },
+  stop_thread: { family: "mutate", verb: "Stopped a thread" },
+  archive_thread: { family: "mutate", verb: "Archived a thread" },
+  rename_thread: { family: "mutate", verb: "Renamed a thread" },
+  update_instructions: { family: "self", verb: "Updated its instructions" },
+  set_composer_text: { family: "compose", verb: "Drafted a message" },
+  append_composer_text: { family: "compose", verb: "Appended to the draft" },
+  run_plugin_command: { family: "plugin", verb: "Ran a plugin command" },
+};
+
+function actionMeta(name: string): { family: ActionFamily; verb: string } {
+  return ACTIONS[name] ?? { family: "other", verb: name.replace(/[._]/g, " ").replace(/^\w/, (c) => c.toUpperCase()) };
+}
+
+/** The most salient argument to show inline next to the verb, if any. */
+function actionObject(name: string, args: Record<string, unknown>): string {
+  const str = (value: unknown): string => (typeof value === "string" ? value : "");
+  const clip = (text: string, max = 64): string => (text.length > max ? `${text.slice(0, max)}…` : text);
+  if (name === "run_plugin_command") {
+    const argv = Array.isArray(args.argv) ? (args.argv as unknown[]).map(String).join(" ") : "";
+    return clip([str(args.plugin_id), argv].filter(Boolean).join(" "));
   }
+  return clip(str(args.query) || str(args.title) || str(args.message) || str(args.text) || str(args.prompt) || str(args.action));
+}
+
+function ActionGlyph({ family }: { family: ActionFamily }) {
+  const cls = "size-3";
+  switch (family) {
+    case "inspect":
+      return <svg viewBox="0 0 16 16" className={cls} fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden><circle cx="7" cy="7" r="4" /><path d="M13 13l-3-3" /></svg>;
+    case "navigate":
+      return <svg viewBox="0 0 16 16" className={cls} fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden><circle cx="8" cy="8" r="5.5" /><circle cx="8" cy="8" r="1.4" fill="currentColor" stroke="none" /></svg>;
+    case "mutate":
+      return <svg viewBox="0 0 16 16" className={cls} fill="currentColor" aria-hidden><path d="M8.7 1L3 9h4l-1.3 6L13 6.5H8.6z" /></svg>;
+    case "compose":
+      return <svg viewBox="0 0 16 16" className={cls} fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden><path d="M11 2.4l2.6 2.6L6 12.6l-3.2.6.6-3.2z" /></svg>;
+    case "self":
+      return <svg viewBox="0 0 16 16" className={cls} fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden><circle cx="8" cy="8" r="2.1" /><circle cx="8" cy="8" r="5.5" /></svg>;
+    case "plugin":
+      return <svg viewBox="0 0 16 16" className={cls} fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round" aria-hidden><path d="M6.2 2.5h3.6v1.6a1.4 1.4 0 002.8 0V4h1.4v3.4h-1.6a1.4 1.4 0 000 2.8h1.6V13H2.4V9.9H4a1.4 1.4 0 000-2.8H2.4V2.5z" /></svg>;
+    default:
+      return <svg viewBox="0 0 16 16" className={cls} fill="currentColor" aria-hidden><circle cx="8" cy="8" r="2.4" /></svg>;
+  }
+}
+
+function Chevron() {
+  return (
+    <svg viewBox="0 0 16 16" className="ml-auto size-3 shrink-0 text-muted-foreground/40 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M6 4l4 4-4 4" />
+    </svg>
+  );
+}
+
+type Row =
+  | { kind: "speech"; id: number; ts: number; who: "you" | "aide"; text: string }
+  | { kind: "action"; id: number; ts: number; name: string; args: Record<string, unknown>; output: string | null }
+  | { kind: "notice"; id: number; ts: number; text: string }
+  | { kind: "error"; id: number; ts: number; message: string }
+  | { kind: "system"; id: number; ts: number; label: string };
+
+/** Fold the raw event log into display rows, pairing each tool.call with its result. */
+function buildRows(events: EventRow[]): Row[] {
+  const rows: Row[] = [];
+  const consumed = new Set<number>();
+  events.forEach((event, index) => {
+    const payload = parsePayload(event.payload);
+    switch (event.kind) {
+      case "user":
+      case "assistant":
+        rows.push({ kind: "speech", id: event.id, ts: event.ts, who: event.kind === "user" ? "you" : "aide", text: String(payload.text ?? "") });
+        break;
+      case "tool.call": {
+        const name = String(payload.name ?? "?");
+        let output: string | null = null;
+        for (let j = index + 1; j < events.length; j++) {
+          const later = events[j];
+          if (later.kind !== "tool.result" || consumed.has(later.id)) continue;
+          const lp = parsePayload(later.payload);
+          if (String(lp.name ?? "?") === name) {
+            output = String(lp.output ?? "");
+            consumed.add(later.id);
+            break;
+          }
+        }
+        rows.push({ kind: "action", id: event.id, ts: event.ts, name, args: (payload.args as Record<string, unknown>) ?? {}, output });
+        break;
+      }
+      case "tool.result":
+        if (consumed.has(event.id)) break; // already merged into its call
+        rows.push({ kind: "action", id: event.id, ts: event.ts, name: String(payload.name ?? "?"), args: {}, output: String(payload.output ?? "") });
+        break;
+      case "notice":
+        rows.push({ kind: "notice", id: event.id, ts: event.ts, text: String(payload.text ?? "") });
+        break;
+      case "error":
+        rows.push({ kind: "error", id: event.id, ts: event.ts, message: String(payload.message ?? "error") });
+        break;
+      default:
+        rows.push({ kind: "system", id: event.id, ts: event.ts, label: event.kind.replace("session.", "session ") });
+    }
+  });
+  return rows;
+}
+
+function SpeechRow({ row }: { row: Extract<Row, { kind: "speech" }> }) {
+  const you = row.who === "you";
+  return (
+    <div className={cn("flex gap-2.5 rounded-md border-l-2 py-1.5 pl-2.5 pr-2", you ? "border-l-border bg-muted/40" : "border-l-primary/50 bg-primary/[0.06]")}>
+      <span className={cn("mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full", you ? "bg-muted text-muted-foreground" : "bg-primary/15 text-primary")}>
+        <span className="scale-75">{you ? <MicIcon slashed={false} /> : <WaveformIcon live={false} />}</span>
+      </span>
+      <div className="min-w-0 flex-1">
+        <span className="flex items-baseline gap-2">
+          <span className={cn("text-xs font-semibold", you ? "text-foreground" : "text-primary")}>{you ? "You" : "Aide"}</span>
+          <span className="text-[10px] tabular-nums text-muted-foreground/50">{fmtTime(row.ts)}</span>
+        </span>
+        <p className="whitespace-pre-wrap text-sm text-foreground/90">{row.text}</p>
+      </div>
+    </div>
+  );
+}
+
+function ActionRow({ row }: { row: Extract<Row, { kind: "action" }> }) {
+  const meta = actionMeta(row.name);
+  const object = actionObject(row.name, row.args);
+  const pending = row.output === null;
+  const isError = !pending && /^tool error/i.test(row.output ?? "");
+  const hasArgs = Object.keys(row.args).length > 0;
+  return (
+    <details className="group pl-2.5">
+      <summary className="flex cursor-pointer list-none items-center gap-2 py-1 text-xs">
+        <span className={cn("flex size-5 shrink-0 items-center justify-center rounded-md", isError ? "bg-destructive/15 text-destructive" : "bg-muted text-muted-foreground")}>
+          <ActionGlyph family={meta.family} />
+        </span>
+        <span className={cn("shrink-0 font-medium", isError ? "text-destructive" : "text-foreground/80")}>{meta.verb}</span>
+        {object ? <span className="truncate text-muted-foreground">· {object}</span> : null}
+        {pending ? <span className="size-1.5 shrink-0 animate-pulse rounded-full bg-primary" /> : null}
+        <Chevron />
+      </summary>
+      <div className="mb-1 mt-1 space-y-1 pl-7">
+        {hasArgs ? (
+          <pre className="overflow-x-auto whitespace-pre-wrap rounded bg-muted p-2 font-mono text-[11px] text-muted-foreground">{JSON.stringify(row.args, null, 2)}</pre>
+        ) : null}
+        {row.output ? (
+          <pre className="overflow-x-auto whitespace-pre-wrap rounded bg-muted p-2 font-mono text-[11px] text-foreground/80">{row.output}</pre>
+        ) : (
+          <p className="text-[11px] italic text-muted-foreground">Waiting for result…</p>
+        )}
+      </div>
+    </details>
+  );
+}
+
+function NoticeRow({ row }: { row: Extract<Row, { kind: "notice" }> }) {
+  return (
+    <p className="px-2 py-1 text-center text-xs italic text-muted-foreground/80">🔔 {row.text}</p>
+  );
+}
+
+function ErrorRow({ row }: { row: Extract<Row, { kind: "error" }> }) {
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-2.5 py-1.5">
+      <span className="mt-px text-xs text-destructive">⚠</span>
+      <span className="text-sm text-destructive">{row.message}</span>
+    </div>
+  );
+}
+
+function SystemRow({ row }: { row: Extract<Row, { kind: "system" }> }) {
+  return <p className="px-2 py-0.5 text-center text-[11px] italic text-muted-foreground/50">{row.label}</p>;
+}
+
+function TranscriptBody({ events }: { events: EventRow[] }) {
+  const rows = buildRows(events);
+  return (
+    <div className="space-y-1 py-1.5">
+      {rows.map((row) => {
+        switch (row.kind) {
+          case "speech":
+            return <SpeechRow key={row.id} row={row} />;
+          case "action":
+            return <ActionRow key={row.id} row={row} />;
+          case "notice":
+            return <NoticeRow key={row.id} row={row} />;
+          case "error":
+            return <ErrorRow key={row.id} row={row} />;
+          default:
+            return <SystemRow key={row.id} row={row} />;
+        }
+      })}
+    </div>
+  );
 }
 
 /**
@@ -440,11 +583,11 @@ export function SessionsPanel() {
                 </span>
               ) : null}
             </div>
-            <div className="divide-y divide-border/50 rounded-lg border border-border bg-card px-3 py-1">
+            <div className="rounded-lg border border-border bg-card px-2 py-1">
               {events.length === 0 ? (
-                <p className="py-3 text-sm text-muted-foreground">No events.</p>
+                <p className="py-3 text-center text-sm text-muted-foreground">No events yet.</p>
               ) : (
-                events.map((event) => <EventLine key={event.id} event={event} />)
+                <TranscriptBody events={events} />
               )}
             </div>
           </>

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -99,6 +99,7 @@ function GearIcon() {
 function CallConsole({ onViewTranscript, selectedId }: { onViewTranscript: (sessionId: string) => void; selectedId: string | null }) {
   const state = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
   const activity = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getActivity);
+  const micSuspended = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getMicSuspended);
   const lastActivity = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getLastActivity);
   const elapsed = useCallElapsed();
   const live = state === "live";
@@ -126,18 +127,22 @@ function CallConsole({ onViewTranscript, selectedId }: { onViewTranscript: (sess
 
   const speaking = activity === "aide";
   const listening = activity === "you";
-  const activityColor = speaking
-    ? "text-[color:var(--success,#6faf76)]" // Aide
-    : listening
-      ? "text-foreground" // you
-      : "text-muted-foreground/70";
-  const label = speaking
-    ? "Aide speaking…"
-    : listening
-      ? "Listening…"
-      : muted
-        ? "Muted"
-        : "Connected";
+  const activityColor = micSuspended
+    ? "text-destructive" // uplink down (iOS backgrounded the mic)
+    : speaking
+      ? "text-[color:var(--success,#6faf76)]" // Aide
+      : listening
+        ? "text-foreground" // you
+        : "text-muted-foreground/70";
+  const label = micSuspended
+    ? "Mic paused"
+    : speaking
+      ? "Aide speaking…"
+      : listening
+        ? "Listening…"
+        : muted
+          ? "Muted"
+          : "Connected";
   const liveId = voiceAgent.getSessionId();
   const ticker = tickerFor(lastActivity);
   // When you're already reading the live transcript, the ticker (and the pill's

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -5,7 +5,12 @@
 // starts/controls the call right here, so you never route through the composer
 // (which collapses on mobile) or switch sidebars to talk.
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
-import { useRealtime, useRpc } from "@get-bb/plugin-sdk/app";
+import {
+  experimental_useSidebarThreadActions,
+  useBbContext,
+  useRealtime,
+  useRpc,
+} from "@get-bb/plugin-sdk/app";
 import type { rpcContract } from "./server";
 import { voiceAgent } from "./voice-agent";
 import { MicIcon, StopIcon, WaveformIcon, useCallElapsed } from "./voice-chrome";
@@ -83,15 +88,17 @@ function TranscriptIcon() {
 }
 
 /**
- * The call console — a bottom-center floating control that owns the entire call
+ * The call console — a bottom-center control that owns the entire call
  * lifecycle right on the Handsfree page. Idle: a "Talk to Aide" pill. Live: it
  * expands into a console (mute · who-has-the-floor + duration · jump to the live
  * transcript · stop). Same neutral-chrome + activity-color language as the
  * composer pill; color marks who's speaking, everything else stays neutral.
- * Positioned bottom-center so it's thumb-reachable on mobile and never depends
- * on the composer being open.
+ *
+ * Rendered as a real element in a footer bar (not `position: fixed`) so it
+ * reserves its own space — nothing overlaps — and stays inside the plugin's own
+ * pointer/stacking context, which is what makes it reliably tappable on mobile.
  */
-function CallFab({ onViewTranscript }: { onViewTranscript: (sessionId: string) => void }) {
+function CallConsole({ onViewTranscript }: { onViewTranscript: (sessionId: string) => void }) {
   const state = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
   const activity = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getActivity);
   const elapsed = useCallElapsed();
@@ -102,21 +109,19 @@ function CallFab({ onViewTranscript }: { onViewTranscript: (sessionId: string) =
 
   if (!active) {
     return (
-      <div className="pointer-events-none fixed inset-x-0 bottom-6 z-40 flex justify-center px-4">
-        <button
-          type="button"
-          aria-label="Start Aide voice agent"
-          title="Talk to Aide"
-          onClick={() => voiceAgent.toggle()}
-          className={cn(
-            "pointer-events-auto flex h-11 items-center gap-2 rounded-full border border-border bg-card px-5 text-sm font-medium text-foreground shadow-lg transition-colors hover:bg-accent",
-            connecting && "animate-pulse",
-          )}
-        >
-          <WaveformIcon live={false} />
-          {connecting ? "Connecting…" : "Talk to Aide"}
-        </button>
-      </div>
+      <button
+        type="button"
+        aria-label="Start Aide voice agent"
+        title="Talk to Aide"
+        onClick={() => voiceAgent.toggle()}
+        className={cn(
+          "flex h-11 items-center gap-2 rounded-full border border-border bg-card px-5 text-sm font-medium text-foreground shadow-lg transition-colors hover:bg-accent",
+          connecting && "animate-pulse",
+        )}
+      >
+        <WaveformIcon live={false} />
+        {connecting ? "Connecting…" : "Talk to Aide"}
+      </button>
     );
   }
 
@@ -137,9 +142,8 @@ function CallFab({ onViewTranscript }: { onViewTranscript: (sessionId: string) =
   const liveId = voiceAgent.getSessionId();
 
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-6 z-40 flex justify-center px-4">
-      <div className="pointer-events-auto flex h-11 max-w-full items-center overflow-hidden rounded-full border border-border bg-card shadow-lg">
-        <button
+    <div className="flex h-11 max-w-full items-center overflow-hidden rounded-full border border-border bg-card shadow-lg">
+      <button
           type="button"
           aria-label={muted ? "Unmute Aide microphone" : "Mute Aide microphone"}
           title={muted ? "Unmute" : "Mute"}
@@ -187,7 +191,6 @@ function CallFab({ onViewTranscript }: { onViewTranscript: (sessionId: string) =
           <StopIcon />
         </button>
       </div>
-    </div>
   );
 }
 
@@ -294,7 +297,29 @@ function useEscapeToClose() {
 
 export function SessionsPanel() {
   const rpc = useRpc<typeof rpcContract>();
+  const { threadId, projectId } = useBbContext();
+  const sidebarActions = experimental_useSidebarThreadActions();
   useEscapeToClose();
+
+  // The Handsfree page has no composer, so nothing else binds the voice agent
+  // here. Install a fallback binding so the FAB can actually start a call from a
+  // cold page — but only when nothing richer is already bound (a live composer's
+  // binding, which its text tools target, must win). We deliberately bind no
+  // composer: with nothing to type into, the text tools report that honestly
+  // (see handleToolCall) rather than silently opening a thread behind the user's
+  // back. Everything else (thread focus, starting work, diffs) runs through rpc,
+  // which works from anywhere.
+  useEffect(() => {
+    voiceAgent.bindFallback({
+      rpc,
+      context: { threadId: threadId ?? null, projectId: projectId ?? null, onNewThreadScreen: false },
+      openNewThread: (targetProjectId) =>
+        sidebarActions.openNewThread({
+          ...(targetProjectId ? { projectId: targetProjectId } : {}),
+          focusPrompt: true,
+        }),
+    });
+  }, [rpc, threadId, projectId, sidebarActions]);
   const [sessions, setSessions] = useState<SessionRow[] | null>(null);
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -393,7 +418,8 @@ export function SessionsPanel() {
   const current = sessions?.find((session) => session.id === selected) ?? null;
 
   return (
-    <div ref={scrollRef} className="h-full overflow-y-auto p-4 pb-24 md:p-5 md:pb-24">
+    <div className="flex h-full flex-col">
+      <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 md:p-5">
       <div className="mx-auto w-full max-w-3xl space-y-4">
         {error ? <p className="text-sm text-destructive">{error}</p> : null}
         {selected ? (
@@ -482,7 +508,12 @@ export function SessionsPanel() {
           </>
         )}
       </div>
-      <CallFab onViewTranscript={(sessionId) => setSelected(sessionId)} />
+      </div>
+      <div className="shrink-0 border-t border-border/60 bg-background/90 px-4 py-3 backdrop-blur">
+        <div className="mx-auto flex w-full max-w-3xl justify-center">
+          <CallConsole onViewTranscript={(sessionId) => setSelected(sessionId)} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -706,6 +706,12 @@ export function SessionsPanel() {
   // reflects it, and relay stop/mute from the console back to the owning realm.
   useRealtime("voice-presence", (payload) => voiceAgent.ingestPresence(payload));
   useRealtime("voice-command", (payload) => voiceAgent.applyVoiceCommand(payload));
+  useRealtime("voice-presence-query", () => voiceAgent.answerPresenceQuery());
+
+  // Catch up the moment the page mounts (e.g. a realm rebuilt after navigating
+  // back) instead of waiting up to a heartbeat — this is the "shows Talk to Aide
+  // over a live call, then flips to Connected a few seconds later" gap.
+  useEffect(() => voiceAgent.requestPresence(), []);
 
   // Auto-follow the transcript: after opening it, or when new events land while
   // you're already reading the bottom, snap to the latest — but if you've

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -23,12 +23,19 @@ interface SessionRow {
   events: number;
   ended: boolean;
   costUsd: number;
+  preview: string;
+  hasError: boolean;
 }
 interface EventRow {
   id: number;
   ts: number;
   kind: string;
   payload: string;
+}
+interface PluginMeta {
+  id: string;
+  name: string;
+  iconUrl: string | null;
 }
 
 function fmtTime(ts: number): string {
@@ -78,15 +85,6 @@ function GearIcon() {
   );
 }
 
-/** Stacked lines — the jump-to-transcript affordance on the live console. */
-function TranscriptIcon() {
-  return (
-    <svg viewBox="0 0 16 16" className="size-3.5" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" aria-hidden>
-      <path d="M3 4h10M3 8h10M3 12h6" />
-    </svg>
-  );
-}
-
 /**
  * The call console — a bottom-center control that owns the entire call
  * lifecycle right on the Handsfree page. Idle: a "Talk to Aide" pill. Live: it
@@ -98,9 +96,10 @@ function TranscriptIcon() {
  * reserves its own space — nothing overlaps — and stays inside the plugin's own
  * pointer/stacking context, which is what makes it reliably tappable on mobile.
  */
-function CallConsole({ onViewTranscript }: { onViewTranscript: (sessionId: string) => void }) {
+function CallConsole({ onViewTranscript, selectedId }: { onViewTranscript: (sessionId: string) => void; selectedId: string | null }) {
   const state = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
   const activity = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getActivity);
+  const lastActivity = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getLastActivity);
   const elapsed = useCallElapsed();
   const live = state === "live";
   const muted = state === "muted";
@@ -140,9 +139,32 @@ function CallConsole({ onViewTranscript }: { onViewTranscript: (sessionId: strin
         ? "Muted"
         : "Connected";
   const liveId = voiceAgent.getSessionId();
+  const ticker = tickerFor(lastActivity);
+  // When you're already reading the live transcript, the ticker (and the pill's
+  // transcript button) are redundant with what's on screen — hide them.
+  const viewingLive = liveId != null && selectedId === liveId;
 
   return (
-    <div className="flex h-11 max-w-full items-center overflow-hidden rounded-full border border-border bg-card shadow-lg">
+    <div className="flex w-full flex-col items-center gap-1.5">
+      {liveId && !viewingLive ? (
+        <button
+          type="button"
+          onClick={() => onViewTranscript(liveId)}
+          className="flex max-w-full items-center gap-1.5 rounded-full bg-card/70 px-3 py-1 text-xs text-muted-foreground shadow-sm backdrop-blur transition-colors hover:text-foreground"
+          title="See full transcript"
+        >
+          {ticker?.family ? (
+            <span className="flex size-4 shrink-0 items-center justify-center text-muted-foreground/80">
+              <ActionGlyph family={ticker.family} />
+            </span>
+          ) : null}
+          <span className="truncate">{ticker?.text ?? "See full transcript"}</span>
+          <svg viewBox="0 0 16 16" className="size-3 shrink-0 text-muted-foreground/50" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <path d="M6 4l4 4-4 4" />
+          </svg>
+        </button>
+      ) : null}
+      <div className="flex h-11 max-w-full items-center overflow-hidden rounded-full border border-border bg-card shadow-lg">
       <button
           type="button"
           aria-label={muted ? "Unmute Aide microphone" : "Mute Aide microphone"}
@@ -165,21 +187,6 @@ function CallConsole({ onViewTranscript }: { onViewTranscript: (sessionId: strin
           <span className="truncate text-sm text-foreground">{label}</span>
           <span className="shrink-0 tabular-nums text-xs text-muted-foreground">{elapsed ?? ""}</span>
         </span>
-        {liveId ? (
-          <>
-            <span className="h-5 w-px bg-border" />
-            <button
-              type="button"
-              onClick={() => onViewTranscript(liveId)}
-              title="View live transcript"
-              aria-label="View live transcript"
-              className="flex h-11 shrink-0 items-center gap-1.5 px-3 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-            >
-              <TranscriptIcon />
-              <span className="hidden sm:inline">Transcript</span>
-            </button>
-          </>
-        ) : null}
         <span className="h-5 w-px bg-border" />
         <button
           type="button"
@@ -191,6 +198,7 @@ function CallConsole({ onViewTranscript }: { onViewTranscript: (sessionId: strin
           <StopIcon />
         </button>
       </div>
+    </div>
   );
 }
 
@@ -228,6 +236,23 @@ const ACTIONS: Record<string, { family: ActionFamily; verb: string }> = {
 
 function actionMeta(name: string): { family: ActionFamily; verb: string } {
   return ACTIONS[name] ?? { family: "other", verb: name.replace(/[._]/g, " ").replace(/^\w/, (c) => c.toUpperCase()) };
+}
+
+/**
+ * Human label for the dock's activity ticker from the agent's last event: a
+ * tool call shows its verb (with the family glyph); speech/notice show a short
+ * quote (no glyph). Returns null when there's nothing worth showing yet.
+ */
+function tickerFor(last: { kind: string; name: string; text: string } | null): { family: ActionFamily | null; text: string } | null {
+  if (!last) return null;
+  if (last.kind === "tool.call") {
+    const meta = actionMeta(last.name);
+    return { family: meta.family, text: meta.verb };
+  }
+  const text = last.text.trim();
+  if (!text) return null;
+  const clipped = text.length > 80 ? `${text.slice(0, 80)}…` : text;
+  return { family: null, text: last.kind === "assistant" ? `“${clipped}”` : clipped };
 }
 
 /** The most salient argument to show inline next to the verb, if any. */
@@ -274,13 +299,31 @@ type Row =
   | { kind: "action"; id: number; ts: number; name: string; args: Record<string, unknown>; output: string | null }
   | { kind: "notice"; id: number; ts: number; text: string }
   | { kind: "error"; id: number; ts: number; message: string }
-  | { kind: "system"; id: number; ts: number; label: string };
+  | { kind: "sysgroup"; id: number; ts: number; events: EventRow[] };
 
-/** Fold the raw event log into display rows, pairing each tool.call with its result. */
+const CONVERSATION_KINDS = new Set(["user", "assistant", "tool.call", "tool.result", "notice", "error"]);
+
+/**
+ * Fold the raw event log into display rows: pair each tool.call with its result,
+ * and coalesce runs of low-level diagnostics (session.*, conn.*, audio.*) into a
+ * single collapsible "session connected"-style group so they don't bury the
+ * conversation. The full detail stays one tap away inside the group.
+ */
 function buildRows(events: EventRow[]): Row[] {
   const rows: Row[] = [];
   const consumed = new Set<number>();
+  let diagnostics: EventRow[] = [];
+  const flush = () => {
+    if (diagnostics.length === 0) return;
+    rows.push({ kind: "sysgroup", id: diagnostics[0].id, ts: diagnostics[0].ts, events: diagnostics });
+    diagnostics = [];
+  };
   events.forEach((event, index) => {
+    if (!CONVERSATION_KINDS.has(event.kind)) {
+      diagnostics.push(event);
+      return;
+    }
+    flush();
     const payload = parsePayload(event.payload);
     switch (event.kind) {
       case "user":
@@ -313,11 +356,19 @@ function buildRows(events: EventRow[]): Row[] {
       case "error":
         rows.push({ kind: "error", id: event.id, ts: event.ts, message: String(payload.message ?? "error") });
         break;
-      default:
-        rows.push({ kind: "system", id: event.id, ts: event.ts, label: event.kind.replace("session.", "session ") });
     }
   });
+  flush();
   return rows;
+}
+
+/** Human label for a diagnostics group, from the lifecycle events it contains. */
+function sysGroupLabel(events: EventRow[]): string {
+  const kinds = new Set(events.map((event) => event.kind));
+  if (kinds.has("session.stopped")) return "Session ended";
+  if (kinds.has("session.live")) return "Session connected";
+  if (kinds.has("session.started")) return "Session connecting";
+  return "Session activity";
 }
 
 function SpeechRow({ row }: { row: Extract<Row, { kind: "speech" }> }) {
@@ -338,29 +389,52 @@ function SpeechRow({ row }: { row: Extract<Row, { kind: "speech" }> }) {
   );
 }
 
-function ActionRow({ row }: { row: Extract<Row, { kind: "action" }> }) {
+function ActionRow({ row, plugins }: { row: Extract<Row, { kind: "action" }>; plugins: Map<string, PluginMeta> }) {
   const meta = actionMeta(row.name);
-  const object = actionObject(row.name, row.args);
   const pending = row.output === null;
   const isError = !pending && /^tool error/i.test(row.output ?? "");
   const hasArgs = Object.keys(row.args).length > 0;
+
+  // run_plugin_command reads as "Used plugin [chip]": the left square keeps the
+  // generic plugin glyph (consistent with every action row), and the plugin's
+  // real name + icon (from listPlugins) ride in a chip next to it.
+  const isPlugin = row.name === "run_plugin_command";
+  let verb = meta.verb;
+  let object = actionObject(row.name, row.args);
+  let pluginName = "";
+  let pluginIcon: string | null = null;
+  if (isPlugin) {
+    const pluginId = typeof row.args.plugin_id === "string" ? row.args.plugin_id : "";
+    const plugin = plugins.get(pluginId);
+    verb = "Used plugin";
+    pluginName = plugin?.name ?? pluginId;
+    pluginIcon = plugin?.iconUrl ?? null;
+    object = Array.isArray(row.args.argv) ? (row.args.argv as unknown[]).map(String).join(" ") : "";
+  }
+
   return (
-    <details className="group pl-2.5">
-      <summary className="flex cursor-pointer list-none items-center gap-2 py-1 text-xs">
+    <details className="group min-w-0 pl-2.5">
+      <summary className="flex min-w-0 cursor-pointer list-none items-center gap-2 py-1 text-xs">
         <span className={cn("flex size-5 shrink-0 items-center justify-center rounded-md", isError ? "bg-destructive/15 text-destructive" : "bg-muted text-muted-foreground")}>
           <ActionGlyph family={meta.family} />
         </span>
-        <span className={cn("shrink-0 font-medium", isError ? "text-destructive" : "text-foreground/80")}>{meta.verb}</span>
-        {object ? <span className="truncate text-muted-foreground">· {object}</span> : null}
+        <span className={cn("shrink-0 font-medium", isError ? "text-destructive" : "text-foreground/80")}>{verb}</span>
+        {isPlugin && pluginName ? (
+          <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted px-1.5 py-px text-[11px] font-medium text-foreground/80">
+            {pluginIcon ? <img src={pluginIcon} alt="" className="size-3 rounded-[3px] object-contain" /> : null}
+            {pluginName}
+          </span>
+        ) : null}
+        {object ? <span className="min-w-0 truncate text-muted-foreground">· {object}</span> : null}
         {pending ? <span className="size-1.5 shrink-0 animate-pulse rounded-full bg-primary" /> : null}
         <Chevron />
       </summary>
       <div className="mb-1 mt-1 space-y-1 pl-7">
         {hasArgs ? (
-          <pre className="overflow-x-auto whitespace-pre-wrap rounded bg-muted p-2 font-mono text-[11px] text-muted-foreground">{JSON.stringify(row.args, null, 2)}</pre>
+          <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded bg-muted p-2 font-mono text-[11px] text-muted-foreground">{JSON.stringify(row.args, null, 2)}</pre>
         ) : null}
         {row.output ? (
-          <pre className="overflow-x-auto whitespace-pre-wrap rounded bg-muted p-2 font-mono text-[11px] text-foreground/80">{row.output}</pre>
+          <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded bg-muted p-2 font-mono text-[11px] text-foreground/80">{row.output}</pre>
         ) : (
           <p className="text-[11px] italic text-muted-foreground">Waiting for result…</p>
         )}
@@ -384,12 +458,80 @@ function ErrorRow({ row }: { row: Extract<Row, { kind: "error" }> }) {
   );
 }
 
-function SystemRow({ row }: { row: Extract<Row, { kind: "system" }> }) {
-  return <p className="px-2 py-0.5 text-center text-[11px] italic text-muted-foreground/50">{row.label}</p>;
+function SysGroupRow({ row }: { row: Extract<Row, { kind: "sysgroup" }> }) {
+  const label = sysGroupLabel(row.events);
+  return (
+    <details className="group min-w-0">
+      <summary className="mx-auto flex w-fit cursor-pointer list-none items-center justify-center gap-1.5 py-0.5 text-[11px] text-muted-foreground/60 hover:text-muted-foreground">
+        <span className="size-1.5 rounded-full bg-muted-foreground/40" />
+        {label}
+        <span className="text-muted-foreground/40">· {row.events.length}</span>
+        <Chevron />
+      </summary>
+      <div className="mt-1 space-y-1 rounded-md bg-muted/40 p-2">
+        {row.events.map((event) => {
+          const payload = event.payload && event.payload !== "{}" ? event.payload : "";
+          return (
+            <div key={event.id} className="min-w-0 font-mono text-[10px] leading-relaxed text-muted-foreground">
+              <span className="mr-2 tabular-nums text-muted-foreground/50">{fmtTime(event.ts)}</span>
+              <span className="text-foreground/70">{event.kind}</span>
+              {payload ? <span className="break-all"> {payload}</span> : null}
+            </div>
+          );
+        })}
+      </div>
+    </details>
+  );
 }
 
-function TranscriptBody({ events }: { events: EventRow[] }) {
-  const rows = buildRows(events);
+type TranscriptFilter = "all" | "talk" | "actions" | "errors";
+
+const FILTERS: { id: TranscriptFilter; label: string }[] = [
+  { id: "all", label: "All" },
+  { id: "talk", label: "Conversation" },
+  { id: "actions", label: "Actions" },
+  { id: "errors", label: "Errors" },
+];
+
+function rowMatchesFilter(row: Row, filter: TranscriptFilter): boolean {
+  const actionErrored = row.kind === "action" && row.output !== null && /^tool error/i.test(row.output);
+  switch (filter) {
+    case "talk":
+      return row.kind === "speech" || row.kind === "notice";
+    case "actions":
+      return row.kind === "action";
+    case "errors":
+      return row.kind === "error" || actionErrored;
+    default:
+      return true;
+  }
+}
+
+function FilterBar({ value, onChange }: { value: TranscriptFilter; onChange: (next: TranscriptFilter) => void }) {
+  return (
+    <div className="flex items-center gap-1 rounded-md border border-border bg-card p-0.5">
+      {FILTERS.map((filter) => (
+        <button
+          key={filter.id}
+          type="button"
+          onClick={() => onChange(filter.id)}
+          className={cn(
+            "rounded px-2 py-0.5 text-xs transition-colors",
+            value === filter.id ? "bg-accent font-medium text-foreground" : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          {filter.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function TranscriptBody({ events, plugins, filter }: { events: EventRow[]; plugins: Map<string, PluginMeta>; filter: TranscriptFilter }) {
+  const rows = buildRows(events).filter((row) => rowMatchesFilter(row, filter));
+  if (rows.length === 0) {
+    return <p className="py-3 text-center text-sm text-muted-foreground">Nothing matches this filter.</p>;
+  }
   return (
     <div className="space-y-1 py-1.5">
       {rows.map((row) => {
@@ -397,13 +539,13 @@ function TranscriptBody({ events }: { events: EventRow[] }) {
           case "speech":
             return <SpeechRow key={row.id} row={row} />;
           case "action":
-            return <ActionRow key={row.id} row={row} />;
+            return <ActionRow key={row.id} row={row} plugins={plugins} />;
           case "notice":
             return <NoticeRow key={row.id} row={row} />;
           case "error":
             return <ErrorRow key={row.id} row={row} />;
           default:
-            return <SystemRow key={row.id} row={row} />;
+            return <SysGroupRow key={row.id} row={row} />;
         }
       })}
     </div>
@@ -468,6 +610,10 @@ export function SessionsPanel() {
   const [loadingMore, setLoadingMore] = useState(false);
   const [selected, setSelected] = useState<string | null>(null);
   const [events, setEvents] = useState<EventRow[]>([]);
+  const [filter, setFilter] = useState<TranscriptFilter>("all");
+  const [search, setSearch] = useState("");
+  const [errorsOnly, setErrorsOnly] = useState(false);
+  const [plugins, setPlugins] = useState<Map<string, PluginMeta>>(() => new Map());
   const [error, setError] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   // Set when the transcript is opened so the first batch of events snaps to the
@@ -531,6 +677,14 @@ export function SessionsPanel() {
   useEffect(() => {
     refreshNewest();
   }, [refreshNewest]);
+  // Plugin metadata (id → name + icon) to narrate run_plugin_command; static
+  // enough to fetch once.
+  useEffect(() => {
+    rpc.call("listPlugins", null).then(
+      (result) => setPlugins(new Map(result.plugins.map((plugin) => [plugin.id, plugin]))),
+      () => undefined,
+    );
+  }, [rpc]);
   useEffect(() => {
     if (selected) {
       pendingBottom.current = true;
@@ -559,42 +713,73 @@ export function SessionsPanel() {
   }, [events, selected]);
 
   const current = sessions?.find((session) => session.id === selected) ?? null;
+  const query = search.trim().toLowerCase();
+  // Client-side filter over already-loaded sessions (Load more fetches the rest).
+  const visibleSessions = sessions?.filter(
+    (session) =>
+      (!errorsOnly || session.hasError) &&
+      (!query || session.preview.toLowerCase().includes(query) || fmtDate(session.startedAt).toLowerCase().includes(query)),
+  );
 
   return (
     <div className="flex h-full flex-col">
-      <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 md:p-5">
-      <div className="mx-auto w-full max-w-3xl space-y-4">
+      <div ref={scrollRef} className="flex-1 overflow-y-auto overflow-x-hidden p-4 md:p-5">
+      <div className="mx-auto w-full min-w-0 max-w-3xl space-y-4">
         {error ? <p className="text-sm text-destructive">{error}</p> : null}
         {selected ? (
           <>
-            <div className="flex items-center gap-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
               <button
                 type="button"
                 onClick={() => setSelected(null)}
-                className="rounded border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+                className="flex shrink-0 items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
               >
                 ← All sessions
               </button>
+              <FilterBar value={filter} onChange={setFilter} />
+            </div>
+            <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 rounded-lg border border-border bg-card px-3.5 py-2.5">
+              <div className="flex items-center gap-2.5">
+                {current && !current.ended ? (
+                  <span className="size-2.5 shrink-0 animate-pulse rounded-full bg-primary" />
+                ) : null}
+                <div className="leading-tight">
+                  <div className="text-sm font-medium text-foreground">
+                    {current ? fmtDate(current.startedAt) : "Live session"}
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    {current ? (current.ended ? "Ended" : "Live now") : "Connecting…"}
+                    {current ? ` · ${duration(current.startedAt, current.lastEventAt)}` : ""}
+                  </div>
+                </div>
+              </div>
               {current ? (
-                <span className="text-sm text-foreground">
-                  {fmtDate(current.startedAt)} · {duration(current.startedAt, current.lastEventAt)} ·{" "}
-                  {current.ended ? "ended" : "live"} ·{" "}
-                  {current.costUsd > 0 ? `~$${current.costUsd.toFixed(4)}` : "no usage recorded"}
-                </span>
+                <div className="flex items-center gap-4 tabular-nums">
+                  <span className="flex flex-col items-end">
+                    <span className="text-sm font-medium text-foreground">{current.events}</span>
+                    <span className="text-[10px] uppercase tracking-wide text-muted-foreground/60">events</span>
+                  </span>
+                  <span className="flex flex-col items-end">
+                    <span className="text-sm font-medium text-foreground">
+                      {current.costUsd > 0 ? `~$${current.costUsd.toFixed(4)}` : "—"}
+                    </span>
+                    <span className="text-[10px] uppercase tracking-wide text-muted-foreground/60">cost</span>
+                  </span>
+                </div>
               ) : null}
             </div>
             <div className="rounded-lg border border-border bg-card px-2 py-1">
               {events.length === 0 ? (
                 <p className="py-3 text-center text-sm text-muted-foreground">No events yet.</p>
               ) : (
-                <TranscriptBody events={events} />
+                <TranscriptBody events={events} plugins={plugins} filter={filter} />
               )}
             </div>
           </>
         ) : (
           <>
             <div className="flex items-center justify-between gap-3">
-              <p className="text-sm text-muted-foreground">Aide Voice Session Transcripts</p>
+              <p className="text-sm font-medium text-foreground">Voice sessions</p>
               <button
                 type="button"
                 onClick={openHandsfreeSettings}
@@ -606,6 +791,29 @@ export function SessionsPanel() {
                 Settings
               </button>
             </div>
+            {sessions && sessions.length > 0 ? (
+              <div className="flex items-center gap-2">
+                <input
+                  type="search"
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                  placeholder="Search sessions…"
+                  className="min-w-0 flex-1 rounded-md border border-border bg-card px-2.5 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                />
+                <button
+                  type="button"
+                  onClick={() => setErrorsOnly((value) => !value)}
+                  className={cn(
+                    "shrink-0 rounded-md border px-2.5 py-1.5 text-xs transition-colors",
+                    errorsOnly
+                      ? "border-destructive/50 bg-destructive/10 text-destructive"
+                      : "border-border text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  Errors
+                </button>
+              </div>
+            ) : null}
             <div className="divide-y divide-border/50 rounded-lg border border-border bg-card">
               {sessions === null ? (
                 <p className="p-3 text-sm text-muted-foreground">Loading…</p>
@@ -613,24 +821,34 @@ export function SessionsPanel() {
                 <p className="p-3 text-sm text-muted-foreground">
                   No sessions yet. Tap “Talk to Aide” below to start your first one.
                 </p>
+              ) : visibleSessions && visibleSessions.length === 0 ? (
+                <p className="p-3 text-sm text-muted-foreground">No sessions match.</p>
               ) : (
-                sessions.map((session) => (
+                visibleSessions?.map((session) => (
                   <button
                     key={session.id}
                     type="button"
                     onClick={() => setSelected(session.id)}
-                    className="flex w-full items-center gap-3 px-3 py-2.5 text-left hover:bg-accent"
+                    className="flex w-full items-start gap-3 px-3 py-2.5 text-left hover:bg-accent"
                   >
-                    <span
-                      className={cn(
-                        "size-2 shrink-0 rounded-full",
-                        session.ended ? "bg-border" : "animate-pulse bg-primary",
-                      )}
-                    />
-                    <span className="flex-1 text-sm text-foreground">{fmtDate(session.startedAt)}</span>
-                    <span className="text-xs tabular-nums text-muted-foreground">
-                      {duration(session.startedAt, session.lastEventAt)} · {session.events} events ·{" "}
-                      {session.costUsd > 0 ? `~$${session.costUsd.toFixed(4)}` : "no usage"}
+                    <span className="mt-1 flex w-12 shrink-0 justify-start">
+                      {!session.ended ? (
+                        <span className="flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-primary">
+                          <span className="size-1.5 animate-pulse rounded-full bg-primary" />
+                          Live
+                        </span>
+                      ) : session.hasError ? (
+                        <span className="text-xs text-destructive" title="This session had an error">⚠</span>
+                      ) : null}
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm text-foreground">
+                        {session.preview || <span className="italic text-muted-foreground">No transcript</span>}
+                      </span>
+                      <span className="mt-0.5 block text-xs tabular-nums text-muted-foreground">
+                        {fmtDate(session.startedAt)} · {duration(session.startedAt, session.lastEventAt)} · {session.events} events
+                        {session.costUsd > 0 ? ` · ~$${session.costUsd.toFixed(4)}` : ""}
+                      </span>
                     </span>
                   </button>
                 ))
@@ -654,7 +872,7 @@ export function SessionsPanel() {
       </div>
       <div className="shrink-0 border-t border-border/60 bg-background/90 px-4 py-3 backdrop-blur">
         <div className="mx-auto flex w-full max-w-3xl justify-center">
-          <CallConsole onViewTranscript={(sessionId) => setSelected(sessionId)} />
+          <CallConsole onViewTranscript={(sessionId) => setSelected(sessionId)} selectedId={selected} />
         </div>
       </div>
     </div>

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -615,6 +615,9 @@ export function SessionsPanel() {
   const [errorsOnly, setErrorsOnly] = useState(false);
   const [plugins, setPlugins] = useState<Map<string, PluginMeta>>(() => new Map());
   const [error, setError] = useState<string | null>(null);
+  // The call active in THIS window always reads live, overriding the server's
+  // stale heuristic (which can't see an active-but-quiet call).
+  const activeSessionId = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getSessionId);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   // Set when the transcript is opened so the first batch of events snaps to the
   // bottom (latest), even if the list is taller than the viewport.
@@ -713,6 +716,7 @@ export function SessionsPanel() {
   }, [events, selected]);
 
   const current = sessions?.find((session) => session.id === selected) ?? null;
+  const isLive = (session: SessionRow): boolean => !session.ended || session.id === activeSessionId;
   const query = search.trim().toLowerCase();
   // Client-side filter over already-loaded sessions (Load more fetches the rest).
   const visibleSessions = sessions?.filter(
@@ -740,7 +744,7 @@ export function SessionsPanel() {
             </div>
             <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 rounded-lg border border-border bg-card px-3.5 py-2.5">
               <div className="flex items-center gap-2.5">
-                {current && !current.ended ? (
+                {current && isLive(current) ? (
                   <span className="size-2.5 shrink-0 animate-pulse rounded-full bg-primary" />
                 ) : null}
                 <div className="leading-tight">
@@ -748,7 +752,7 @@ export function SessionsPanel() {
                     {current ? fmtDate(current.startedAt) : "Live session"}
                   </div>
                   <div className="text-xs text-muted-foreground">
-                    {current ? (current.ended ? "Ended" : "Live now") : "Connecting…"}
+                    {current ? (isLive(current) ? "Live now" : "Ended") : "Connecting…"}
                     {current ? ` · ${duration(current.startedAt, current.lastEventAt)}` : ""}
                   </div>
                 </div>
@@ -832,7 +836,7 @@ export function SessionsPanel() {
                     className="flex w-full items-start gap-3 px-3 py-2.5 text-left hover:bg-accent"
                   >
                     <span className="mt-1 flex w-12 shrink-0 justify-start">
-                      {!session.ended ? (
+                      {isLive(session) ? (
                         <span className="flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-primary">
                           <span className="size-1.5 animate-pulse rounded-full bg-primary" />
                           Live

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -112,7 +112,7 @@ function CallConsole({ onViewTranscript, selectedId }: { onViewTranscript: (sess
         type="button"
         aria-label="Start Aide voice agent"
         title="Talk to Aide"
-        onClick={() => voiceAgent.toggle()}
+        onClick={() => voiceAgent.toggleFromSurface()}
         className={cn(
           "flex h-11 items-center gap-2 rounded-full border border-border bg-card px-5 text-sm font-medium text-foreground shadow-lg transition-colors hover:bg-accent",
           connecting && "animate-pulse",
@@ -169,7 +169,7 @@ function CallConsole({ onViewTranscript, selectedId }: { onViewTranscript: (sess
           type="button"
           aria-label={muted ? "Unmute Aide microphone" : "Mute Aide microphone"}
           title={muted ? "Unmute" : "Mute"}
-          onClick={() => voiceAgent.toggleMute()}
+          onClick={() => voiceAgent.toggleMuteFromSurface()}
           className={cn(
             "flex size-11 shrink-0 items-center justify-center transition-colors",
             muted
@@ -192,7 +192,7 @@ function CallConsole({ onViewTranscript, selectedId }: { onViewTranscript: (sess
           type="button"
           aria-label="Stop Aide voice session"
           title="Stop"
-          onClick={() => voiceAgent.stop()}
+          onClick={() => voiceAgent.stopFromSurface()}
           className="flex size-11 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:bg-destructive/15 hover:text-destructive"
         >
           <StopIcon />
@@ -701,6 +701,11 @@ export function SessionsPanel() {
     const sessionId = (payload as { sessionId?: unknown } | null)?.sessionId;
     if (selected && sessionId === selected) refetchEvents(selected);
   });
+
+  // Cross-surface presence: mirror a call owned by another realm so the console
+  // reflects it, and relay stop/mute from the console back to the owning realm.
+  useRealtime("voice-presence", (payload) => voiceAgent.ingestPresence(payload));
+  useRealtime("voice-command", (payload) => voiceAgent.applyVoiceCommand(payload));
 
   // Auto-follow the transcript: after opening it, or when new events land while
   // you're already reading the bottom, snap to the latest — but if you've

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -833,27 +833,21 @@ export function SessionsPanel() {
                     key={session.id}
                     type="button"
                     onClick={() => setSelected(session.id)}
-                    className="flex w-full items-start gap-3 px-3 py-2.5 text-left hover:bg-accent"
+                    className="flex w-full items-center gap-3 px-3 py-2.5 text-left hover:bg-accent"
                   >
-                    <span className="mt-1 flex w-12 shrink-0 justify-start">
-                      {isLive(session) ? (
-                        <span className="flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-primary">
-                          <span className="size-1.5 animate-pulse rounded-full bg-primary" />
-                          Live
-                        </span>
-                      ) : session.hasError ? (
-                        <span className="text-xs text-destructive" title="This session had an error">⚠</span>
-                      ) : null}
-                    </span>
                     <span className="min-w-0 flex-1">
                       <span className="block truncate text-sm text-foreground">
                         {session.preview || <span className="italic text-muted-foreground">No transcript</span>}
                       </span>
                       <span className="mt-0.5 block text-xs tabular-nums text-muted-foreground">
-                        {fmtDate(session.startedAt)} · {duration(session.startedAt, session.lastEventAt)} · {session.events} events
-                        {session.costUsd > 0 ? ` · ~$${session.costUsd.toFixed(4)}` : ""}
+                        {fmtDate(session.startedAt)} · {duration(session.startedAt, session.lastEventAt)}
                       </span>
                     </span>
+                    {isLive(session) ? (
+                      <span className="size-2 shrink-0 animate-pulse rounded-full bg-primary" title="Live" />
+                    ) : session.hasError ? (
+                      <span className="shrink-0 text-xs text-destructive" title="This session had an error">⚠</span>
+                    ) : null}
                   </button>
                 ))
               )}

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -16,6 +16,13 @@ import { voiceAgent } from "./voice-agent";
 import { MicIcon, StopIcon, WaveformIcon, useCallElapsed } from "./voice-chrome";
 import { cn } from "@/lib/utils";
 
+interface DeviceInfo {
+  label: string;
+  mobile: boolean;
+  platform: string;
+  browser: string;
+  runtime: string;
+}
 interface SessionRow {
   id: string;
   startedAt: number;
@@ -25,6 +32,40 @@ interface SessionRow {
   costUsd: number;
   preview: string;
   hasError: boolean;
+  device: DeviceInfo | null;
+}
+
+/** A phone glyph for mobile clients, a monitor for everything else. */
+function DeviceIcon({ mobile, className }: { mobile: boolean; className?: string }) {
+  return mobile ? (
+    <svg viewBox="0 0 16 16" className={className} fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden>
+      <rect x="4.5" y="1.5" width="7" height="13" rx="1.6" />
+      <path d="M7 12.5h2" strokeLinecap="round" />
+    </svg>
+  ) : (
+    <svg viewBox="0 0 16 16" className={className} fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden>
+      <rect x="1.5" y="2.5" width="13" height="8.5" rx="1.4" />
+      <path d="M6 14h4M8 11v3" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+/** A friendly one-word runtime for the session header. */
+function runtimeLabel(runtime: string): string {
+  return runtime === "electron"
+    ? "desktop app"
+    : runtime === "native-webview"
+      ? "native app"
+      : runtime === "pwa"
+        ? "installed"
+        : runtime === "browser"
+          ? "browser"
+          : runtime;
+}
+
+/** "iOS · Safari · native app" — omits blanks. */
+function deviceDetail(d: DeviceInfo): string {
+  return [d.platform, d.browser, runtimeLabel(d.runtime)].filter(Boolean).join(" · ");
 }
 interface EventRow {
   id: number;
@@ -771,6 +812,12 @@ export function SessionsPanel() {
                     {current ? (isLive(current) ? "Live now" : "Ended") : "Connecting…"}
                     {current ? ` · ${duration(current.startedAt, current.lastEventAt)}` : ""}
                   </div>
+                  {current?.device ? (
+                    <div className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground/80">
+                      <DeviceIcon mobile={current.device.mobile} className="size-3.5 shrink-0" />
+                      <span className="truncate">{deviceDetail(current.device)}</span>
+                    </div>
+                  ) : null}
                 </div>
               </div>
               {current ? (
@@ -859,6 +906,11 @@ export function SessionsPanel() {
                         {fmtDate(session.startedAt)} · {duration(session.startedAt, session.lastEventAt)}
                       </span>
                     </span>
+                    {session.device ? (
+                      <span title={session.device.label} className="flex shrink-0 items-center">
+                        <DeviceIcon mobile={session.device.mobile} className="size-4 text-muted-foreground/50" />
+                      </span>
+                    ) : null}
                     {isLive(session) ? (
                       <span className="size-2 shrink-0 animate-pulse rounded-full bg-primary" title="Live" />
                     ) : session.hasError ? (

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -1,11 +1,14 @@
 // Aide sessions page: inspect voice sessions inside bb — the bb-native
 // version of CodeAide's HTML session log. Lists sessions with cost, and shows
 // a live-updating transcript: what you said, what Aide said, every tool call
-// with arguments and result, and errors.
-import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+// with arguments and result, and errors. A bottom-center call console (the FAB)
+// starts/controls the call right here, so you never route through the composer
+// (which collapses on mobile) or switch sidebars to talk.
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { useRealtime, useRpc } from "@get-bb/plugin-sdk/app";
 import type { rpcContract } from "./server";
 import { voiceAgent } from "./voice-agent";
+import { MicIcon, StopIcon, WaveformIcon, useCallElapsed } from "./voice-chrome";
 import { cn } from "@/lib/utils";
 
 interface SessionRow {
@@ -70,41 +73,121 @@ function GearIcon() {
   );
 }
 
-/** Live session controls: state, mute/unmute, stop — right on the page. */
-function SessionControls() {
-  const state = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
-  if (state === "idle") {
-    return <span className="text-xs text-muted-foreground">No active session</span>;
-  }
-  const muted = state === "muted";
+/** Stacked lines — the jump-to-transcript affordance on the live console. */
+function TranscriptIcon() {
   return (
-    <span className="flex items-center gap-2">
-      <span className={cn("flex items-center gap-1.5 text-xs", muted ? "text-destructive" : "text-primary")}>
-        <span className={cn("size-2 rounded-full", muted ? "bg-destructive/70" : "animate-pulse bg-primary")} />
-        {state}
-      </span>
-      {state !== "connecting" ? (
+    <svg viewBox="0 0 16 16" className="size-3.5" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" aria-hidden>
+      <path d="M3 4h10M3 8h10M3 12h6" />
+    </svg>
+  );
+}
+
+/**
+ * The call console — a bottom-center floating control that owns the entire call
+ * lifecycle right on the Handsfree page. Idle: a "Talk to Aide" pill. Live: it
+ * expands into a console (mute · who-has-the-floor + duration · jump to the live
+ * transcript · stop). Same neutral-chrome + activity-color language as the
+ * composer pill; color marks who's speaking, everything else stays neutral.
+ * Positioned bottom-center so it's thumb-reachable on mobile and never depends
+ * on the composer being open.
+ */
+function CallFab({ onViewTranscript }: { onViewTranscript: (sessionId: string) => void }) {
+  const state = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
+  const activity = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getActivity);
+  const elapsed = useCallElapsed();
+  const live = state === "live";
+  const muted = state === "muted";
+  const active = live || muted;
+  const connecting = state === "connecting";
+
+  if (!active) {
+    return (
+      <div className="pointer-events-none fixed inset-x-0 bottom-6 z-40 flex justify-center px-4">
         <button
           type="button"
-          onClick={() => voiceAgent.toggleMute()}
+          aria-label="Start Aide voice agent"
+          title="Talk to Aide"
+          onClick={() => voiceAgent.toggle()}
           className={cn(
-            "rounded-md border px-2 py-0.5 text-xs",
-            muted
-              ? "border-destructive text-destructive"
-              : "border-border text-muted-foreground hover:text-foreground",
+            "pointer-events-auto flex h-11 items-center gap-2 rounded-full border border-border bg-card px-5 text-sm font-medium text-foreground shadow-lg transition-colors hover:bg-accent",
+            connecting && "animate-pulse",
           )}
         >
-          {muted ? "Unmute" : "Mute"}
+          <WaveformIcon live={false} />
+          {connecting ? "Connecting…" : "Talk to Aide"}
         </button>
-      ) : null}
-      <button
-        type="button"
-        onClick={() => voiceAgent.stop()}
-        className="rounded-md border border-border px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground"
-      >
-        Stop
-      </button>
-    </span>
+      </div>
+    );
+  }
+
+  const speaking = activity === "aide";
+  const listening = activity === "you";
+  const activityColor = speaking
+    ? "text-[color:var(--success,#6faf76)]" // Aide
+    : listening
+      ? "text-foreground" // you
+      : "text-muted-foreground/70";
+  const label = speaking
+    ? "Aide speaking…"
+    : listening
+      ? "Listening…"
+      : muted
+        ? "Muted"
+        : "Connected";
+  const liveId = voiceAgent.getSessionId();
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-6 z-40 flex justify-center px-4">
+      <div className="pointer-events-auto flex h-11 max-w-full items-center overflow-hidden rounded-full border border-border bg-card shadow-lg">
+        <button
+          type="button"
+          aria-label={muted ? "Unmute Aide microphone" : "Mute Aide microphone"}
+          title={muted ? "Unmute" : "Mute"}
+          onClick={() => voiceAgent.toggleMute()}
+          className={cn(
+            "flex size-11 shrink-0 items-center justify-center transition-colors",
+            muted
+              ? "text-destructive hover:bg-destructive/15"
+              : "text-muted-foreground hover:bg-accent hover:text-foreground",
+          )}
+        >
+          <MicIcon slashed={muted} />
+        </button>
+        <span className="h-5 w-px bg-border" />
+        <span className="flex min-w-0 items-center gap-2 px-3">
+          <span className={cn("flex shrink-0 items-center", activityColor)} title={label} aria-label={label}>
+            <WaveformIcon live={speaking || listening} />
+          </span>
+          <span className="truncate text-sm text-foreground">{label}</span>
+          <span className="shrink-0 tabular-nums text-xs text-muted-foreground">{elapsed ?? ""}</span>
+        </span>
+        {liveId ? (
+          <>
+            <span className="h-5 w-px bg-border" />
+            <button
+              type="button"
+              onClick={() => onViewTranscript(liveId)}
+              title="View live transcript"
+              aria-label="View live transcript"
+              className="flex h-11 shrink-0 items-center gap-1.5 px-3 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <TranscriptIcon />
+              <span className="hidden sm:inline">Transcript</span>
+            </button>
+          </>
+        ) : null}
+        <span className="h-5 w-px bg-border" />
+        <button
+          type="button"
+          aria-label="Stop Aide voice session"
+          title="Stop"
+          onClick={() => voiceAgent.stop()}
+          className="flex size-11 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:bg-destructive/15 hover:text-destructive"
+        >
+          <StopIcon />
+        </button>
+      </div>
+    </div>
   );
 }
 
@@ -213,19 +296,59 @@ export function SessionsPanel() {
   const rpc = useRpc<typeof rpcContract>();
   useEscapeToClose();
   const [sessions, setSessions] = useState<SessionRow[] | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [selected, setSelected] = useState<string | null>(null);
   const [events, setEvents] = useState<EventRow[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  // Set when the transcript is opened so the first batch of events snaps to the
+  // bottom (latest), even if the list is taller than the viewport.
+  const pendingBottom = useRef(false);
 
-  const refetchSessions = useCallback(() => {
-    rpc.call("listSessions", null).then(
+  // Refresh the newest page and fold it over what's loaded: update rows in place
+  // (counts/cost/ended change as a call runs) and prepend brand-new sessions,
+  // without dropping older pages the user already fetched via "Load more".
+  const mergeNewest = useCallback((rows: SessionRow[], more: boolean) => {
+    setSessions((prev) => {
+      if (!prev) {
+        setHasMore(more);
+        return rows;
+      }
+      const incoming = new Map(rows.map((row) => [row.id, row]));
+      const updated = prev.map((session) => incoming.get(session.id) ?? session);
+      const existing = new Set(prev.map((session) => session.id));
+      const fresh = rows.filter((row) => !existing.has(row.id));
+      return fresh.length ? [...fresh, ...updated] : updated;
+    });
+  }, []);
+
+  const refreshNewest = useCallback(() => {
+    rpc.call("listSessions", { offset: 0 }).then(
       (result) => {
-        setSessions(result.sessions);
+        mergeNewest(result.sessions, result.hasMore);
         setError(null);
       },
       (cause) => setError(cause instanceof Error ? cause.message : String(cause)),
     );
-  }, [rpc]);
+  }, [rpc, mergeNewest]);
+
+  const loadMore = useCallback(() => {
+    if (!sessions) return;
+    setLoadingMore(true);
+    rpc.call("listSessions", { offset: sessions.length }).then(
+      (result) => {
+        setSessions((prev) => {
+          if (!prev) return result.sessions;
+          const existing = new Set(prev.map((session) => session.id));
+          return [...prev, ...result.sessions.filter((row) => !existing.has(row.id))];
+        });
+        setHasMore(result.hasMore);
+        setLoadingMore(false);
+      },
+      () => setLoadingMore(false),
+    );
+  }, [rpc, sessions]);
 
   const refetchEvents = useCallback(
     (sessionId: string) => {
@@ -237,25 +360,43 @@ export function SessionsPanel() {
     [rpc],
   );
 
-  useEffect(refetchSessions, [refetchSessions]);
   useEffect(() => {
-    if (selected) refetchEvents(selected);
+    refreshNewest();
+  }, [refreshNewest]);
+  useEffect(() => {
+    if (selected) {
+      pendingBottom.current = true;
+      refetchEvents(selected);
+    }
   }, [selected, refetchEvents]);
 
   // Live updates: the server publishes on every logged event.
   useRealtime("aide-log", (payload) => {
-    refetchSessions();
+    refreshNewest();
     const sessionId = (payload as { sessionId?: unknown } | null)?.sessionId;
     if (selected && sessionId === selected) refetchEvents(selected);
   });
 
+  // Auto-follow the transcript: after opening it, or when new events land while
+  // you're already reading the bottom, snap to the latest — but if you've
+  // scrolled up to read history, stay put.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!selected || !el) return;
+    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 160;
+    if (pendingBottom.current || nearBottom) {
+      el.scrollTop = el.scrollHeight;
+      pendingBottom.current = false;
+    }
+  }, [events, selected]);
+
   const current = sessions?.find((session) => session.id === selected) ?? null;
 
   return (
-    <div className="h-full overflow-y-auto p-4 md:p-5">
+    <div ref={scrollRef} className="h-full overflow-y-auto p-4 pb-24 md:p-5 md:pb-24">
       <div className="mx-auto w-full max-w-3xl space-y-4">
         {error ? <p className="text-sm text-destructive">{error}</p> : null}
-        {current ? (
+        {selected ? (
           <>
             <div className="flex items-center gap-3">
               <button
@@ -265,11 +406,13 @@ export function SessionsPanel() {
               >
                 ← All sessions
               </button>
-              <span className="text-sm text-foreground">
-                {fmtDate(current.startedAt)} · {duration(current.startedAt, current.lastEventAt)} ·{" "}
-                {current.ended ? "ended" : "live"} ·{" "}
-                {current.costUsd > 0 ? `~$${current.costUsd.toFixed(4)}` : "no usage recorded"}
-              </span>
+              {current ? (
+                <span className="text-sm text-foreground">
+                  {fmtDate(current.startedAt)} · {duration(current.startedAt, current.lastEventAt)} ·{" "}
+                  {current.ended ? "ended" : "live"} ·{" "}
+                  {current.costUsd > 0 ? `~$${current.costUsd.toFixed(4)}` : "no usage recorded"}
+                </span>
+              ) : null}
             </div>
             <div className="divide-y divide-border/50 rounded-lg border border-border bg-card px-3 py-1">
               {events.length === 0 ? (
@@ -283,26 +426,23 @@ export function SessionsPanel() {
           <>
             <div className="flex items-center justify-between gap-3">
               <p className="text-sm text-muted-foreground">Aide Voice Session Transcripts</p>
-              <span className="flex items-center gap-4">
-                <SessionControls />
-                <button
-                  type="button"
-                  onClick={openHandsfreeSettings}
-                  title="Open Handsfree settings"
-                  aria-label="Open Handsfree settings"
-                  className="flex items-center gap-1.5 rounded-md border border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
-                >
-                  <GearIcon />
-                  Settings
-                </button>
-              </span>
+              <button
+                type="button"
+                onClick={openHandsfreeSettings}
+                title="Open Handsfree settings"
+                aria-label="Open Handsfree settings"
+                className="flex items-center gap-1.5 rounded-md border border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+              >
+                <GearIcon />
+                Settings
+              </button>
             </div>
             <div className="divide-y divide-border/50 rounded-lg border border-border bg-card">
               {sessions === null ? (
                 <p className="p-3 text-sm text-muted-foreground">Loading…</p>
               ) : sessions.length === 0 ? (
                 <p className="p-3 text-sm text-muted-foreground">
-                  No sessions yet. Click the waveform button in any composer and start talking.
+                  No sessions yet. Tap “Talk to Aide” below to start your first one.
                 </p>
               ) : (
                 sessions.map((session) => (
@@ -327,9 +467,22 @@ export function SessionsPanel() {
                 ))
               )}
             </div>
+            {hasMore ? (
+              <div className="flex justify-center">
+                <button
+                  type="button"
+                  onClick={loadMore}
+                  disabled={loadingMore}
+                  className="rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-60"
+                >
+                  {loadingMore ? "Loading…" : "Load more"}
+                </button>
+              </div>
+            ) : null}
           </>
         )}
       </div>
+      <CallFab onViewTranscript={(sessionId) => setSelected(sessionId)} />
     </div>
   );
 }

--- a/settings-sections.tsx
+++ b/settings-sections.tsx
@@ -413,6 +413,7 @@ interface PluginInfo {
   id: string;
   name: string;
   summary: string;
+  iconUrl: string | null;
 }
 
 /** A modal checklist of installed plugins; the selection is stored as a csv. */

--- a/voice-agent.test.ts
+++ b/voice-agent.test.ts
@@ -86,6 +86,17 @@ test("stop/mute from a surface that doesn't own the call is relayed to the owner
   agent.ingestPresence({ nonce: "call-A", phase: "idle", startedAt: null });
 });
 
+test("presence catch-up: a surface requests, a non-owner never answers", () => {
+  const { agent, calls } = agentWithRpcSpy();
+  agent.requestPresence();
+  assert.deepEqual(calls.at(-1), { method: "requestPresence", args: null });
+
+  // We own no call, so a peer's query must NOT make us publish presence.
+  calls.length = 0;
+  agent.answerPresenceQuery();
+  assert.equal(calls.length, 0);
+});
+
 test("a relayed command is ignored by a realm that doesn't own that call", () => {
   const { agent, calls } = agentWithRpcSpy();
   // Idle here: we own nothing, so an incoming command must be a no-op.

--- a/voice-agent.test.ts
+++ b/voice-agent.test.ts
@@ -1,7 +1,98 @@
-import test from "node:test";
+import test, { mock } from "node:test";
 import assert from "node:assert/strict";
 import { VoiceAgent } from "./voice-agent.ts";
 import { writeAudioDevicePreferences } from "./audio-devices.ts";
+
+/** A VoiceAgent bound to a spy rpc that records every relayed call. */
+function agentWithRpcSpy() {
+  const calls: { method: string; args: unknown }[] = [];
+  const agent = new VoiceAgent();
+  agent.bind({
+    rpc: {
+      call: (async (method: string, args: unknown) => {
+        calls.push({ method, args });
+        return { ok: true };
+      }) as never,
+    },
+    context: { threadId: null, projectId: null, onNewThreadScreen: false },
+    openNewThread() {},
+  });
+  return { agent, calls };
+}
+
+test("mirrors a call owned by another realm from voice-presence", () => {
+  const agent = new VoiceAgent();
+  assert.equal(agent.getState(), "idle");
+
+  agent.ingestPresence({ nonce: "call-A", phase: "live", startedAt: 1000 });
+  assert.equal(agent.getState(), "live");
+  assert.equal(agent.getSessionId(), "call-A");
+  assert.equal(agent.getLiveStartedAt(), 1000);
+
+  agent.ingestPresence({ nonce: "call-A", phase: "muted", startedAt: 1000 });
+  assert.equal(agent.getState(), "muted");
+
+  // The owner announcing idle clears the mirror on every other surface.
+  agent.ingestPresence({ nonce: "call-A", phase: "idle", startedAt: null });
+  assert.equal(agent.getState(), "idle");
+  assert.equal(agent.getSessionId(), null);
+});
+
+test("ignores malformed or nonce-less presence", () => {
+  const agent = new VoiceAgent();
+  agent.ingestPresence(null);
+  agent.ingestPresence({ phase: "live" });
+  agent.ingestPresence({ nonce: "x", phase: "bogus" });
+  assert.equal(agent.getState(), "idle");
+});
+
+test("a mirrored call expires once its heartbeats lapse (no ghost live)", () => {
+  mock.timers.enable({ apis: ["Date", "setInterval"] });
+  try {
+    const agent = new VoiceAgent();
+    agent.ingestPresence({ nonce: "call-A", phase: "live", startedAt: 0 });
+    assert.equal(agent.getState(), "live");
+
+    mock.timers.tick(10_000); // still within the fresh window
+    assert.equal(agent.getState(), "live");
+
+    mock.timers.tick(20_000); // now past PRESENCE_STALE_MS (25s)
+    assert.equal(agent.getState(), "idle");
+  } finally {
+    mock.timers.reset();
+  }
+});
+
+test("stop/mute from a surface that doesn't own the call is relayed to the owner", () => {
+  const { agent, calls } = agentWithRpcSpy();
+  agent.ingestPresence({ nonce: "call-A", phase: "live", startedAt: 1000 });
+
+  agent.stopFromSurface();
+  assert.deepEqual(calls.at(-1), {
+    method: "sendVoiceCommand",
+    args: { nonce: "call-A", action: "stop" },
+  });
+
+  agent.toggleMuteFromSurface(); // live → mute
+  assert.deepEqual(calls.at(-1)?.args, { nonce: "call-A", action: "mute" });
+
+  agent.ingestPresence({ nonce: "call-A", phase: "muted", startedAt: 1000 });
+  agent.toggleMuteFromSurface(); // muted → unmute
+  assert.deepEqual(calls.at(-1)?.args, { nonce: "call-A", action: "unmute" });
+
+  agent.toggleFromSurface(); // a mirrored call is stopped, not re-toggled
+  assert.deepEqual(calls.at(-1)?.args, { nonce: "call-A", action: "stop" });
+
+  agent.ingestPresence({ nonce: "call-A", phase: "idle", startedAt: null });
+});
+
+test("a relayed command is ignored by a realm that doesn't own that call", () => {
+  const { agent, calls } = agentWithRpcSpy();
+  // Idle here: we own nothing, so an incoming command must be a no-op.
+  agent.applyVoiceCommand({ nonce: "call-A", action: "stop" });
+  assert.equal(agent.getState(), "idle");
+  assert.equal(calls.length, 0);
+});
 
 test("reloads audio preferences saved by another browser window", () => {
   const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");

--- a/voice-agent.test.ts
+++ b/voice-agent.test.ts
@@ -71,22 +71,23 @@ test("stop/mute from a surface that doesn't own the call is relayed to the owner
 
   // Commands also carry client/realm identity (observability); assert the parts
   // that matter for routing.
-  const lastCommand = () => calls.at(-1)?.args as { nonce: string; action: string };
+  const lastArgs = () => calls.at(-1)?.args as { nonce: string; action?: string };
 
-  agent.stopFromSurface();
+  agent.toggleMuteFromSurface(); // live → mute (relayed to the owner)
   assert.equal(calls.at(-1)?.method, "sendVoiceCommand");
-  assert.equal(lastCommand().nonce, "call-A");
-  assert.equal(lastCommand().action, "stop");
-
-  agent.toggleMuteFromSurface(); // live → mute
-  assert.equal(lastCommand().action, "mute");
+  assert.equal(lastArgs().nonce, "call-A");
+  assert.equal(lastArgs().action, "mute");
 
   agent.ingestPresence({ nonce: "call-A", phase: "muted", startedAt: 1000 });
   agent.toggleMuteFromSurface(); // muted → unmute
-  assert.equal(lastCommand().action, "unmute");
+  assert.equal(lastArgs().action, "unmute");
 
-  agent.toggleFromSurface(); // a mirrored call is stopped, not re-toggled
-  assert.equal(lastCommand().action, "stop");
+  // Stop of a mirrored call is server-authoritative (forceStop) so it works even
+  // against a frozen owner, and clears the mirror immediately.
+  agent.stopFromSurface();
+  assert.equal(calls.at(-1)?.method, "forceStop");
+  assert.equal(lastArgs().nonce, "call-A");
+  assert.equal(agent.getState(), "idle");
 
   agent.ingestPresence({ nonce: "call-A", phase: "idle", startedAt: null });
 });

--- a/voice-agent.test.ts
+++ b/voice-agent.test.ts
@@ -17,6 +17,8 @@ function agentWithRpcSpy() {
     context: { threadId: null, projectId: null, onNewThreadScreen: false },
     openNewThread() {},
   });
+  // bind() emits a one-time client.hello diagnostic; drop it so tests start clean.
+  calls.length = 0;
   return { agent, calls };
 }
 
@@ -67,21 +69,24 @@ test("stop/mute from a surface that doesn't own the call is relayed to the owner
   const { agent, calls } = agentWithRpcSpy();
   agent.ingestPresence({ nonce: "call-A", phase: "live", startedAt: 1000 });
 
+  // Commands also carry client/realm identity (observability); assert the parts
+  // that matter for routing.
+  const lastCommand = () => calls.at(-1)?.args as { nonce: string; action: string };
+
   agent.stopFromSurface();
-  assert.deepEqual(calls.at(-1), {
-    method: "sendVoiceCommand",
-    args: { nonce: "call-A", action: "stop" },
-  });
+  assert.equal(calls.at(-1)?.method, "sendVoiceCommand");
+  assert.equal(lastCommand().nonce, "call-A");
+  assert.equal(lastCommand().action, "stop");
 
   agent.toggleMuteFromSurface(); // live → mute
-  assert.deepEqual(calls.at(-1)?.args, { nonce: "call-A", action: "mute" });
+  assert.equal(lastCommand().action, "mute");
 
   agent.ingestPresence({ nonce: "call-A", phase: "muted", startedAt: 1000 });
   agent.toggleMuteFromSurface(); // muted → unmute
-  assert.deepEqual(calls.at(-1)?.args, { nonce: "call-A", action: "unmute" });
+  assert.equal(lastCommand().action, "unmute");
 
   agent.toggleFromSurface(); // a mirrored call is stopped, not re-toggled
-  assert.deepEqual(calls.at(-1)?.args, { nonce: "call-A", action: "stop" });
+  assert.equal(lastCommand().action, "stop");
 
   agent.ingestPresence({ nonce: "call-A", phase: "idle", startedAt: null });
 });

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -15,7 +15,7 @@ import {
   writeAudioDevicePreferences,
   type AudioDevicePreferences,
 } from "./audio-devices.ts";
-import { clientId, realmId, identityTag } from "./client-identity.ts";
+import { clientId, realmId, identityTag, clientDescriptor } from "./client-identity.ts";
 
 export type VoiceState = "idle" | "connecting" | "live" | "muted";
 /** Who currently has the floor during a live call, for the "listening" UI. */
@@ -277,7 +277,7 @@ export class VoiceAgent {
 
   bind(bindings: Bindings) {
     this.bindings = bindings;
-    this.helloOnce();
+    this.helloOnce("composer");
   }
 
   /**
@@ -288,19 +288,22 @@ export class VoiceAgent {
    */
   bindFallback(bindings: Bindings) {
     if (!this.bindings) this.bindings = bindings;
-    this.helloOnce();
+    this.helloOnce("page");
   }
 
   /**
    * Announce this realm once it can talk to the backend, so every surface (even
    * idle ones that never start a call) leaves a durable record of its client +
-   * realm id. This is how we enumerate "which realms exist on which client".
+   * realm id, the device descriptor, and which surface it is. This is how we
+   * enumerate "which realms exist on which client, and what kind of device".
    */
-  private helloOnce() {
+  private helloOnce(surface: string) {
     if (this.helloed || !this.bindings) return;
     this.helloed = true;
     this.logDiag("client.hello", {
-      surface: typeof document !== "undefined" ? document.visibilityState : "unknown",
+      surface, // realm/usage: which surface this realm is (composer vs page)
+      visibility: typeof document !== "undefined" ? document.visibilityState : "unknown",
+      ...clientDescriptor, // client/device: platform, browser, runtime, ua, …
     });
   }
 

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -121,6 +121,13 @@ export class VoiceAgent {
   readonly getLiveStartedAt = (): number | null => this.liveStartedAt;
 
   /**
+   * The active session id (the call nonce, which doubles as the session id used
+   * when logging events), or null when idle. Lets the page jump straight to the
+   * live session's transcript.
+   */
+  readonly getSessionId = (): string | null => this.nonce;
+
+  /**
    * Who is talking right now, from the data-channel signals we already track
    * (VAD for the user, response lifecycle for Aide). Deliberately no audio
    * analysis — it stays reliable and never touches the audio pipeline. The

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -114,6 +114,8 @@ export class VoiceAgent {
   private connectTimer: ReturnType<typeof setTimeout> | null = null;
   /** When the call first went live (ms), for elapsed-duration UI; null if not. */
   private liveStartedAt: number | null = null;
+  /** The most recent meaningful event, for the dock's live activity ticker. */
+  private lastActivity: { kind: string; name: string; text: string } | null = null;
 
   readonly subscribe = (listener: () => void): (() => void) => {
     this.listeners.add(listener);
@@ -131,6 +133,13 @@ export class VoiceAgent {
    * live session's transcript.
    */
   readonly getSessionId = (): string | null => this.nonce;
+
+  /**
+   * The latest meaningful event (speech / tool call / notice), for the dock's
+   * activity ticker. Stable identity between changes so it's safe for
+   * useSyncExternalStore. The UI owns human phrasing (tool → verb).
+   */
+  readonly getLastActivity = (): { kind: string; name: string; text: string } | null => this.lastActivity;
 
   /**
    * Who is talking right now, from the data-channel signals we already track
@@ -304,7 +313,19 @@ export class VoiceAgent {
     const sessionId = this.nonce;
     const bindings = this.bindings;
     if (!sessionId || !bindings) return;
+    this.noteActivity(kind, payload);
     void bindings.rpc.call("logEvent", { sessionId, kind, payload }).catch(() => undefined);
+  }
+
+  /** Track the latest meaningful event for the dock ticker (ignores diagnostics). */
+  private noteActivity(kind: string, payload: Record<string, unknown>) {
+    let next: { kind: string; name: string; text: string } | null;
+    if (kind === "session.started") next = null;
+    else if (kind === "user" || kind === "assistant" || kind === "notice") next = { kind, name: "", text: String(payload.text ?? "") };
+    else if (kind === "tool.call") next = { kind, name: String(payload.name ?? ""), text: "" };
+    else return; // diagnostics / tool.result don't move the ticker
+    this.lastActivity = next;
+    this.emitChange();
   }
 
   /**

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -49,6 +49,14 @@ interface RemotePresence {
  */
 const MOBILE_NAV_TOOLS = new Set(["focus_thread"]);
 
+/**
+ * Tools that do real work AND navigate (spawn/diff, then `bb.sdk.threads.open`).
+ * Unlike a pure-navigation tool we don't refuse these — we run them with
+ * `focus:false` on a live mobile call so the work happens without backgrounding
+ * the call. The server honors the flag by skipping its `threads.open`.
+ */
+const FOCUS_SUPPRESSIBLE_TOOLS = new Set(["start_thread", "show_diff"]);
+
 /** A mirror is stale (owner realm likely gone) after two missed heartbeats. */
 const PRESENCE_STALE_MS = 25_000;
 /** How often the owning realm re-announces a live call, for the mirror above. */
@@ -388,7 +396,10 @@ export class VoiceAgent {
       | { nonce?: unknown; phase?: unknown; startedAt?: unknown; client?: unknown; realm?: unknown }
       | null;
     const nonce = typeof p?.nonce === "string" ? p.nonce : null;
-    if (!nonce || nonce === this.nonce || this.hasLocalCall()) return;
+    // Never mirror our own broadcast. Match on realm too, not just nonce: after
+    // stop() nulls the nonce, a reordered trailing "live" frame from this realm
+    // would otherwise slip past the nonce check and ghost as a remote call.
+    if (!nonce || nonce === this.nonce || p?.realm === realmId || this.hasLocalCall()) return;
     const phase = p?.phase;
     if (phase === "idle") {
       // Only the call we're actually mirroring can clear it — a late idle for an
@@ -756,7 +767,15 @@ export class VoiceAgent {
       if (!newTrack) throw new Error("no audio track");
       newTrack.enabled = this.state !== "muted"; // preserve the user's mute
       await sender.replaceTrack(newTrack);
-      session.micTrack?.stop();
+      // Detach the old track's lifecycle handlers before stopping it — otherwise
+      // its onended fires (session still current) and re-enters suspend/recover,
+      // flashing a false "mic paused".
+      if (session.micTrack) {
+        session.micTrack.onmute = null;
+        session.micTrack.onunmute = null;
+        session.micTrack.onended = null;
+        session.micTrack.stop();
+      }
       session.micTrack = newTrack;
       this.attachMicLifecycle(session, newTrack);
       this.setMicSuspended(false);
@@ -947,11 +966,11 @@ export class VoiceAgent {
       output =
         "On mobile you can't navigate the app during a live call — it would background the call and cut the mic. Do NOT navigate. Instead, tell the user in one short sentence exactly what to tap to get there themselves.";
     } else {
-      // start_thread navigates (spawn → threads.open) which backgrounds a live
-      // mobile call — tell the server not to focus so the thread still starts but
+      // These tools navigate (…→ threads.open) which would background a live
+      // mobile call — tell the server not to focus so the work still happens but
       // nothing navigates. (The promptless start_thread is handled above.)
       const suppressFocus =
-        name === "start_thread" &&
+        FOCUS_SUPPRESSIBLE_TOOLS.has(name) &&
         clientDescriptor.mobile &&
         (this.state === "live" || this.state === "muted");
       if (suppressFocus) this.logDiag("nav.suppressedFocus", { name });
@@ -1156,7 +1175,10 @@ export class VoiceAgent {
           }
           const response = event.response as Record<string, unknown> | undefined;
           const usage = response?.usage;
-          if (usage && typeof usage === "object") {
+          // A response.done can land after stop() cleared the nonce; without one
+          // the cost can't be attributed to a session, so drop it rather than
+          // writing an orphan usage row.
+          if (usage && typeof usage === "object" && this.nonce) {
             void this.bindings?.rpc
               .call("recordUsage", {
                 model: typeof response?.model === "string" ? response.model : null,

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -15,6 +15,7 @@ import {
   writeAudioDevicePreferences,
   type AudioDevicePreferences,
 } from "./audio-devices.ts";
+import { clientId, realmId, identityTag } from "./client-identity.ts";
 
 export type VoiceState = "idle" | "connecting" | "live" | "muted";
 /** Who currently has the floor during a live call, for the "listening" UI. */
@@ -32,6 +33,9 @@ interface RemotePresence {
   phase: Exclude<VoiceState, "idle">;
   startedAt: number | null;
   receivedAt: number;
+  /** Which client/realm owns the mirrored call (observability / future "live on X"). */
+  ownerClient?: string;
+  ownerRealm?: string;
 }
 
 /** A mirror is stale (owner realm likely gone) after two missed heartbeats. */
@@ -175,6 +179,8 @@ export class VoiceAgent {
   private presenceTimer: ReturnType<typeof setInterval> | null = null;
   /** Expires a stale mirror (owner realm gone) so we never show a ghost call. */
   private remoteExpiryTimer: ReturnType<typeof setInterval> | null = null;
+  /** Guards the once-per-realm `client.hello` observability record. */
+  private helloed = false;
 
   readonly subscribe = (listener: () => void): (() => void) => {
     this.listeners.add(listener);
@@ -271,6 +277,7 @@ export class VoiceAgent {
 
   bind(bindings: Bindings) {
     this.bindings = bindings;
+    this.helloOnce();
   }
 
   /**
@@ -281,6 +288,20 @@ export class VoiceAgent {
    */
   bindFallback(bindings: Bindings) {
     if (!this.bindings) this.bindings = bindings;
+    this.helloOnce();
+  }
+
+  /**
+   * Announce this realm once it can talk to the backend, so every surface (even
+   * idle ones that never start a call) leaves a durable record of its client +
+   * realm id. This is how we enumerate "which realms exist on which client".
+   */
+  private helloOnce() {
+    if (this.helloed || !this.bindings) return;
+    this.helloed = true;
+    this.logDiag("client.hello", {
+      surface: typeof document !== "undefined" ? document.visibilityState : "unknown",
+    });
   }
 
   private setState(next: VoiceState) {
@@ -307,7 +328,7 @@ export class VoiceAgent {
     const rpc = this.bindings?.rpc;
     if (!rpc) return;
     void rpc
-      .call("publishPresence", { nonce, phase, startedAt: this.liveStartedAt })
+      .call("publishPresence", { nonce, phase, startedAt: this.liveStartedAt, client: clientId, realm: realmId })
       .catch(() => undefined);
   }
 
@@ -347,7 +368,9 @@ export class VoiceAgent {
    * remote call so this realm's controls reflect it.
    */
   ingestPresence(payload: unknown) {
-    const p = payload as { nonce?: unknown; phase?: unknown; startedAt?: unknown } | null;
+    const p = payload as
+      | { nonce?: unknown; phase?: unknown; startedAt?: unknown; client?: unknown; realm?: unknown }
+      | null;
     const nonce = typeof p?.nonce === "string" ? p.nonce : null;
     if (!nonce || nonce === this.nonce || this.hasLocalCall()) return;
     const phase = p?.phase;
@@ -363,7 +386,9 @@ export class VoiceAgent {
     }
     if (phase !== "connecting" && phase !== "live" && phase !== "muted") return;
     const startedAt = typeof p?.startedAt === "number" ? p.startedAt : null;
-    this.remotePresence = { nonce, phase, startedAt, receivedAt: Date.now() };
+    const ownerClient = typeof p?.client === "string" ? p.client : undefined;
+    const ownerRealm = typeof p?.realm === "string" ? p.realm : undefined;
+    this.remotePresence = { nonce, phase, startedAt, receivedAt: Date.now(), ownerClient, ownerRealm };
     this.armRemoteExpiry();
     this.emitChange();
   }
@@ -393,7 +418,9 @@ export class VoiceAgent {
   private sendCommand(nonce: string, action: VoiceCommandAction) {
     const rpc = this.bindings?.rpc;
     if (!rpc) return;
-    void rpc.call("sendVoiceCommand", { nonce, action }).catch(() => undefined);
+    void rpc
+      .call("sendVoiceCommand", { nonce, action, client: clientId, realm: realmId })
+      .catch(() => undefined);
   }
 
   /** Apply a relayed command — but only if THIS realm owns that call. */
@@ -548,7 +575,11 @@ export class VoiceAgent {
     const bindings = this.bindings;
     if (!sessionId || !bindings) return;
     this.noteActivity(kind, payload);
-    void bindings.rpc.call("logEvent", { sessionId, kind, payload }).catch(() => undefined);
+    // Stamp which client/realm produced this event (see client-identity.ts) so
+    // the transcript/DB shows where things actually happened across surfaces.
+    void bindings.rpc
+      .call("logEvent", { sessionId, kind, payload: { ...payload, _id: identityTag() } })
+      .catch(() => undefined);
   }
 
   /** Track the latest meaningful event for the dock ticker (ignores diagnostics). */
@@ -572,7 +603,11 @@ export class VoiceAgent {
     const rpc = this.bindings?.rpc;
     if (!rpc) return;
     void rpc
-      .call("logEvent", { sessionId: this.nonce ?? "audio-diagnostics", kind, payload })
+      .call("logEvent", {
+        sessionId: this.nonce ?? "audio-diagnostics",
+        kind,
+        payload: { ...payload, _id: identityTag() },
+      })
       .catch(() => undefined);
   }
 

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -1,6 +1,8 @@
-// The app-global voice session singleton. Lives in its own module so both
-// the composer button (app.tsx) and the Handsfree page (sessions-panel.tsx)
-// can control one shared session without a circular import.
+// The voice session singleton for a plugin realm. Lives in its own module so
+// both the composer button (app.tsx) and the Handsfree page (sessions-panel.tsx)
+// can reach it without a circular import. Note: bb renders each surface in a
+// separate realm, so this is one instance PER surface; cross-surface state is
+// shared over realtime presence/command channels (see VoiceAgent below).
 import { toast } from "sonner";
 import type { useRpc } from "@get-bb/plugin-sdk/app";
 import type { rpcContract } from "./server";
@@ -17,6 +19,25 @@ import {
 export type VoiceState = "idle" | "connecting" | "live" | "muted";
 /** Who currently has the floor during a live call, for the "listening" UI. */
 export type VoiceActivity = "you" | "aide" | "idle";
+/** A control intent relayed from a non-owning surface to the owning realm. */
+export type VoiceCommandAction = "stop" | "mute" | "unmute";
+
+/**
+ * A live call owned by another surface's realm, mirrored here from the
+ * `voice-presence` broadcast so this realm's controls reflect it. `receivedAt`
+ * lets us expire a call whose owner realm vanished without a clean stop.
+ */
+interface RemotePresence {
+  nonce: string;
+  phase: Exclude<VoiceState, "idle">;
+  startedAt: number | null;
+  receivedAt: number;
+}
+
+/** A mirror is stale (owner realm likely gone) after two missed heartbeats. */
+const PRESENCE_STALE_MS = 25_000;
+/** How often the owning realm re-announces a live call, for the mirror above. */
+const PRESENCE_HEARTBEAT_MS = 10_000;
 
 interface RpcClient {
   call: ReturnType<typeof useRpc<typeof rpcContract>>["call"];
@@ -51,6 +72,16 @@ interface SessionHandle {
   dc: RTCDataChannel | null;
 }
 
+/**
+ * Detach a timer from the event loop where the runtime supports it (Node's
+ * `unref`). No-op in the browser (timer ids have no `unref`), where it isn't
+ * needed — this just keeps background presence timers from holding a process
+ * (e.g. tests) open.
+ */
+function maybeUnref(timer: ReturnType<typeof setInterval>) {
+  (timer as { unref?: () => void }).unref?.();
+}
+
 function browserStorage(): Storage | null {
   try {
     return typeof window === "undefined" ? null : window.localStorage;
@@ -77,9 +108,15 @@ function waitForIceGathering(pc: RTCPeerConnection, timeoutMs = 2000): Promise<v
 }
 
 /**
- * App-global voice session. Mounted buttons keep `bindings` fresh (latest
- * composer + route context win), so tool calls always act on what the user
- * is currently looking at, and navigation never interrupts the call.
+ * Voice session for one plugin realm. bb renders each surface (composer,
+ * sidebar, the Handsfree page) in its own JS realm, so this singleton is
+ * per-surface, not truly app-global: the realm that starts a call OWNS the
+ * WebRTC session; the call keeps running there as the user navigates within
+ * that realm. Other realms don't hold the session — they mirror its coarse
+ * state over the `voice-presence` broadcast and relay stop/mute back to the
+ * owner via `voice-command`, so every surface reflects and can control the one
+ * live call. Mounted buttons keep `bindings` fresh (latest composer + route
+ * context win) so tool calls act on what the user is currently looking at.
  */
 export class VoiceAgent {
   private state: VoiceState = "idle";
@@ -116,23 +153,55 @@ export class VoiceAgent {
   private liveStartedAt: number | null = null;
   /** The most recent meaningful event, for the dock's live activity ticker. */
   private lastActivity: { kind: string; name: string; text: string } | null = null;
+  /**
+   * A call owned by another surface's realm, mirrored from `voice-presence`.
+   * Non-null only when THIS realm does not own the call; drives the effective
+   * getters so every surface reflects the one live call. Null when we own it.
+   */
+  private remotePresence: RemotePresence | null = null;
+  /** Re-announces our live call so other realms' mirrors don't go stale. */
+  private presenceTimer: ReturnType<typeof setInterval> | null = null;
+  /** Expires a stale mirror (owner realm gone) so we never show a ghost call. */
+  private remoteExpiryTimer: ReturnType<typeof setInterval> | null = null;
 
   readonly subscribe = (listener: () => void): (() => void) => {
     this.listeners.add(listener);
     return () => this.listeners.delete(listener);
   };
 
-  readonly getState = (): VoiceState => this.state;
+  /**
+   * The effective call state for the UI: our own if we own a call, otherwise a
+   * call mirrored from another surface's realm (`voice-presence`). This is what
+   * makes every surface reflect the single live call, not just the one that
+   * started it.
+   */
+  readonly getState = (): VoiceState =>
+    this.state !== "idle" ? this.state : this.remotePresenceLive()?.phase ?? "idle";
 
   /** Epoch ms when the call went live, or null when not in a live/muted call. */
-  readonly getLiveStartedAt = (): number | null => this.liveStartedAt;
+  readonly getLiveStartedAt = (): number | null =>
+    this.state !== "idle" ? this.liveStartedAt : this.remotePresenceLive()?.startedAt ?? null;
 
   /**
    * The active session id (the call nonce, which doubles as the session id used
    * when logging events), or null when idle. Lets the page jump straight to the
-   * live session's transcript.
+   * live session's transcript — including a call owned by another surface.
    */
-  readonly getSessionId = (): string | null => this.nonce;
+  readonly getSessionId = (): string | null =>
+    this.state !== "idle" ? this.nonce : this.remotePresenceLive()?.nonce ?? null;
+
+  /** True while THIS realm owns (or is opening) the call. */
+  private hasLocalCall(): boolean {
+    return this.state !== "idle";
+  }
+
+  /** The mirrored remote call if still fresh; null once its heartbeats lapse. */
+  private remotePresenceLive(): RemotePresence | null {
+    const remote = this.remotePresence;
+    if (!remote) return null;
+    if (Date.now() - remote.receivedAt > PRESENCE_STALE_MS) return null;
+    return remote;
+  }
 
   /**
    * The latest meaningful event (speech / tool call / notice), for the dock's
@@ -191,10 +260,133 @@ export class VoiceAgent {
   private setState(next: VoiceState) {
     this.state = next;
     this.emitChange();
+    // Announce our own transitions so other realms mirror this call. Idle is
+    // announced explicitly by stop() (which clears the nonce first), so skip it
+    // here — a null nonce has nothing to identify.
+    if (next !== "idle" && this.nonce) this.broadcastPresence(next, this.nonce);
   }
 
   private emitChange() {
     for (const listener of this.listeners) listener();
+  }
+
+  // ---- cross-surface presence (see server: voice-presence / voice-command) ----
+
+  /**
+   * Announce our own call so other realms mirror it. Fire-and-forget; presence
+   * is cosmetic, so a failed publish must never touch the call. Only our own
+   * transitions reach here (setState / stop), so `nonce` always identifies us.
+   */
+  private broadcastPresence(phase: VoiceState, nonce: string) {
+    const rpc = this.bindings?.rpc;
+    if (!rpc) return;
+    void rpc
+      .call("publishPresence", { nonce, phase, startedAt: this.liveStartedAt })
+      .catch(() => undefined);
+  }
+
+  /** Keep remote mirrors fresh while we own a live call (see PRESENCE_STALE_MS). */
+  private startPresenceHeartbeat() {
+    this.stopPresenceHeartbeat();
+    this.presenceTimer = setInterval(() => {
+      if (this.nonce && this.hasLocalCall()) this.broadcastPresence(this.state, this.nonce);
+    }, PRESENCE_HEARTBEAT_MS);
+    maybeUnref(this.presenceTimer);
+  }
+
+  private stopPresenceHeartbeat() {
+    if (this.presenceTimer) clearInterval(this.presenceTimer);
+    this.presenceTimer = null;
+  }
+
+  /**
+   * Ingest a `voice-presence` broadcast. Ignores our own echo and anything while
+   * we own a call (our local state already drives the UI); otherwise mirrors the
+   * remote call so this realm's controls reflect it.
+   */
+  ingestPresence(payload: unknown) {
+    const p = payload as { nonce?: unknown; phase?: unknown; startedAt?: unknown } | null;
+    const nonce = typeof p?.nonce === "string" ? p.nonce : null;
+    if (!nonce || nonce === this.nonce || this.hasLocalCall()) return;
+    const phase = p?.phase;
+    if (phase === "idle") {
+      // Only the call we're actually mirroring can clear it — a late idle for an
+      // older, already-superseded call must not wipe a newer live mirror.
+      if (this.remotePresence?.nonce === nonce) {
+        this.remotePresence = null;
+        this.disarmRemoteExpiry();
+        this.emitChange();
+      }
+      return;
+    }
+    if (phase !== "connecting" && phase !== "live" && phase !== "muted") return;
+    const startedAt = typeof p?.startedAt === "number" ? p.startedAt : null;
+    this.remotePresence = { nonce, phase, startedAt, receivedAt: Date.now() };
+    this.armRemoteExpiry();
+    this.emitChange();
+  }
+
+  /** Poll a mirror to expiry so a vanished owner doesn't leave a ghost "live". */
+  private armRemoteExpiry() {
+    if (this.remoteExpiryTimer) return;
+    this.remoteExpiryTimer = setInterval(() => {
+      if (!this.remotePresence) {
+        this.disarmRemoteExpiry();
+        return;
+      }
+      if (this.remotePresenceLive()) return; // still fresh
+      this.remotePresence = null;
+      this.disarmRemoteExpiry();
+      this.emitChange();
+    }, 5000);
+    maybeUnref(this.remoteExpiryTimer);
+  }
+
+  private disarmRemoteExpiry() {
+    if (this.remoteExpiryTimer) clearInterval(this.remoteExpiryTimer);
+    this.remoteExpiryTimer = null;
+  }
+
+  /** Relay a control intent to whichever realm owns the call. */
+  private sendCommand(nonce: string, action: VoiceCommandAction) {
+    const rpc = this.bindings?.rpc;
+    if (!rpc) return;
+    void rpc.call("sendVoiceCommand", { nonce, action }).catch(() => undefined);
+  }
+
+  /** Apply a relayed command — but only if THIS realm owns that call. */
+  applyVoiceCommand(payload: unknown) {
+    const p = payload as { nonce?: unknown; action?: unknown } | null;
+    const nonce = typeof p?.nonce === "string" ? p.nonce : null;
+    if (!nonce || nonce !== this.nonce || !this.hasLocalCall()) return;
+    const action = p?.action;
+    if (action === "stop") this.stop();
+    else if (action === "mute") this.setMuted(true);
+    else if (action === "unmute") this.setMuted(false);
+  }
+
+  // ---- surface controls: act on the local call, or relay to the owner ----
+
+  /** Start/stop from any surface. A mirrored remote call is stopped, not toggled. */
+  toggleFromSurface() {
+    if (this.hasLocalCall()) return this.toggle();
+    const remote = this.remotePresenceLive();
+    if (remote) return this.sendCommand(remote.nonce, "stop");
+    void this.start();
+  }
+
+  /** Mute/unmute from any surface. */
+  toggleMuteFromSurface() {
+    if (this.hasLocalCall()) return this.toggleMute();
+    const remote = this.remotePresenceLive();
+    if (remote) this.sendCommand(remote.nonce, remote.phase === "muted" ? "unmute" : "mute");
+  }
+
+  /** Stop from any surface. */
+  stopFromSurface() {
+    if (this.hasLocalCall()) return this.stop();
+    const remote = this.remotePresenceLive();
+    if (remote) this.sendCommand(remote.nonce, "stop");
   }
 
   setAudioPreferences(next: AudioDevicePreferences) {
@@ -433,8 +625,10 @@ export class VoiceAgent {
   }
 
   stop() {
+    const endedNonce = this.nonce;
     if (this.session) this.log("session.stopped");
     this.clearConnectWatchdog();
+    this.stopPresenceHeartbeat();
     this.liveStartedAt = null;
     const session = this.session;
     this.session = null;
@@ -455,6 +649,9 @@ export class VoiceAgent {
       session.audio.remove();
     }
     this.setState("idle");
+    // Clear every mirror now that the call is over. Done after nulling nonce so
+    // setState's own broadcast is skipped and this is the single idle announce.
+    if (endedNonce) this.broadcastPresence("idle", endedNonce);
   }
 
   private async handleToolCall(dc: RTCDataChannel, event: Record<string, unknown>) {
@@ -526,9 +723,11 @@ export class VoiceAgent {
   private async start() {
     const bindings = this.bindings;
     if (!bindings) return;
-    this.setState("connecting");
+    // Assign the nonce before entering "connecting" so that state's presence
+    // broadcast already carries our identity.
     const nonce = crypto.randomUUID();
     this.nonce = nonce;
+    this.setState("connecting");
     this.log("session.started", { ...bindings.context });
     try {
       // Deterministic acquisition: enumerate what is actually present, resolve
@@ -634,6 +833,7 @@ export class VoiceAgent {
           this.clearConnectWatchdog();
           this.liveStartedAt = Date.now();
           this.setState("live");
+          this.startPresenceHeartbeat();
           this.log("session.live");
           this.logDiag("conn.dc.open");
         }

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -285,6 +285,22 @@ export class VoiceAgent {
       .catch(() => undefined);
   }
 
+  /**
+   * Ask any realm that owns a live call to re-announce it now. A surface calls
+   * this on mount so it catches up immediately instead of waiting up to a full
+   * heartbeat — the "briefly shows Talk to Aide over a live call" gap.
+   */
+  requestPresence() {
+    const rpc = this.bindings?.rpc;
+    if (!rpc) return;
+    void rpc.call("requestPresence", null).catch(() => undefined);
+  }
+
+  /** Re-announce our call in response to a peer's mount-time presence request. */
+  answerPresenceQuery() {
+    if (this.nonce && this.hasLocalCall()) this.broadcastPresence(this.state, this.nonce);
+  }
+
   /** Keep remote mirrors fresh while we own a live call (see PRESENCE_STALE_MS). */
   private startPresenceHeartbeat() {
     this.stopPresenceHeartbeat();

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -947,10 +947,18 @@ export class VoiceAgent {
       output =
         "On mobile you can't navigate the app during a live call — it would background the call and cut the mic. Do NOT navigate. Instead, tell the user in one short sentence exactly what to tap to get there themselves.";
     } else {
+      // start_thread navigates (spawn → threads.open) which backgrounds a live
+      // mobile call — tell the server not to focus so the thread still starts but
+      // nothing navigates. (The promptless start_thread is handled above.)
+      const suppressFocus =
+        name === "start_thread" &&
+        clientDescriptor.mobile &&
+        (this.state === "live" || this.state === "muted");
+      if (suppressFocus) this.logDiag("nav.suppressedFocus", { name });
       try {
         const result = await bindings.rpc.call("runTool", {
           name,
-          args,
+          args: suppressFocus ? { ...args, focus: false } : args,
           ...bindings.context,
         });
         output = result.output;

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -15,7 +15,7 @@ import {
   writeAudioDevicePreferences,
   type AudioDevicePreferences,
 } from "./audio-devices.ts";
-import { clientId, realmId, identityTag, clientDescriptor } from "./client-identity.ts";
+import { clientId, realmId, identityTag, clientDescriptor, deviceSummary } from "./client-identity.ts";
 
 export type VoiceState = "idle" | "connecting" | "live" | "muted";
 /** Who currently has the floor during a live call, for the "listening" UI. */
@@ -1005,7 +1005,7 @@ export class VoiceAgent {
     const nonce = crypto.randomUUID();
     this.nonce = nonce;
     this.setState("connecting");
-    this.log("session.started", { ...bindings.context });
+    this.log("session.started", { ...bindings.context, device: deviceSummary() });
     try {
       // Deterministic acquisition: enumerate what is actually present, resolve
       // the saved ids against it (a saved id whose salt rotated across restarts

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -426,6 +426,27 @@ export class VoiceAgent {
       .catch(() => undefined);
   }
 
+  /**
+   * End a call server-authoritatively, so it works even when the owner realm is
+   * a frozen/backgrounded mobile webview that can't receive commands — the fix
+   * for the navigation zombie. Fire-and-forget; cosmetic on failure.
+   */
+  private forceStop(nonce: string) {
+    const rpc = this.bindings?.rpc;
+    if (!rpc) return;
+    void rpc.call("forceStop", { nonce }).catch(() => undefined);
+  }
+
+  /** Stop a call we only mirror: force-stop on the server + drop the mirror now. */
+  private stopRemote(nonce: string) {
+    this.forceStop(nonce);
+    if (this.remotePresence?.nonce === nonce) {
+      this.remotePresence = null;
+      this.disarmRemoteExpiry();
+      this.emitChange();
+    }
+  }
+
   /** Apply a relayed command — but only if THIS realm owns that call. */
   applyVoiceCommand(payload: unknown) {
     const p = payload as { nonce?: unknown; action?: unknown } | null;
@@ -443,7 +464,7 @@ export class VoiceAgent {
   toggleFromSurface() {
     if (this.hasLocalCall()) return this.toggle();
     const remote = this.remotePresenceLive();
-    if (remote) return this.sendCommand(remote.nonce, "stop");
+    if (remote) return this.stopRemote(remote.nonce);
     void this.start();
   }
 
@@ -454,11 +475,11 @@ export class VoiceAgent {
     if (remote) this.sendCommand(remote.nonce, remote.phase === "muted" ? "unmute" : "mute");
   }
 
-  /** Stop from any surface. */
+  /** Stop from any surface — server-authoritative for a call we only mirror. */
   stopFromSurface() {
     if (this.hasLocalCall()) return this.stop();
     const remote = this.remotePresenceLive();
-    if (remote) this.sendCommand(remote.nonce, "stop");
+    if (remote) this.stopRemote(remote.nonce);
   }
 
   setAudioPreferences(next: AudioDevicePreferences) {
@@ -639,8 +660,19 @@ export class VoiceAgent {
   private attachMicLifecycle(session: SessionHandle, track: MediaStreamTrack) {
     track.onmute = () => {
       if (this.session !== session) return;
-      this.logDiag("mic.track.muted", {});
-      this.setMicSuspended(true);
+      const hidden = typeof document !== "undefined" && document.visibilityState === "hidden";
+      this.logDiag("mic.track.muted", { hidden });
+      if (hidden) {
+        // Backgrounded on mobile: the mic is gone and this realm is about to
+        // freeze. End cleanly NOW (while the handler still runs) and enforce it
+        // server-side, so it never becomes an unstoppable zombie.
+        this.logDiag("mic.suspend.teardown", {});
+        this.endBecauseSuspended();
+      } else {
+        // Mic muted while visible (another app grabbed it, glitch): try to heal.
+        this.setMicSuspended(true);
+        void this.recoverMicIfNeeded(session);
+      }
     };
     track.onunmute = () => {
       if (this.session !== session) return;
@@ -653,6 +685,19 @@ export class VoiceAgent {
       this.setMicSuspended(true);
       void this.recoverMicIfNeeded(session);
     };
+  }
+
+  /**
+   * End a call because the OS suspended its mic while backgrounded (mobile).
+   * Force-stops server-side FIRST (so the end survives even if this realm freezes
+   * a beat later), then tears down locally. This is the honest alternative to a
+   * silent one-way zombie: the call ends and every surface goes idle.
+   */
+  private endBecauseSuspended() {
+    const nonce = this.nonce;
+    toast.info("Aide: call ended — the app moved to the background");
+    if (nonce) this.forceStop(nonce);
+    this.stop();
   }
 
   /** On returning to the foreground, try to revive a suspended mic. */
@@ -872,6 +917,17 @@ export class VoiceAgent {
       bindings.openNewThread(projectId);
       output =
         "Opened the New thread screen with the project preselected. The user will type the prompt themselves; no thread exists yet.";
+    } else if (
+      (name === "focus_thread" || name === "set_pane") &&
+      clientDescriptor.mobile &&
+      (this.state === "live" || this.state === "muted")
+    ) {
+      // On mobile, navigating the app backgrounds the realm that owns this call
+      // and iOS suspends the mic — the call dies. So don't navigate during a live
+      // mobile call; have the model point the user to the tap target instead.
+      this.logDiag("nav.blocked", { name });
+      output =
+        "On mobile you can't navigate the app during a live call — it would background the call and cut the mic. Do NOT navigate. Instead, tell the user in one short sentence exactly what to tap to get there themselves.";
     } else {
       try {
         const result = await bindings.rpc.call("runTool", {

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -70,6 +70,12 @@ interface SessionHandle {
   stream: MediaStream;
   audio: HTMLAudioElement;
   dc: RTCDataChannel | null;
+  /** The live mic track feeding the pc; swapped in when iOS suspends the mic. */
+  micTrack: MediaStreamTrack | null;
+  /** The pc's audio sender, so a fresh mic track can replace a suspended one. */
+  micSender: RTCRtpSender | null;
+  /** Tears down the page/visibility listeners installed for this session. */
+  disposeLifecycle?: () => void;
 }
 
 /**
@@ -151,6 +157,12 @@ export class VoiceAgent {
   private connectTimer: ReturnType<typeof setTimeout> | null = null;
   /** When the call first went live (ms), for elapsed-duration UI; null if not. */
   private liveStartedAt: number | null = null;
+  /**
+   * True while the OS has suspended the mic (typically iOS backgrounding the
+   * owning realm). The uplink is dead until recovered — surfaced honestly rather
+   * than leaving the call looking "Connected" while Aide can't hear you.
+   */
+  private micSuspended = false;
   /** The most recent meaningful event, for the dock's live activity ticker. */
   private lastActivity: { kind: string; name: string; text: string } | null = null;
   /**
@@ -222,6 +234,20 @@ export class VoiceAgent {
     if (this.assistantSpeaking) return "aide";
     return "idle";
   };
+
+  /**
+   * True when THIS realm owns a call whose mic the OS has suspended — the
+   * uplink is down (Aide can't hear you) until it comes back to the foreground
+   * and recovers. Only meaningful for the owner; mirrors don't hold the mic.
+   */
+  readonly getMicSuspended = (): boolean =>
+    this.micSuspended && (this.state === "live" || this.state === "muted");
+
+  private setMicSuspended(value: boolean) {
+    if (this.micSuspended === value) return;
+    this.micSuspended = value;
+    this.emitChange();
+  }
 
   private setUserSpeaking(value: boolean) {
     if (this.userSpeaking === value) return;
@@ -550,11 +576,104 @@ export class VoiceAgent {
       .catch(() => undefined);
   }
 
+  // ---- audio lifecycle: keep inbound audio playing and the mic alive across
+  // navigation/backgrounding (see HF-2). Everything here is defensive; a browser
+  // without DOM (tests) simply skips the DOM/track wiring.
+
+  /** Inline playback + in-DOM element: the reliable iOS shape for WebRTC audio. */
+  private prepareAudioElement(audio: HTMLAudioElement) {
+    (audio as HTMLAudioElement & { playsInline?: boolean }).playsInline = true;
+    if (typeof document === "undefined") return;
+    try {
+      audio.setAttribute("playsinline", "");
+      audio.style.display = "none";
+      document.body.appendChild(audio);
+    } catch {
+      /* no DOM to attach to — inbound audio still plays via srcObject */
+    }
+  }
+
+  /**
+   * Watch a mic track for OS suspension. iOS mutes (and sometimes ends) the mic
+   * track when it backgrounds the owning realm; `enabled=false` from our own
+   * mute does NOT fire these, so `mute` here always means the source stopped.
+   */
+  private attachMicLifecycle(session: SessionHandle, track: MediaStreamTrack) {
+    track.onmute = () => {
+      if (this.session !== session) return;
+      this.logDiag("mic.track.muted", {});
+      this.setMicSuspended(true);
+    };
+    track.onunmute = () => {
+      if (this.session !== session) return;
+      this.logDiag("mic.track.unmuted", {});
+      this.setMicSuspended(false); // OS resumed the same track — uplink is back
+    };
+    track.onended = () => {
+      if (this.session !== session) return;
+      this.logDiag("mic.track.ended", {});
+      this.setMicSuspended(true);
+      void this.recoverMicIfNeeded(session);
+    };
+  }
+
+  /** On returning to the foreground, try to revive a suspended mic. */
+  private attachPageLifecycle(session: SessionHandle) {
+    if (typeof document === "undefined") return;
+    const onVisibility = () => {
+      if (this.session !== session) return;
+      this.logDiag("page.visibility", { state: document.visibilityState });
+      if (document.visibilityState === "visible") void this.recoverMicIfNeeded(session);
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    session.disposeLifecycle = () => document.removeEventListener("visibilitychange", onVisibility);
+  }
+
+  /**
+   * Replace a dead/suspended mic track with a fresh one, keeping the same pc and
+   * realtime session (replaceTrack needs no renegotiation). Only attempts in the
+   * foreground — iOS blocks getUserMedia while backgrounded. A no-op when the mic
+   * is already healthy.
+   */
+  private async recoverMicIfNeeded(session: SessionHandle) {
+    if (this.session !== session) return;
+    const sender = session.micSender;
+    const track = session.micTrack;
+    if (!sender) return;
+    if (track && track.readyState === "live" && !track.muted) {
+      this.setMicSuspended(false); // already healthy
+      return;
+    }
+    if (typeof document !== "undefined" && document.visibilityState !== "visible") return;
+    this.logDiag("mic.recover.attempt", { readyState: track?.readyState ?? null, muted: track?.muted ?? null });
+    try {
+      const fresh = await this.acquireMic(this.audioPreferences.inputDeviceId);
+      if (this.session !== session) {
+        for (const t of fresh.getTracks()) t.stop();
+        return;
+      }
+      const newTrack = fresh.getAudioTracks()[0];
+      if (!newTrack) throw new Error("no audio track");
+      newTrack.enabled = this.state !== "muted"; // preserve the user's mute
+      await sender.replaceTrack(newTrack);
+      session.micTrack?.stop();
+      session.micTrack = newTrack;
+      this.attachMicLifecycle(session, newTrack);
+      this.setMicSuspended(false);
+      this.logDiag("mic.recover.ok", {});
+    } catch (error) {
+      this.logDiag("mic.recover.failed", { name: error instanceof Error ? error.name : "unknown" });
+    }
+  }
+
   /** Mute = mic track sends silence; the call and playback stay up. */
   setMuted(muted: boolean) {
     const session = this.session;
     if (!session || (this.state !== "live" && this.state !== "muted")) return;
-    for (const track of session.stream.getAudioTracks()) track.enabled = !muted;
+    // Prefer the tracked mic track — recovery may have replaced it with one that
+    // is no longer part of the original getUserMedia stream.
+    if (session.micTrack) session.micTrack.enabled = !muted;
+    else for (const track of session.stream.getAudioTracks()) track.enabled = !muted;
     this.log(muted ? "muted" : "unmuted");
     this.setUserSpeaking(false); // a muted mic can't be mid-utterance
     this.setState(muted ? "muted" : "live");
@@ -657,10 +776,13 @@ export class VoiceAgent {
     if (this.noticeTimer) clearTimeout(this.noticeTimer);
     this.noticeTimer = null;
     this.setUserSpeaking(false);
+    this.setMicSuspended(false);
     if (session) {
+      session.disposeLifecycle?.();
       session.dc?.close();
       session.pc.close();
       for (const track of session.stream.getTracks()) track.stop();
+      session.micTrack?.stop(); // a recovered track lives outside stream
       session.audio.srcObject = null;
       session.audio.remove();
     }
@@ -795,7 +917,11 @@ export class VoiceAgent {
       const pc = new RTCPeerConnection();
       const audio = new Audio();
       audio.autoplay = true;
-      const session: SessionHandle = { pc, stream, audio, dc: null };
+      // iOS plays inline (not fullscreen) and is far more reliable across
+      // navigation/backgrounding when the element is actually in the DOM — a
+      // detached `new Audio()` can go silent. Hidden so it never shows.
+      this.prepareAudioElement(audio);
+      const session: SessionHandle = { pc, stream, audio, dc: null, micTrack: null, micSender: null };
       this.session = session;
       // Never stay "connecting" forever: if the data channel hasn't opened in
       // time, tear the attempt down and let the user retry cleanly.
@@ -810,6 +936,13 @@ export class VoiceAgent {
       if (this.session?.pc !== pc) return;
 
       for (const track of stream.getTracks()) pc.addTrack(track, stream);
+      // Track the mic sender + track so a suspended mic (iOS backgrounding) can
+      // be swapped for a fresh one via replaceTrack, no renegotiation needed.
+      session.micTrack = stream.getAudioTracks()[0] ?? null;
+      session.micSender =
+        pc.getSenders?.().find((sender) => sender.track?.kind === "audio") ?? null;
+      if (session.micTrack) this.attachMicLifecycle(session, session.micTrack);
+      this.attachPageLifecycle(session);
       pc.ontrack = (event) => {
         if (this.session?.pc !== pc) return; // torn down mid-negotiation
         audio.srcObject = event.streams[0] ?? new MediaStream([event.track]);

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -35,7 +35,12 @@ export interface Bindings {
     /** True when the user is on the New thread screen (no thread exists yet). */
     onNewThreadScreen: boolean;
   };
-  composer: ComposerBinding;
+  /**
+   * The composer to type into — present only when a composer surface is mounted
+   * (e.g. a thread view). Absent on surfaces like the Handsfree page, where the
+   * text tools report that no composer is focused rather than faking one.
+   */
+  composer?: ComposerBinding;
   openNewThread: (projectId: string | null) => void;
 }
 
@@ -162,6 +167,16 @@ export class VoiceAgent {
 
   bind(bindings: Bindings) {
     this.bindings = bindings;
+  }
+
+  /**
+   * Bind a surface only if nothing is bound yet. The Handsfree page uses this so
+   * a call can be started with no composer mounted (its FAB), without clobbering
+   * the richer binding a real composer installs — a live composer's text tools
+   * must keep targeting that composer, not the page's new-thread fallback.
+   */
+  bindFallback(bindings: Bindings) {
+    if (!this.bindings) this.bindings = bindings;
   }
 
   private setState(next: VoiceState) {
@@ -436,12 +451,20 @@ export class VoiceAgent {
     if (!bindings) {
       output = "Tool error: no bb surface is bound right now.";
     } else if (name === "set_composer_text") {
-      bindings.composer.setText(String(args.text ?? ""));
-      output = "Composer text replaced.";
+      if (!bindings.composer) {
+        output = "No composer is focused right now — open or start a thread to draft a message.";
+      } else {
+        bindings.composer.setText(String(args.text ?? ""));
+        output = "Composer text replaced.";
+      }
     } else if (name === "append_composer_text") {
-      const text = String(args.text ?? "");
-      bindings.composer.updateText((current) => (current ? `${current}\n${text}` : text));
-      output = "Text appended to composer.";
+      if (!bindings.composer) {
+        output = "No composer is focused right now — open or start a thread to draft a message.";
+      } else {
+        const text = String(args.text ?? "");
+        bindings.composer.updateText((current) => (current ? `${current}\n${text}` : text));
+        output = "Text appended to composer.";
+      }
     } else if (
       name === "start_thread" &&
       !(typeof args.prompt === "string" && args.prompt.trim())

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -38,6 +38,17 @@ interface RemotePresence {
   ownerRealm?: string;
 }
 
+/**
+ * Tools measured to background the owner realm on mobile (→ iOS suspends the mic
+ * → the call dies), so they're refused during a live mobile call. Verified on
+ * 2026-09-01: `focus_thread` backgrounds the app; `set_pane` and `start_thread`
+ * do NOT. This is the correctness-optimization list; if a new/other tool ever
+ * backgrounds us anyway, `mic.suspend.teardown {cause}` names it in the logs and
+ * the call still ends cleanly — so this list can stay small and be extended from
+ * evidence, not guesswork.
+ */
+const MOBILE_NAV_TOOLS = new Set(["focus_thread"]);
+
 /** A mirror is stale (owner realm likely gone) after two missed heartbeats. */
 const PRESENCE_STALE_MS = 25_000;
 /** How often the owning realm re-announces a live call, for the mirror above. */
@@ -181,6 +192,8 @@ export class VoiceAgent {
   private remoteExpiryTimer: ReturnType<typeof setInterval> | null = null;
   /** Guards the once-per-realm `client.hello` observability record. */
   private helloed = false;
+  /** The most recent tool call, so a suspend/teardown can name its likely cause. */
+  private lastTool: { name: string; at: number } | null = null;
 
   readonly subscribe = (listener: () => void): (() => void) => {
     this.listeners.add(listener);
@@ -661,12 +674,16 @@ export class VoiceAgent {
     track.onmute = () => {
       if (this.session !== session) return;
       const hidden = typeof document !== "undefined" && document.visibilityState === "hidden";
-      this.logDiag("mic.track.muted", { hidden });
+      // Name the tool that ran just before this, so a suspension caused by a
+      // navigation tool we haven't classified yet is self-reporting in the logs.
+      const cause =
+        this.lastTool && Date.now() - this.lastTool.at < 4000 ? this.lastTool.name : null;
+      this.logDiag("mic.track.muted", { hidden, cause });
       if (hidden) {
         // Backgrounded on mobile: the mic is gone and this realm is about to
         // freeze. End cleanly NOW (while the handler still runs) and enforce it
         // server-side, so it never becomes an unstoppable zombie.
-        this.logDiag("mic.suspend.teardown", {});
+        this.logDiag("mic.suspend.teardown", { cause });
         this.endBecauseSuspended();
       } else {
         // Mic muted while visible (another app grabbed it, glitch): try to heal.
@@ -886,6 +903,7 @@ export class VoiceAgent {
       /* keep {} */
     }
     this.log("tool.call", { name, args });
+    this.lastTool = { name, at: Date.now() };
     let output: string;
     if (!bindings) {
       output = "Tool error: no bb surface is bound right now.";
@@ -918,13 +936,13 @@ export class VoiceAgent {
       output =
         "Opened the New thread screen with the project preselected. The user will type the prompt themselves; no thread exists yet.";
     } else if (
-      (name === "focus_thread" || name === "set_pane") &&
+      MOBILE_NAV_TOOLS.has(name) &&
       clientDescriptor.mobile &&
       (this.state === "live" || this.state === "muted")
     ) {
-      // On mobile, navigating the app backgrounds the realm that owns this call
-      // and iOS suspends the mic — the call dies. So don't navigate during a live
-      // mobile call; have the model point the user to the tap target instead.
+      // On mobile, this tool backgrounds the realm that owns the call and iOS
+      // suspends the mic — the call dies. So don't run it during a live mobile
+      // call; have the model point the user to the tap target instead.
       this.logDiag("nav.blocked", { name });
       output =
         "On mobile you can't navigate the app during a live call — it would background the call and cut the mic. Do NOT navigate. Instead, tell the user in one short sentence exactly what to tap to get there themselves.";

--- a/voice-chrome.tsx
+++ b/voice-chrome.tsx
@@ -1,0 +1,63 @@
+// Shared voice-call chrome: the waveform/mic/stop icons and the live-duration
+// ticker, used by both the composer button (app.tsx) and the on-page call
+// console (sessions-panel.tsx) so every surface speaks the same visual
+// language — neutral chrome, activity color only on the waveform.
+import { useEffect, useState, useSyncExternalStore } from "react";
+import { voiceAgent } from "./voice-agent";
+import { cn } from "@/lib/utils";
+
+export function WaveformIcon({ live }: { live: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      className={cn("size-4", live && "aide-wave-live")}
+      fill="currentColor"
+      aria-hidden
+    >
+      <rect className="aide-bar" x="1.5" y="6" width="1.8" height="4" rx="0.9" />
+      <rect className="aide-bar" x="4.9" y="3.5" width="1.8" height="9" rx="0.9" />
+      <rect className="aide-bar" x="8.3" y="1.5" width="1.8" height="13" rx="0.9" />
+      <rect className="aide-bar" x="11.7" y="4.5" width="1.8" height="7" rx="0.9" />
+    </svg>
+  );
+}
+
+export function MicIcon({ slashed }: { slashed: boolean }) {
+  return (
+    <svg viewBox="0 0 16 16" className="size-4" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" aria-hidden>
+      <rect x="6" y="1.8" width="4" height="7" rx="2" fill="currentColor" stroke="none" />
+      <path d="M3.5 7.5a4.5 4.5 0 0 0 9 0" />
+      <path d="M8 12v2.2" />
+      {slashed ? <path d="M2.5 2.5l11 11" strokeWidth="1.6" /> : null}
+    </svg>
+  );
+}
+
+/** A rounded stop square — ends the voice session. */
+export function StopIcon() {
+  return (
+    <svg viewBox="0 0 16 16" className="size-3.5" fill="currentColor" aria-hidden>
+      <rect x="4" y="4" width="8" height="8" rx="1.6" />
+    </svg>
+  );
+}
+
+export function formatElapsed(ms: number): string {
+  const total = Math.floor(Math.max(0, ms) / 1000);
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+/** Live call duration as m:ss, ticking each second; null when no live call. */
+export function useCallElapsed(): string | null {
+  const startedAt = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getLiveStartedAt);
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (startedAt == null) return;
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [startedAt]);
+  return startedAt == null ? null : formatElapsed(now - startedAt);
+}


### PR DESCRIPTION
## Overview

Two things in one branch (the second builds on the first):

1. **Redesign** the Handsfree page into a self-contained place to **talk, watch, and review** — an on-page call console, a narrated transcript, and a scannable session list.
2. **Voice reliability** — make a call's state and control work across every surface (composer, sidebar, page) and survive mobile: no more silent one-way "zombie" calls after the agent navigates, honest teardown when iOS backgrounds the app, and a stop that always works.

Plus lightweight client/device observability that made the mobile bugs diagnosable.

_Supersedes #10 (contains its commits)._

## The redesign

- **On-page call console** — idle "Talk to Aide" pill → live mute · who's-speaking + duration · stop, with an activity ticker that doubles as a "See full transcript" entry point. The page binds the agent itself (only when nothing richer is bound), so a call no longer needs a composer mounted.
- **Narrated transcript** — speaker rows with per-speaker tint, tool calls as readable action chips (icon + verb + argument, result one tap away), plugin commands with the real plugin name/icon, connection/audio diagnostics collapsed, and a conversation/actions/errors filter.
- **Scannable session list** — preview-forward rows, small live/error indicators, "Load more".
- **Honesty touches** — no silent fallbacks; where there's no composer to type into, the agent says so.

## Voice reliability (cross-surface + mobile)

- **Cross-surface state** — every surface mirrors the one live call (state, duration) and can mute/stop it, over a server-mediated presence/command bus. Stale mirrors expire, so nothing shows a ghost "live".
- **Mobile audio-lifecycle** — iOS suspends the mic when the owning webview is backgrounded. So during a mobile call the agent doesn't navigate away (`focus_thread` is refused with "tap here"; `start_thread` starts the thread *without* navigating), and if the app is backgrounded anyway the call **ends cleanly and server-authoritatively** — a dead call reads as ended, never a silent zombie you can't stop.
- **Observability** — minted client/realm ids + a device descriptor stamped on events, so any surface's actions are attributable and a mis-classified navigating tool self-reports.

Full technical detail — terminology, the realm/WebRTC model, and every scenario:
- [docs/handsfree-voice-architecture.md](docs/handsfree-voice-architecture.md)
- [docs/handsfree-voice-scenarios.md](docs/handsfree-voice-scenarios.md)

## Testing

- **Unit:** `npm test` (voice-agent + audio-devices), `npm run typecheck` — clean.
- **Device:** verified on desktop (Electron) and iOS (native app + bb-connect) — cross-surface mirror, control from other surfaces, `focus_thread` gating, `start_thread`-without-navigate, background teardown, and never-stuck stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)