### PR TITLE
[spike] Production companion mode: threads and browser

### DIFF
--- a/app.tsx
+++ b/app.tsx
@@ -19,6 +19,7 @@ import type { PluginThreadListProps } from "@get-bb/plugin-sdk/app";
 import type { rpcContract } from "./server";
 import { voiceAgent } from "./voice-agent";
 import { SessionsPanel } from "./sessions-panel";
+import { COMPANION_TAB, CompanionTab } from "./companion";
 import { AudioSettings, BehaviorSettings, ModelsSettings } from "./settings-sections";
 import { cn } from "@/lib/utils";
 import { AUDIO_DEVICE_STORAGE_KEY } from "./audio-devices";
@@ -331,6 +332,16 @@ export default definePluginApp((app) => {
     path: "sessions",
     component: SessionsPanel,
     experimental_sidebarAccessory: SidebarLiveIndicator,
+    // Prototype: a companion split pane that shows a bb thread beside the page.
+    fixedTabs: [
+      {
+        ...COMPANION_TAB,
+        title: "Companion",
+        icon: "PanelRight",
+        component: CompanionTab,
+        layout: "flush",
+      },
+    ],
   });
   // --- Global surface trial: multiple always-reachable triggers for the same
   // singleton call. All are pure toggles; the composer button owns the binding.

