### PR TITLE
Fix voice controls on iOS PWA

### DIFF
--- a/app.tsx
+++ b/app.tsx
@@ -132,6 +132,7 @@ function AideVoiceButton() {
           type="button"
           aria-label={muted ? "Unmute Aide microphone" : "Mute Aide microphone"}
           title={muted ? "Unmute" : "Mute"}
+          onPointerDown={(event) => event.button === 0 && event.preventDefault()}
           onClick={() => voiceAgent.toggleMuteFromSurface()}
           className={cn(
             "flex size-7 items-center justify-center transition-colors",
@@ -166,6 +167,7 @@ function AideVoiceButton() {
           type="button"
           aria-label="Stop Aide voice session"
           title="Stop"
+          onPointerDown={(event) => event.button === 0 && event.preventDefault()}
           onClick={() => voiceAgent.stopFromSurface()}
           className="flex size-7 items-center justify-center text-muted-foreground transition-colors hover:bg-destructive/15 hover:text-destructive"
         >
@@ -180,6 +182,7 @@ function AideVoiceButton() {
       type="button"
       aria-label="Start Aide voice agent"
       title="Talk to Aide"
+      onPointerDown={(event) => event.button === 0 && event.preventDefault()}
       onClick={() => voiceAgent.toggleFromSurface()}
       className={cn(
         "flex size-7 shrink-0 items-center justify-center rounded-full border transition-colors",


### PR DESCRIPTION
## Summary

- preserve composer focus on primary pointer down for the Handsfree start, stop, and mute controls
- match bb native voice-input button behavior so taps are not swallowed by the focused composer on iOS PWA

Fixes #20.

## Verification

- npm test (24 tests passed)
- npm run typecheck
- bb plugin build .
- live iOS PWA test reached session.started and session.live after the patched frontend was reloaded

Before this change, tapping the waveform button while the iOS keyboard/composer was focused produced no session event.