--- a/app.tsx
+++ b/app.tsx
@@ -10,6 +10,7 @@ import {
   definePluginApp,
   experimental_useSidebarThreadActions,
   useBbContext,
+  useBbNavigate,
   useComposer,
   useComposerView,
   useRealtime,
@@ -64,6 +65,12 @@ function AideVoiceButton() {
   // Catch up immediately when this surface mounts (e.g. a realm rebuilt after
   // navigation), rather than waiting up to a heartbeat to learn a call is live.
   useEffect(() => voiceAgent.requestPresence(), []);
+
+  // Let the agent open URLs in the bb browser (works from any surface).
+  const navigate = useBbNavigate();
+  useEffect(() => {
+    voiceAgent.setUrlOpener((url) => navigate.openUrl(url));
+  }, [navigate]);
 
   // Thread-event notifications (digested; disabled via `notifications` setting).
   useRealtime("aide-thread-event", (payload) => {

--- a/companion.tsx
+++ b/companion.tsx
@@ -1,0 +1,91 @@
+// Prototype: a "companion" split pane for the Handsfree page.
+//
+// The Handsfree nav panel declares a fixed tab (COMPANION_TAB) that the host
+// renders in its right split pane. From the page we call
+// experimental_useAppPanel().openFixedTab(...) with a { threadId } target; the
+// tab reads that target and shows the thread via <ThreadChat>. Re-targeting with
+// a different threadId swaps which thread is shown — the thing we're testing:
+// can the plugin open a second pane and drive its content.
+//
+// Everything here is experimental_ SDK surface (fixedTabs / useAppPanel /
+// useFixedTabTarget) — treat as a spike, expect it to move.
+import { useState } from "react";
+import {
+  ThreadChat,
+  experimental_useAppPanel,
+  experimental_useFixedTabTarget,
+  experimental_useSidebarThreads,
+} from "@get-bb/plugin-sdk/app";
+import type { ExperimentalPluginFixedTabReference, JsonValue, PluginNavPanelProps } from "@get-bb/plugin-sdk/app";
+import { cn } from "@/lib/utils";
+
+// Must be JSON-serializable for the host, hence the index signature.
+interface CompanionTarget {
+  threadId: string;
+  [key: string]: JsonValue;
+}
+
+function isCompanionTarget(value: unknown): value is CompanionTarget {
+  return !!value && typeof value === "object" && typeof (value as { threadId?: unknown }).threadId === "string";
+}
+
+/** Shared reference: used both to register the tab (app.tsx) and to open/target it. */
+export const COMPANION_TAB: ExperimentalPluginFixedTabReference<CompanionTarget> = {
+  panelId: "sessions",
+  id: "companion",
+  experimental_target: {
+    validate: (value): value is CompanionTarget => isCompanionTarget(value),
+  },
+};
+
+/** The right-pane component. Shows the targeted thread, or a hint when untargeted. */
+export function CompanionTab(_props: PluginNavPanelProps) {
+  const state = experimental_useFixedTabTarget(COMPANION_TAB);
+  const threadId = state?.target.threadId ?? null;
+  if (!threadId) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-center text-sm text-muted-foreground">
+        Pick a thread on the Handsfree page to show it here.
+      </div>
+    );
+  }
+  return <ThreadChat threadId={threadId} variant="compact" layout="contained" />;
+}
+
+/**
+ * Controls rendered on the Handsfree page: pick a thread to open in the companion
+ * pane. Selecting a different one re-targets (swaps) the same pane.
+ */
+export function CompanionControls({ className }: { className?: string }) {
+  const appPanel = experimental_useAppPanel();
+  const { threads, status } = experimental_useSidebarThreads();
+  const [selected, setSelected] = useState("");
+
+  if (status !== "ready" || threads.length === 0) return null;
+
+  const openThread = (threadId: string) => {
+    setSelected(threadId);
+    // surface: "current" = the panel we're in (the Handsfree page).
+    appPanel.openFixedTab({ surface: { kind: "current" }, tab: COMPANION_TAB, target: { threadId } });
+  };
+
+  return (
+    <div className={cn("flex items-center gap-2 text-xs text-muted-foreground", className)}>
+      <span className="shrink-0">Companion pane (experimental):</span>
+      <select
+        value={selected}
+        onChange={(event) => {
+          if (event.target.value) openThread(event.target.value);
+        }}
+        className="min-w-0 flex-1 rounded-md border border-border bg-card px-2 py-1 text-foreground"
+      >
+        <option value="">Pick a thread to show on the right…</option>
+        {threads.slice(0, 40).map((thread) => (
+          <option key={thread.id} value={thread.id}>
+            {thread.title ?? thread.titleFallback ?? "Untitled thread"}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/server.ts
+++ b/server.ts
@@ -382,6 +382,7 @@ function toolSchemas(pluginCommands: PluginCommandInfo[] = []) {
     // Handled locally in the bb app frontend, never reaches runTool:
     { type: "function", name: "set_composer_text", description: "Replace the text in the user's message composer (the box they type prompts into).", parameters: { type: "object", properties: { text: { type: "string" } }, required: ["text"] } },
     { type: "function", name: "append_composer_text", description: "Append text to the user's message composer.", parameters: { type: "object", properties: { text: { type: "string" } }, required: ["text"] } },
+    { type: "function", name: "show_thread", description: "Show a thread in the companion pane beside the conversation, WITHOUT navigating away — this keeps the voice call alive. Prefer this over focus_thread when the user wants to see a thread during a live call.", parameters: { type: "object", properties: { thread_id: { type: "string" } }, required: ["thread_id"] } },
   ];
 }
 
@@ -1144,7 +1145,7 @@ export default async function plugin(bb: BbPluginApi) {
       return { sdp: text };
     },
     async getTools() {
-      const local = new Set(["set_composer_text", "append_composer_text"]);
+      const local = new Set(["set_composer_text", "append_composer_text", "show_thread"]);
       const pluginCommands = await exposedPluginCommands();
       return {
         tools: toolSchemas(pluginCommands).map((tool) => ({

--- a/server.ts
+++ b/server.ts
@@ -1049,10 +1049,17 @@ export default async function plugin(bb: BbPluginApi) {
           rows: 30,
           scope,
           title,
-          start: command
-            ? { mode: "command", command }
-            : { mode: "shell" },
+          // Keep a shell behind one-shot commands so their output remains in a
+          // visible companion tab instead of the PTY exiting (and bb removing
+          // the tab) immediately after `pwd`, `git status`, etc. finish.
+          start: { mode: "shell" },
         });
+        if (command) {
+          await bb.sdk.terminals.input({
+            terminalId: terminal.id,
+            dataBase64: Buffer.from(`${command}\n`, "utf8").toString("base64"),
+          });
+        }
         // The terminal itself is durable server state. This signal is only the
         // client-local reveal intent: whichever Handsfree page is mounted asks
         // bb to add the existing session to its native companion tab strip.

--- a/server.ts
+++ b/server.ts
@@ -398,6 +398,7 @@ function toolSchemas(pluginCommands: PluginCommandInfo[] = []) {
     { type: "function", name: "set_composer_text", description: "Replace the text in the user's message composer (the box they type prompts into).", parameters: { type: "object", properties: { text: { type: "string" } }, required: ["text"] } },
     { type: "function", name: "append_composer_text", description: "Append text to the user's message composer.", parameters: { type: "object", properties: { text: { type: "string" } }, required: ["text"] } },
     { type: "function", name: "show_thread", description: "Show a thread in the companion pane beside the conversation, WITHOUT navigating away — this keeps the voice call alive. Prefer this over focus_thread when the user wants to see a thread during a live call.", parameters: { type: "object", properties: { thread_id: { type: "string" } }, required: ["thread_id"] } },
+    { type: "function", name: "open_url", description: "Open an http(s) URL in the bb browser — e.g. a pull request, an issue, or docs the user asks to see. Only use a real, complete URL.", parameters: { type: "object", properties: { url: { type: "string" } }, required: ["url"] } },
   ];
 }
 
@@ -1160,7 +1161,7 @@ export default async function plugin(bb: BbPluginApi) {
       return { sdp: text };
     },
     async getTools() {
-      const local = new Set(["set_composer_text", "append_composer_text", "show_thread"]);
+      const local = new Set(["set_composer_text", "append_composer_text", "show_thread", "open_url"]);
       const pluginCommands = await exposedPluginCommands();
       return {
         tools: toolSchemas(pluginCommands).map((tool) => ({

--- a/server.ts
+++ b/server.ts
@@ -223,6 +223,21 @@ export const rpcContract = defineRpcContract({
     output: z.object({ ok: z.literal(true) }).strict(),
   },
   /**
+   * Relay a "show this thread in the companion pane" request to whichever realm
+   * has the Handsfree page mounted (the call may be owned by a composer realm
+   * that has no pane of its own).
+   */
+  sendCompanion: {
+    input: z
+      .object({
+        threadId: z.string().min(1),
+        client: z.string().optional(),
+        realm: z.string().optional(),
+      })
+      .strict(),
+    output: z.object({ ok: z.literal(true) }).strict(),
+  },
+  /**
    * End a call authoritatively, without needing its owner realm to act — the
    * owner may be a frozen, backgrounded mobile webview that can no longer receive
    * commands. Marks the session stopped (so the list stops showing it live) and
@@ -1256,6 +1271,10 @@ export default async function plugin(bb: BbPluginApi) {
     },
     async sendVoiceCommand({ nonce, action, client, realm }) {
       bb.realtime.publish("voice-command", { nonce, action, client, realm });
+      return { ok: true as const };
+    },
+    async sendCompanion({ threadId, client, realm }) {
+      bb.realtime.publish("voice-companion", { threadId, client, realm });
       return { ok: true as const };
     },
     async forceStop({ nonce }) {

--- a/server.ts
+++ b/server.ts
@@ -393,6 +393,7 @@ function toolSchemas(pluginCommands: PluginCommandInfo[] = []) {
     { type: "function", name: "archive_thread", description: "Archive a thread (and its children).", parameters: { type: "object", properties: { thread_id: { type: "string" } }, required: ["thread_id"] } },
     { type: "function", name: "rename_thread", description: "Rename a thread.", parameters: { type: "object", properties: { thread_id: { type: "string" }, title: { type: "string" } }, required: ["thread_id", "title"] } },
     { type: "function", name: "show_diff", description: "Summarize a thread's workspace diff (changed files, additions/deletions) and focus the thread so the user can see it.", parameters: { type: "object", properties: { thread_id: { type: "string" } }, required: ["thread_id"] } },
+    { type: "function", name: "open_terminal", description: "Open a real bb terminal in the companion panel, optionally starting a command the user explicitly requested. Scope it to a thread when possible; otherwise pass a machine id from list_machines. Never invent a shell command or use this for destructive/elevated work without the user's explicit confirmation.", parameters: { type: "object", properties: { thread_id: { type: "string", description: "Thread whose workspace the terminal should use. Defaults to the current thread when one is in view." }, machine_id: { type: "string", description: "Machine id for a home-directory terminal when there is no thread. Use list_machines first." }, command: { type: "string", description: "Optional shell command the user explicitly asked to run. Omit for an interactive shell." }, title: { type: "string", description: "Optional short terminal tab title." } } } },
     { type: "function", name: "update_instructions", description: "Amend your own standing instructions (the system prompt for future voice sessions). Pass the COMPLETE new instructions text, not a diff. Use only when the user asks for a lasting behavior change.", parameters: { type: "object", properties: { instructions: { type: "string", description: "The full replacement instructions." }, reason: { type: "string", description: "One short sentence: why, quoting the user's request." } }, required: ["instructions", "reason"] } },
     // Handled locally in the bb app frontend, never reaches runTool:
     { type: "function", name: "set_composer_text", description: "Replace the text in the user's message composer (the box they type prompts into).", parameters: { type: "object", properties: { text: { type: "string" } }, required: ["text"] } },
@@ -404,12 +405,13 @@ function toolSchemas(pluginCommands: PluginCommandInfo[] = []) {
 
 const DEFAULT_PROMPT = `You are Aide, a concise voice operator for bb — the user's agentic IDE where coding agents run in threads inside projects.
 
-The user talks to you to drive bb hands-free. You can list/search/read threads, focus them on screen, spotlight or maximize panes, send messages to agent threads, start new threads, stop or archive threads, summarize diffs, and edit the user's prompt composer.
+The user talks to you to drive bb hands-free. You can list/search/read threads, focus them on screen, spotlight or maximize panes, send messages to agent threads, start new threads, stop or archive threads, summarize diffs, open browser pages, open terminals, and edit the user's prompt composer.
 
 Rules:
 - Be extremely succinct. One short sentence by default ("Done.", "Focused.", "Sent."). Never narrate what you're about to do, never enumerate options, never restate the user's request. Add detail only when asked.
 - Thread ids look like thr_x… and project ids like proj_x…. When the user names a thread by topic or title, find it with list_threads or search_threads first.
 - Never invent prompts, titles, or messages on the user's behalf. If required information is missing, ask one short question.
+- Never invent a shell command. Run only the command the user explicitly requested; ask for explicit confirmation before destructive or elevated commands.
 - When reading agent output aloud, give a one-or-two-sentence summary; never read code or ids verbatim.
 - Prefer focus_thread so the user sees what you are talking about.
 - Threads run on a machine. start_thread uses the project's default machine unless you pass machine_id — when the project is on several connected machines and the user didn't name one, use list_machines and ask one short question (e.g. "On your MacBook or the studio?") before starting.
@@ -1016,6 +1018,54 @@ export default async function plugin(bb: BbPluginApi) {
         if (diff.outcome !== "available") return `Diff not available (${diff.outcome}).`;
         const files = diff.files.map((f) => ({ path: f.path, additions: f.additions, deletions: f.deletions }));
         return JSON.stringify({ shortstat: diff.shortstat, files: files.slice(0, 50) });
+      }
+      case "open_terminal": {
+        const threadId =
+          typeof args.thread_id === "string" && args.thread_id
+            ? args.thread_id
+            : context.threadId;
+        const machineId =
+          typeof args.machine_id === "string" && args.machine_id
+            ? args.machine_id
+            : null;
+        if (!threadId && !machineId) {
+          return "No thread or machine is selected. Find a thread, or call list_machines and ask which machine to use.";
+        }
+        const scope = threadId
+          ? ({ kind: "thread", threadId } as const)
+          : ({ kind: "host_path", hostId: machineId!, cwd: null } as const);
+        const command =
+          typeof args.command === "string" && args.command.trim()
+            ? args.command.trim()
+            : null;
+        const title =
+          typeof args.title === "string" && args.title.trim()
+            ? args.title.trim().slice(0, 120)
+            : command
+              ? command.slice(0, 80)
+              : "Terminal";
+        const terminal = await bb.sdk.terminals.create({
+          cols: 100,
+          rows: 30,
+          scope,
+          title,
+          start: command
+            ? { mode: "command", command }
+            : { mode: "shell" },
+        });
+        // The terminal itself is durable server state. This signal is only the
+        // client-local reveal intent: whichever Handsfree page is mounted asks
+        // bb to add the existing session to its native companion tab strip.
+        bb.realtime.publish("voice-terminal", {
+          terminalId: terminal.id,
+          target: scope,
+        });
+        return JSON.stringify({
+          terminalId: terminal.id,
+          title: terminal.title,
+          status: terminal.status,
+          commandStarted: command !== null,
+        });
       }
       default:
         return `Unknown tool: ${name}`;

--- a/server.ts
+++ b/server.ts
@@ -393,7 +393,6 @@ function toolSchemas(pluginCommands: PluginCommandInfo[] = []) {
     { type: "function", name: "archive_thread", description: "Archive a thread (and its children).", parameters: { type: "object", properties: { thread_id: { type: "string" } }, required: ["thread_id"] } },
     { type: "function", name: "rename_thread", description: "Rename a thread.", parameters: { type: "object", properties: { thread_id: { type: "string" }, title: { type: "string" } }, required: ["thread_id", "title"] } },
     { type: "function", name: "show_diff", description: "Summarize a thread's workspace diff (changed files, additions/deletions) and focus the thread so the user can see it.", parameters: { type: "object", properties: { thread_id: { type: "string" } }, required: ["thread_id"] } },
-    { type: "function", name: "open_terminal", description: "Open a real bb terminal in the companion panel, optionally starting a command the user explicitly requested. Scope it to a thread when possible; otherwise pass a machine id from list_machines. Never invent a shell command or use this for destructive/elevated work without the user's explicit confirmation.", parameters: { type: "object", properties: { thread_id: { type: "string", description: "Thread whose workspace the terminal should use. Defaults to the current thread when one is in view." }, machine_id: { type: "string", description: "Machine id for a home-directory terminal when there is no thread. Use list_machines first." }, command: { type: "string", description: "Optional shell command the user explicitly asked to run. Omit for an interactive shell." }, title: { type: "string", description: "Optional short terminal tab title." } } } },
     { type: "function", name: "update_instructions", description: "Amend your own standing instructions (the system prompt for future voice sessions). Pass the COMPLETE new instructions text, not a diff. Use only when the user asks for a lasting behavior change.", parameters: { type: "object", properties: { instructions: { type: "string", description: "The full replacement instructions." }, reason: { type: "string", description: "One short sentence: why, quoting the user's request." } }, required: ["instructions", "reason"] } },
     // Handled locally in the bb app frontend, never reaches runTool:
     { type: "function", name: "set_composer_text", description: "Replace the text in the user's message composer (the box they type prompts into).", parameters: { type: "object", properties: { text: { type: "string" } }, required: ["text"] } },
@@ -405,13 +404,12 @@ function toolSchemas(pluginCommands: PluginCommandInfo[] = []) {
 
 const DEFAULT_PROMPT = `You are Aide, a concise voice operator for bb — the user's agentic IDE where coding agents run in threads inside projects.
 
-The user talks to you to drive bb hands-free. You can list/search/read threads, focus them on screen, spotlight or maximize panes, send messages to agent threads, start new threads, stop or archive threads, summarize diffs, open browser pages, open terminals, and edit the user's prompt composer.
+The user talks to you to drive bb hands-free. You can list/search/read threads, focus them on screen, spotlight or maximize panes, send messages to agent threads, start new threads, stop or archive threads, summarize diffs, open browser pages, and edit the user's prompt composer.
 
 Rules:
 - Be extremely succinct. One short sentence by default ("Done.", "Focused.", "Sent."). Never narrate what you're about to do, never enumerate options, never restate the user's request. Add detail only when asked.
 - Thread ids look like thr_x… and project ids like proj_x…. When the user names a thread by topic or title, find it with list_threads or search_threads first.
 - Never invent prompts, titles, or messages on the user's behalf. If required information is missing, ask one short question.
-- Never invent a shell command. Run only the command the user explicitly requested; ask for explicit confirmation before destructive or elevated commands.
 - When reading agent output aloud, give a one-or-two-sentence summary; never read code or ids verbatim.
 - Prefer focus_thread so the user sees what you are talking about.
 - Threads run on a machine. start_thread uses the project's default machine unless you pass machine_id — when the project is on several connected machines and the user didn't name one, use list_machines and ask one short question (e.g. "On your MacBook or the studio?") before starting.
@@ -1018,61 +1016,6 @@ export default async function plugin(bb: BbPluginApi) {
         if (diff.outcome !== "available") return `Diff not available (${diff.outcome}).`;
         const files = diff.files.map((f) => ({ path: f.path, additions: f.additions, deletions: f.deletions }));
         return JSON.stringify({ shortstat: diff.shortstat, files: files.slice(0, 50) });
-      }
-      case "open_terminal": {
-        const threadId =
-          typeof args.thread_id === "string" && args.thread_id
-            ? args.thread_id
-            : context.threadId;
-        const machineId =
-          typeof args.machine_id === "string" && args.machine_id
-            ? args.machine_id
-            : null;
-        if (!threadId && !machineId) {
-          return "No thread or machine is selected. Find a thread, or call list_machines and ask which machine to use.";
-        }
-        const scope = threadId
-          ? ({ kind: "thread", threadId } as const)
-          : ({ kind: "host_path", hostId: machineId!, cwd: null } as const);
-        const command =
-          typeof args.command === "string" && args.command.trim()
-            ? args.command.trim()
-            : null;
-        const title =
-          typeof args.title === "string" && args.title.trim()
-            ? args.title.trim().slice(0, 120)
-            : command
-              ? command.slice(0, 80)
-              : "Terminal";
-        const terminal = await bb.sdk.terminals.create({
-          cols: 100,
-          rows: 30,
-          scope,
-          title,
-          // Keep a shell behind one-shot commands so their output remains in a
-          // visible companion tab instead of the PTY exiting (and bb removing
-          // the tab) immediately after `pwd`, `git status`, etc. finish.
-          start: { mode: "shell" },
-        });
-        if (command) {
-          await bb.sdk.terminals.input({
-            terminalId: terminal.id,
-            dataBase64: Buffer.from(`${command}\n`, "utf8").toString("base64"),
-          });
-        }
-        // The terminal itself is durable server state. This signal is only the
-        // client-local reveal intent: whichever Handsfree page is mounted asks
-        // bb to add the existing session to its native companion tab strip.
-        bb.realtime.publish("voice-terminal", {
-          terminalId: terminal.id,
-          target: scope,
-        });
-        return JSON.stringify({
-          terminalId: terminal.id,
-          title: terminal.title,
-          status: terminal.status,
-          commandStarted: command !== null,
-        });
       }
       default:
         return `Unknown tool: ${name}`;

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -652,11 +652,20 @@ export function SessionsPanel() {
           ...(targetProjectId ? { projectId: targetProjectId } : {}),
           focusPrompt: true,
         }),
-      // Let the agent show a thread in the companion split pane (no navigation).
-      openCompanionThread: (id) =>
-        appPanel.openFixedTab({ surface: { kind: "current" }, tab: COMPANION_TAB, target: { threadId: id } }),
     });
-  }, [rpc, threadId, projectId, sidebarActions, appPanel]);
+  }, [rpc, threadId, projectId, sidebarActions]);
+
+  // Register the companion-pane opener OUTSIDE the voice binding, so a composer's
+  // bind() (which replaces the whole bindings object) can't clobber it. The agent's
+  // show_thread runs in whichever realm owns the call and relays over
+  // voice-companion; the realm with the page mounted (this one) opens the pane.
+  useEffect(() => {
+    voiceAgent.setCompanionOpener((id) =>
+      appPanel.openFixedTab({ surface: { kind: "current" }, tab: COMPANION_TAB, target: { threadId: id } }),
+    );
+    return () => voiceAgent.setCompanionOpener(null);
+  }, [appPanel]);
+  useRealtime("voice-companion", (payload) => voiceAgent.applyCompanion(payload));
   const [sessions, setSessions] = useState<SessionRow[] | null>(null);
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -14,6 +14,7 @@ import {
 import type { rpcContract } from "./server";
 import { voiceAgent } from "./voice-agent";
 import { MicIcon, StopIcon, WaveformIcon, useCallElapsed } from "./voice-chrome";
+import { CompanionControls } from "./companion";
 import { cn } from "@/lib/utils";
 
 interface DeviceInfo {
@@ -858,6 +859,7 @@ export function SessionsPanel() {
                 Settings
               </button>
             </div>
+            <CompanionControls className="rounded-md border border-dashed border-border/70 px-2.5 py-1.5" />
             {sessions && sessions.length > 0 ? (
               <div className="flex items-center gap-2">
                 <input

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -668,6 +668,37 @@ export function SessionsPanel() {
   }, [appPanel]);
   useRealtime("voice-companion", (payload) => voiceAgent.applyCompanion(payload));
 
+  // Terminal sessions are created by the backend tool, then revealed here in
+  // bb's native Terminal tab. `openTerminal` is the small companion-mode SDK
+  // seam currently being prototyped in the local bb dev app; feature-detect it
+  // so the plugin still loads on an older host and the tool can report its id.
+  useRealtime("voice-terminal", (payload) => {
+    const value = payload as {
+      terminalId?: unknown;
+      target?: unknown;
+    } | null;
+    if (typeof value?.terminalId !== "string" || !value.target) return;
+    const panel = appPanel as typeof appPanel & {
+      openTerminal?: (options: {
+        surface: { kind: "current" };
+        terminalId: string;
+        target:
+          | { kind: "thread"; threadId: string }
+          | { kind: "environment"; environmentId: string }
+          | { kind: "host_path"; hostId: string; cwd: string | null };
+      }) => boolean;
+    };
+    const target = value.target as
+      | { kind: "thread"; threadId: string }
+      | { kind: "environment"; environmentId: string }
+      | { kind: "host_path"; hostId: string; cwd: string | null };
+    panel.openTerminal?.({
+      surface: { kind: "current" },
+      terminalId: value.terminalId,
+      target,
+    });
+  });
+
   // Open URLs in the bb browser (works from any surface; harmless duplicate set).
   const navigate = useBbNavigate();
   useEffect(() => {

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -9,6 +9,7 @@ import {
   experimental_useAppPanel,
   experimental_useSidebarThreadActions,
   useBbContext,
+  useBbNavigate,
   useRealtime,
   useRpc,
 } from "@get-bb/plugin-sdk/app";
@@ -666,6 +667,12 @@ export function SessionsPanel() {
     return () => voiceAgent.setCompanionOpener(null);
   }, [appPanel]);
   useRealtime("voice-companion", (payload) => voiceAgent.applyCompanion(payload));
+
+  // Open URLs in the bb browser (works from any surface; harmless duplicate set).
+  const navigate = useBbNavigate();
+  useEffect(() => {
+    voiceAgent.setUrlOpener((url) => navigate.openUrl(url));
+  }, [navigate]);
   const [sessions, setSessions] = useState<SessionRow[] | null>(null);
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -6,6 +6,7 @@
 // (which collapses on mobile) or switch sidebars to talk.
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import {
+  experimental_useAppPanel,
   experimental_useSidebarThreadActions,
   useBbContext,
   useRealtime,
@@ -14,7 +15,7 @@ import {
 import type { rpcContract } from "./server";
 import { voiceAgent } from "./voice-agent";
 import { MicIcon, StopIcon, WaveformIcon, useCallElapsed } from "./voice-chrome";
-import { CompanionControls } from "./companion";
+import { COMPANION_TAB, CompanionControls } from "./companion";
 import { cn } from "@/lib/utils";
 
 interface DeviceInfo {
@@ -631,6 +632,7 @@ export function SessionsPanel() {
   const rpc = useRpc<typeof rpcContract>();
   const { threadId, projectId } = useBbContext();
   const sidebarActions = experimental_useSidebarThreadActions();
+  const appPanel = experimental_useAppPanel();
   useEscapeToClose();
 
   // The Handsfree page has no composer, so nothing else binds the voice agent
@@ -650,8 +652,11 @@ export function SessionsPanel() {
           ...(targetProjectId ? { projectId: targetProjectId } : {}),
           focusPrompt: true,
         }),
+      // Let the agent show a thread in the companion split pane (no navigation).
+      openCompanionThread: (id) =>
+        appPanel.openFixedTab({ surface: { kind: "current" }, tab: COMPANION_TAB, target: { threadId: id } }),
     });
-  }, [rpc, threadId, projectId, sidebarActions]);
+  }, [rpc, threadId, projectId, sidebarActions, appPanel]);
   const [sessions, setSessions] = useState<SessionRow[] | null>(null);
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -668,37 +668,6 @@ export function SessionsPanel() {
   }, [appPanel]);
   useRealtime("voice-companion", (payload) => voiceAgent.applyCompanion(payload));
 
-  // Terminal sessions are created by the backend tool, then revealed here in
-  // bb's native Terminal tab. `openTerminal` is the small companion-mode SDK
-  // seam currently being prototyped in the local bb dev app; feature-detect it
-  // so the plugin still loads on an older host and the tool can report its id.
-  useRealtime("voice-terminal", (payload) => {
-    const value = payload as {
-      terminalId?: unknown;
-      target?: unknown;
-    } | null;
-    if (typeof value?.terminalId !== "string" || !value.target) return;
-    const panel = appPanel as typeof appPanel & {
-      openTerminal?: (options: {
-        surface: { kind: "current" };
-        terminalId: string;
-        target:
-          | { kind: "thread"; threadId: string }
-          | { kind: "environment"; environmentId: string }
-          | { kind: "host_path"; hostId: string; cwd: string | null };
-      }) => boolean;
-    };
-    const target = value.target as
-      | { kind: "thread"; threadId: string }
-      | { kind: "environment"; environmentId: string }
-      | { kind: "host_path"; hostId: string; cwd: string | null };
-    panel.openTerminal?.({
-      surface: { kind: "current" },
-      terminalId: value.terminalId,
-      target,
-    });
-  });
-
   // Open URLs in the bb browser (works from any surface; harmless duplicate set).
   const navigate = useBbNavigate();
   useEffect(() => {

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -206,6 +206,12 @@ export class VoiceAgent {
    * and cleared on unmount. Null in realms without a mounted Handsfree page.
    */
   private companionOpener: ((threadId: string) => void) | null = null;
+  /**
+   * Opens an http(s) URL in the bb browser (from `useBbNavigate().openUrl`). Set
+   * by any mounted voice surface, independent of `bindings`. Works from any realm,
+   * so no relay is needed — the owner realm's own surface sets it.
+   */
+  private urlOpener: ((url: string) => boolean) | null = null;
   /** The most recent tool call, so a suspend/teardown can name its likely cause. */
   private lastTool: { name: string; at: number } | null = null;
 
@@ -482,6 +488,11 @@ export class VoiceAgent {
   /** The Handsfree page registers (and clears) its pane opener here. */
   setCompanionOpener(opener: ((threadId: string) => void) | null) {
     this.companionOpener = opener;
+  }
+
+  /** Any voice surface registers the bb-browser opener here. */
+  setUrlOpener(opener: ((url: string) => boolean) | null) {
+    this.urlOpener = opener;
   }
 
   /**
@@ -985,6 +996,17 @@ export class VoiceAgent {
       } else {
         this.openCompanion(threadId);
         output = "Opened the thread in the companion pane beside the conversation.";
+      }
+    } else if (name === "open_url") {
+      const url = String(args.url ?? "");
+      if (!url) {
+        output = "No url given.";
+      } else if (!this.urlOpener) {
+        output = "Can't open a browser from here right now.";
+      } else {
+        output = this.urlOpener(url)
+          ? "Opened the URL in the bb browser."
+          : "The bb browser couldn't open that URL.";
       }
     } else if (
       name === "start_thread" &&

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -86,12 +86,6 @@ export interface Bindings {
    */
   composer?: ComposerBinding;
   openNewThread: (projectId: string | null) => void;
-  /**
-   * Show a thread in the Handsfree page's companion split pane, without
-   * navigating. Present only when a companion-capable surface (the page) is
-   * bound; absent elsewhere, so the tool reports honestly.
-   */
-  openCompanionThread?: (threadId: string) => void;
 }
 
 interface SessionHandle {
@@ -206,6 +200,12 @@ export class VoiceAgent {
   private remoteExpiryTimer: ReturnType<typeof setInterval> | null = null;
   /** Guards the once-per-realm `client.hello` observability record. */
   private helloed = false;
+  /**
+   * Opens a thread in the Handsfree page's companion split pane. Set by the page
+   * surface independently of `bindings` (so a composer's bind() can't clobber it)
+   * and cleared on unmount. Null in realms without a mounted Handsfree page.
+   */
+  private companionOpener: ((threadId: string) => void) | null = null;
   /** The most recent tool call, so a suspend/teardown can name its likely cause. */
   private lastTool: { name: string; at: number } | null = null;
 
@@ -474,6 +474,37 @@ export class VoiceAgent {
       this.remotePresence = null;
       this.disarmRemoteExpiry();
       this.emitChange();
+    }
+  }
+
+  // ---- companion pane (the Handsfree page's right split pane) ----
+
+  /** The Handsfree page registers (and clears) its pane opener here. */
+  setCompanionOpener(opener: ((threadId: string) => void) | null) {
+    this.companionOpener = opener;
+  }
+
+  /**
+   * Show a thread in the companion pane. If this realm hosts the page, open it
+   * directly; otherwise relay over the bus so whichever realm has the mounted
+   * page opens it (the call may be owned by a composer realm with no pane).
+   */
+  private openCompanion(threadId: string) {
+    if (this.companionOpener) {
+      this.companionOpener(threadId);
+      return;
+    }
+    const rpc = this.bindings?.rpc;
+    if (rpc) {
+      void rpc.call("sendCompanion", { threadId, client: clientId, realm: realmId }).catch(() => undefined);
+    }
+  }
+
+  /** Handle a relayed companion request; only a realm with a mounted page acts. */
+  applyCompanion(payload: unknown) {
+    const threadId = (payload as { threadId?: unknown } | null)?.threadId;
+    if (typeof threadId === "string" && threadId && this.companionOpener) {
+      this.companionOpener(threadId);
     }
   }
 
@@ -949,13 +980,10 @@ export class VoiceAgent {
       }
     } else if (name === "show_thread") {
       const threadId = String(args.thread_id ?? "");
-      if (!bindings.openCompanionThread) {
-        output =
-          "The companion pane is only available on the Handsfree page. Ask the user to open Handsfree, or use focus_thread.";
-      } else if (!threadId) {
+      if (!threadId) {
         output = "No thread_id given.";
       } else {
-        bindings.openCompanionThread(threadId);
+        this.openCompanion(threadId);
         output = "Opened the thread in the companion pane beside the conversation.";
       }
     } else if (

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -86,6 +86,12 @@ export interface Bindings {
    */
   composer?: ComposerBinding;
   openNewThread: (projectId: string | null) => void;
+  /**
+   * Show a thread in the Handsfree page's companion split pane, without
+   * navigating. Present only when a companion-capable surface (the page) is
+   * bound; absent elsewhere, so the tool reports honestly.
+   */
+  openCompanionThread?: (threadId: string) => void;
 }
 
 interface SessionHandle {
@@ -941,6 +947,17 @@ export class VoiceAgent {
         bindings.composer.updateText((current) => (current ? `${current}\n${text}` : text));
         output = "Text appended to composer.";
       }
+    } else if (name === "show_thread") {
+      const threadId = String(args.thread_id ?? "");
+      if (!bindings.openCompanionThread) {
+        output =
+          "The companion pane is only available on the Handsfree page. Ask the user to open Handsfree, or use focus_thread.";
+      } else if (!threadId) {
+        output = "No thread_id given.";
+      } else {
+        bindings.openCompanionThread(threadId);
+        output = "Opened the thread in the companion pane beside the conversation.";
+      }
     } else if (
       name === "start_thread" &&
       !(typeof args.prompt === "string" && args.prompt.trim())
@@ -964,7 +981,7 @@ export class VoiceAgent {
       // call; have the model point the user to the tap target instead.
       this.logDiag("nav.blocked", { name });
       output =
-        "On mobile you can't navigate the app during a live call — it would background the call and cut the mic. Do NOT navigate. Instead, tell the user in one short sentence exactly what to tap to get there themselves.";
+        "On mobile you can't navigate the app during a live call — it would background the call and cut the mic. Do NOT navigate. If this is a thread, use show_thread to display it in the companion pane beside the call instead. Otherwise, tell the user in one short sentence what to tap.";
     } else {
       // These tools navigate (…→ threads.open) which would background a live
       // mobile call — tell the server not to focus so the work still happens but


### PR DESCRIPTION
Draft companion-mode spike constrained to the SDK surfaces available in production bb.

### Summary
Turns the Handsfree page right panel into an agent-driven companion. During a live voice call, Aide can show or swap a thread without navigating away and open URLs through bb's existing navigation API.

### Verified behavior
- `show_thread` opens and swaps `ThreadChat` in the plugin-owned companion tab on desktop and mobile.
- The mobile call remains alive while the companion drawer is open.
- Cross-realm relay works whether the Handsfree page or a composer owns the call.
- `open_url` uses the production navigation API for PRs, issues, and docs.
- Tests pass (22/22) and TypeScript checks cleanly.

### Production boundary
This branch does not require changes to bb core. The earlier terminal experiment has been removed because a production plugin cannot currently reveal an existing native terminal session in the page's panel.

Capabilities we can explore next using today's production SDK:
- a plugin-owned Diff tab using the host `experimental_Diff` component;
- file/source context using the host preview and source components;
- richer companion targets implemented as plugin-owned fixed tabs.

### Deferred bb maintainer proposal
Terminal companion UX needs a small host API—such as `appPanel.openTerminal(...)`, or a more general API for revealing host-owned tabs. Terminal creation/control already exists server-side, but that alone cannot present an interactive terminal to the user.

### UX hypothesis to test
Keep the Handsfree page as the call anchor. Tool calls retarget a single companion surface—desktop side panel or mobile drawer—to the relevant thread, diff, file, or URL without ending the call or navigating away. We should validate each production-supported target before deciding whether companion mode needs an explicit toggle.
