### PR TITLE
Rebindable keyboard shortcuts in Handsfree settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ The button has three states:
 
 Keyboard: **Cmd+Shift+H** (Ctrl+Shift+H on Windows/Linux) starts or stops a
 call from anywhere in bb; **Cmd+Shift+U** mutes/unmutes during a call. Both are
-also in the quick palette (Cmd+Shift+P) under Handsfree.
+also in the quick palette (Cmd+Shift+P) under Handsfree. To rebind them, open
+Settings → Plugins → Handsfree → **Keyboard shortcuts**, click **Change**, and
+press the new combination.
 
 ## Things you can say
 
@@ -89,6 +91,11 @@ Open the Handsfree plugin settings for curated sections:
   session; if it disconnects, Handsfree falls back to the system default.
   Playback always uses your system-default speaker (change it in your OS Sound
   settings).
+- **Keyboard shortcuts** — rebind the start/stop and mute keys: click
+  **Change** and press the new combination (Esc keeps the current one). A
+  binding needs ⌘/Ctrl or Alt, or a function key, so it can't fire while you
+  type, and bb's own Cmd+Shift+P / Cmd+Shift+M are refused. Bindings are
+  shared across your devices.
 
 The only credential is the **OpenAI API key**, a secret stored in bb's plugin
 secret store (0600 file, never in the db or frontend). It's optional: leave it

--- a/app.tsx
+++ b/app.tsx
@@ -19,17 +19,13 @@ import type { PluginThreadListProps } from "@get-bb/plugin-sdk/app";
 import type { rpcContract } from "./server";
 import { voiceAgent } from "./voice-agent";
 import { SessionsPanel } from "./sessions-panel";
-import { AudioSettings, BehaviorSettings, ModelsSettings } from "./settings-sections";
+import { AudioSettings, BehaviorSettings, ModelsSettings, ShortcutsSettings } from "./settings-sections";
 import { cn } from "@/lib/utils";
 import { AUDIO_DEVICE_STORAGE_KEY } from "./audio-devices";
 import { MicIcon, StopIcon, WaveformIcon, useCallElapsed } from "./voice-chrome";
-import { clientDescriptor } from "./client-identity";
-import { isMacPlatform, matchShortcut, shortcutLabel } from "./shortcuts";
+import { matchShortcut, shortcutLabel } from "./shortcuts";
+import { MAC, SHORTCUT_STORAGE_KEY, shortcutStore, useShortcutSync, useShortcuts } from "./shortcut-store";
 import "./app.css";
-
-const MAC = isMacPlatform(clientDescriptor.platform);
-const TOGGLE_HINT = shortcutLabel("toggle", MAC);
-const MUTE_HINT = shortcutLabel("mute", MAC);
 
 function AideVoiceButton() {
   const rpc = useRpc<typeof rpcContract>();
@@ -47,6 +43,12 @@ function AideVoiceButton() {
   const state = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
   const activity = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getActivity);
   const micSuspended = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getMicSuspended);
+  // Shortcut hints for the tooltips. This button is mounted on nearly every
+  // page, so it also keeps the content-script mirror in step with the config.
+  useShortcutSync();
+  const shortcuts = useShortcuts();
+  const toggleHint = shortcutLabel(shortcuts.toggle, MAC);
+  const muteHint = shortcutLabel(shortcuts.mute, MAC);
 
   // Global exclusivity: when any window starts a call, all others stop theirs.
   useRealtime("voice-call", (payload) => {
@@ -137,7 +139,7 @@ function AideVoiceButton() {
         <button
           type="button"
           aria-label={muted ? "Unmute Aide microphone" : "Mute Aide microphone"}
-          title={`${muted ? "Unmute" : "Mute"} (${MUTE_HINT})`}
+          title={`${muted ? "Unmute" : "Mute"} (${muteHint})`}
           onPointerDown={(event) => event.button === 0 && event.preventDefault()}
           onClick={() => voiceAgent.toggleMuteFromSurface()}
           className={cn(
@@ -172,7 +174,7 @@ function AideVoiceButton() {
         <button
           type="button"
           aria-label="Stop Aide voice session"
-          title={`Stop (${TOGGLE_HINT})`}
+          title={`Stop (${toggleHint})`}
           onPointerDown={(event) => event.button === 0 && event.preventDefault()}
           onClick={() => voiceAgent.stopFromSurface()}
           className="flex size-7 items-center justify-center text-muted-foreground transition-colors hover:bg-destructive/15 hover:text-destructive"
@@ -187,7 +189,7 @@ function AideVoiceButton() {
     <button
       type="button"
       aria-label="Start Aide voice agent"
-      title={`Talk to Aide (${TOGGLE_HINT})`}
+      title={`Talk to Aide (${toggleHint})`}
       onPointerDown={(event) => event.button === 0 && event.preventDefault()}
       onClick={() => voiceAgent.toggleFromSurface()}
       className={cn(
@@ -214,6 +216,9 @@ function SidebarVoiceBar() {
   const live = state === "live";
   const muted = state === "muted";
   const active = live || muted;
+  const shortcuts = useShortcuts();
+  const toggleHint = shortcutLabel(shortcuts.toggle, MAC);
+  const muteHint = shortcutLabel(shortcuts.mute, MAC);
   const speaking = activity === "aide";
   const listening = activity === "you";
   // Same neutral-chrome + activity-color scheme as the composer pill: color
@@ -240,7 +245,7 @@ function SidebarVoiceBar() {
       <button
         type="button"
         aria-label={active ? "Stop Aide voice agent" : "Start Aide voice agent"}
-        title={`${active ? "Stop Aide" : "Talk to Aide"} (${TOGGLE_HINT})`}
+        title={`${active ? "Stop Aide" : "Talk to Aide"} (${toggleHint})`}
         onClick={() => voiceAgent.toggleFromSurface()}
         className={cn(
           "flex h-7 flex-1 items-center justify-center gap-1.5 rounded-md border border-border px-2 text-xs font-medium transition-colors",
@@ -259,7 +264,7 @@ function SidebarVoiceBar() {
         <button
           type="button"
           aria-label={muted ? "Unmute Aide microphone" : "Mute Aide microphone"}
-          title={`${muted ? "Unmute" : "Mute"} (${MUTE_HINT})`}
+          title={`${muted ? "Unmute" : "Mute"} (${muteHint})`}
           onClick={() => voiceAgent.toggleMuteFromSurface()}
           className={cn(
             "flex size-7 shrink-0 items-center justify-center rounded-md border border-border transition-colors",
@@ -339,6 +344,11 @@ export default definePluginApp((app) => {
     title: "Audio",
     component: AudioSettings,
   });
+  app.slots.settingsSection({
+    id: "shortcuts",
+    title: "Keyboard shortcuts",
+    component: ShortcutsSettings,
+  });
   app.composer.customize({
     id: "aide-voice",
     actions: [{ id: "voice-agent", component: AideVoiceButton }],
@@ -360,12 +370,12 @@ export default definePluginApp((app) => {
   // activates it), but users can pin BB's list under Settings → Appearance.
   app.slots.commandPaletteAction({
     id: "toggle-voice",
-    title: `Handsfree: start/stop voice (${TOGGLE_HINT})`,
+    title: "Handsfree: start/stop voice",
     run: () => voiceAgent.toggleFromSurface(),
   });
   app.slots.commandPaletteAction({
     id: "toggle-mute",
-    title: `Handsfree: mute/unmute (${MUTE_HINT})`,
+    title: "Handsfree: mute/unmute",
     isAvailable: () => voiceAgent.getState() === "live" || voiceAgent.getState() === "muted",
     run: () => voiceAgent.toggleMuteFromSurface(),
   });
@@ -383,17 +393,23 @@ export default definePluginApp((app) => {
     mount({ signal }) {
       window.addEventListener("storage", (event) => {
         if (event.key === AUDIO_DEVICE_STORAGE_KEY) voiceAgent.refreshAudioPreferences();
+        if (event.key === SHORTCUT_STORAGE_KEY) shortcutStore.refresh();
       }, { signal });
-      // Release the mic synchronously before the page tears down. Without this,
-      // a hard reload (Cmd+R) leaves the previous page holding the input device,
-      // so the fresh page enumerates zero microphones until the OS reclaims it.
+      // Keyboard shortcuts (rebindable under Settings → Keyboard shortcuts).
+      // Bindings come from the mirror in shortcut-store.ts, so an edit applies
+      // without a reload; while the settings page is recording a new combo the
+      // listener stands down so the old binding can't fire mid-capture.
       window.addEventListener("keydown", (event) => {
-        const action = matchShortcut(event, MAC);
+        if (shortcutStore.isRecording()) return;
+        const action = matchShortcut(event, MAC, shortcutStore.get());
         if (!action) return;
         event.preventDefault();
         if (action === "toggle") voiceAgent.toggleFromSurface();
         else voiceAgent.toggleMuteFromSurface();
       }, { signal });
+      // Release the mic synchronously before the page tears down. Without this,
+      // a hard reload (Cmd+R) leaves the previous page holding the input device,
+      // so the fresh page enumerates zero microphones until the OS reclaims it.
       window.addEventListener("pagehide", () => voiceAgent.stop(), { signal });
       signal.addEventListener("abort", () => voiceAgent.stop());
       return () => voiceAgent.stop();

--- a/server.ts
+++ b/server.ts
@@ -19,6 +19,19 @@ import {
   type RealtimeModel,
   type Voice,
 } from "./models";
+import { DEFAULT_SHORTCUTS, isValidShortcut, normalizeShortcuts, type Shortcuts } from "./shortcuts";
+
+/**
+ * Rebindable keyboard shortcuts (see shortcuts.ts): each value is a
+ * "Mod+Shift+H"-style string that includes Mod or Alt, or is a function key,
+ * so it can't fire while the user is merely typing.
+ */
+const shortcutsSchema = z
+  .object({
+    toggle: z.string().max(60).refine(isValidShortcut, "not a usable key combination"),
+    mute: z.string().max(60).refine(isValidShortcut, "not a usable key combination"),
+  })
+  .strict();
 
 export const rpcContract = defineRpcContract({
   /** Exchange a WebRTC SDP offer with OpenAI Realtime. Returns the answer. */
@@ -109,6 +122,7 @@ export const rpcContract = defineRpcContract({
         notifications: z.boolean(),
         pluginCommands: z.string(),
         credentialPreference: z.enum(["auto", "apiKey", "subscription"]),
+        shortcuts: shortcutsSchema,
       })
       .strict(),
   },
@@ -121,6 +135,7 @@ export const rpcContract = defineRpcContract({
         notifications: z.boolean().optional(),
         pluginCommands: z.string().max(2000).optional(),
         credentialPreference: z.enum(["auto", "apiKey", "subscription"]).optional(),
+        shortcuts: shortcutsSchema.optional(),
       })
       .strict(),
     output: z
@@ -130,6 +145,7 @@ export const rpcContract = defineRpcContract({
         notifications: z.boolean(),
         pluginCommands: z.string(),
         credentialPreference: z.enum(["auto", "apiKey", "subscription"]),
+        shortcuts: shortcutsSchema,
       })
       .strict(),
   },
@@ -469,6 +485,7 @@ export default async function plugin(bb: BbPluginApi) {
     notifications: boolean;
     pluginCommands: string;
     credentialPreference: CredentialPreference;
+    shortcuts: Shortcuts;
   }
   const CONFIG_KEY = "config";
   const CONFIG_DEFAULTS: VoiceConfig = {
@@ -477,6 +494,7 @@ export default async function plugin(bb: BbPluginApi) {
     notifications: true,
     pluginCommands: "all",
     credentialPreference: "auto",
+    shortcuts: { ...DEFAULT_SHORTCUTS },
   };
   async function readConfig(): Promise<VoiceConfig> {
     const stored = (await bb.storage.kv.get<Partial<VoiceConfig>>(CONFIG_KEY)) ?? {};
@@ -490,9 +508,12 @@ export default async function plugin(bb: BbPluginApi) {
       credentialPreference: isCredentialPreference(stored.credentialPreference)
         ? stored.credentialPreference
         : CONFIG_DEFAULTS.credentialPreference,
+      shortcuts: normalizeShortcuts(stored.shortcuts),
     };
   }
   async function writeConfig(patch: Partial<VoiceConfig>): Promise<VoiceConfig> {
+    // Store the canonical spelling so equality checks downstream are simple.
+    if (patch.shortcuts) patch = { ...patch, shortcuts: normalizeShortcuts(patch.shortcuts) };
     const next = { ...(await readConfig()), ...patch };
     await bb.storage.kv.set(CONFIG_KEY, next);
     return next;

--- a/settings-sections.tsx
+++ b/settings-sections.tsx
@@ -2,8 +2,9 @@
 //
 // The host renders a single declarative field (the secret OpenAI API key) and
 // then these custom sections below it. Everything the user tunes day-to-day —
-// which model and voice to use, whether Aide announces thread events, and the
-// microphone — lives here as curated sections instead of a flat auto-form.
+// which model and voice to use, whether Aide announces thread events, the
+// microphone, and the keyboard shortcuts — lives here as curated sections
+// instead of a flat auto-form.
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
 import { useRealtime, useRpc } from "@get-bb/plugin-sdk/app";
 import { toast } from "sonner";
@@ -29,6 +30,21 @@ import {
 } from "./models";
 import { voiceAgent } from "./voice-agent";
 import { deviceDisplayLabel } from "./audio-devices";
+import {
+  DEFAULT_SHORTCUTS,
+  SHORTCUT_ACTIONS,
+  SHORTCUT_ACTION_LABELS,
+  comboFromEvent,
+  formatShortcut,
+  isModifierKey,
+  sameShortcut,
+  shortcutLabel,
+  shortcutLabelParts,
+  shortcutProblem,
+  type ShortcutAction,
+  type Shortcuts,
+} from "./shortcuts";
+import { MAC, shortcutStore } from "./shortcut-store";
 import { cn } from "@/lib/utils";
 
 type CredentialPreference = "auto" | "apiKey" | "subscription";
@@ -39,6 +55,7 @@ interface VoiceConfig {
   notifications: boolean;
   pluginCommands: string;
   credentialPreference: CredentialPreference;
+  shortcuts: Shortcuts;
 }
 
 /**
@@ -50,9 +67,15 @@ function useVoiceConfig() {
   const rpc = useRpc<typeof rpcContract>();
   const [config, setConfig] = useState<VoiceConfig | null>(null);
 
+  // Whatever the backend says is also pushed into the shortcut mirror, so the
+  // content-script listener and tooltips follow an edit made on this page.
+  const adopt = useCallback((next: VoiceConfig) => {
+    setConfig(next);
+    shortcutStore.set(next.shortcuts);
+  }, []);
   const refetch = useCallback(() => {
-    rpc.call("getConfig", null).then(setConfig, () => undefined);
-  }, [rpc]);
+    rpc.call("getConfig", null).then(adopt, () => undefined);
+  }, [rpc, adopt]);
   useEffect(refetch, [refetch]);
   useRealtime("config-changed", refetch);
 
@@ -60,7 +83,7 @@ function useVoiceConfig() {
     async (patch: Partial<VoiceConfig>) => {
       setConfig((prev) => (prev ? { ...prev, ...patch } : prev));
       try {
-        setConfig(await rpc.call("setConfig", patch));
+        adopt(await rpc.call("setConfig", patch));
         return true;
       } catch (cause) {
         refetch();
@@ -68,7 +91,7 @@ function useVoiceConfig() {
         return false;
       }
     },
-    [rpc, refetch],
+    [rpc, refetch, adopt],
   );
 
   return { config, update };
@@ -849,6 +872,148 @@ export function AudioSettings() {
           Switching speakers in the app isn't supported yet — change your output in your system sound settings.
         </p>
       </Group>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Keyboard shortcuts: one row per action showing the current binding as
+// keycaps, with a recorder that captures the next combination pressed.
+// ---------------------------------------------------------------------------
+
+/** The binding as keycaps, e.g. [⌘][Shift][H]; an ellipsis while recording. */
+function Keycaps({ value }: { value: string | null }) {
+  const parts = value === null ? ["…"] : shortcutLabelParts(value, MAC);
+  return (
+    <span className="flex items-center gap-1" aria-hidden={value === null}>
+      {parts.map((part, index) => (
+        <kbd
+          key={index}
+          className="inline-flex h-6 min-w-6 items-center justify-center rounded border border-border bg-muted px-1.5 font-sans text-[11px] font-medium text-foreground shadow-[inset_0_-1px_0_var(--border)]"
+        >
+          {part}
+        </kbd>
+      ))}
+    </span>
+  );
+}
+
+function ShortcutRow({
+  action,
+  shortcuts,
+  disabled,
+  onChange,
+}: {
+  action: ShortcutAction;
+  shortcuts: Shortcuts;
+  disabled: boolean;
+  onChange: (value: string) => void;
+}) {
+  const [recording, setRecording] = useState(false);
+  const [problem, setProblem] = useState<string | null>(null);
+  // The recorder is installed once per recording session; read the latest
+  // bindings and callback through a ref so it never goes stale.
+  const latest = useRef({ shortcuts, onChange });
+  latest.current = { shortcuts, onChange };
+  const value = shortcuts[action];
+  const isDefault = sameShortcut(value, DEFAULT_SHORTCUTS[action]);
+
+  useEffect(() => {
+    if (!recording) return;
+    shortcutStore.setRecording(true);
+    const onKeyDown = (event: KeyboardEvent) => {
+      // Capture phase on window: ahead of bb's own bindings and our global
+      // listener, so the keystroke reaches only this recorder and nothing is
+      // typed into whatever has focus.
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      if (event.key === "Escape") {
+        setRecording(false);
+        return;
+      }
+      if (isModifierKey(event.key)) return; // waiting for the key itself
+      const combo = comboFromEvent(event, MAC);
+      if (!combo) {
+        setProblem(MAC ? "Use ⌘ rather than Control." : "Use Ctrl rather than the Windows or Command key.");
+        return;
+      }
+      const next = formatShortcut(combo);
+      const why = shortcutProblem(next, action, latest.current.shortcuts, MAC);
+      if (why) {
+        setProblem(why); // stay in recording mode so they can try again
+        return;
+      }
+      setRecording(false);
+      latest.current.onChange(next);
+    };
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", onKeyDown, { capture: true });
+      shortcutStore.setRecording(false);
+    };
+  }, [recording, action]);
+
+  const status = recording ? (
+    <span className={cn("block text-xs", problem ? "text-destructive" : "text-muted-foreground")}>
+      {problem ?? "Press the new combination, or Esc to keep the current one."}
+    </span>
+  ) : isDefault ? null : (
+    <button type="button" className={linkClass} disabled={disabled} onClick={() => onChange(DEFAULT_SHORTCUTS[action])}>
+      Reset to {shortcutLabel(DEFAULT_SHORTCUTS[action], MAC)}
+    </button>
+  );
+
+  return (
+    <div className="flex items-center justify-between gap-3 px-3 py-2">
+      <div className="min-w-0 space-y-0.5">
+        <span className="block text-sm text-foreground">{SHORTCUT_ACTION_LABELS[action]}</span>
+        {status}
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <Keycaps value={recording ? null : value} />
+        <Button
+          type="button"
+          variant={recording ? "secondary" : "outline"}
+          size="sm"
+          disabled={disabled}
+          onClick={() => {
+            setProblem(null);
+            setRecording((prev) => !prev);
+          }}
+        >
+          {recording ? "Cancel" : "Change"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function ShortcutsSettings() {
+  const { config, update } = useVoiceConfig();
+  const shortcuts = config?.shortcuts ?? DEFAULT_SHORTCUTS;
+  const loading = config === null;
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-muted-foreground">
+        These work anywhere in bb, even while typing in the composer. Click Change, then press the new
+        combination. Bindings are shared across your devices; ⌘ here means Ctrl on Windows and Linux.
+      </p>
+      <div className="divide-y divide-border/50 rounded-md border border-border">
+        {SHORTCUT_ACTIONS.map((action) => (
+          <ShortcutRow
+            key={action}
+            action={action}
+            shortcuts={shortcuts}
+            disabled={loading}
+            onChange={(value) => {
+              void update({ shortcuts: { ...shortcuts, [action]: value } }).then((ok) => {
+                if (ok) toast.success(`Shortcut saved: ${shortcutLabel(value, MAC)}`);
+              });
+            }}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/shortcut-store.ts
+++ b/shortcut-store.ts
@@ -1,0 +1,94 @@
+// Browser-side mirror of the shortcut bindings. The authoritative copy is the
+// plugin's kv config (server.ts, edited under Settings → Keyboard shortcuts);
+// this mirror exists so the window keydown listener in the content script —
+// which runs outside React — can read the bindings synchronously, and so
+// tooltips update the moment a binding changes. A localStorage cache seeds the
+// mirror on page load, before any rpc round-trip has completed.
+import { useEffect, useSyncExternalStore } from "react";
+import { useRealtime, useRpc } from "@get-bb/plugin-sdk/app";
+import type { rpcContract } from "./server";
+import { clientDescriptor } from "./client-identity";
+import { DEFAULT_SHORTCUTS, isMacPlatform, normalizeShortcuts, type Shortcuts } from "./shortcuts";
+
+export const SHORTCUT_STORAGE_KEY = "bb-handsfree.shortcuts";
+
+/** Whether Mod means ⌘ (macOS/iOS) or Ctrl on this client. */
+export const MAC = isMacPlatform(clientDescriptor.platform);
+
+function storage(): Storage | null {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function readCache(): Shortcuts {
+  try {
+    return normalizeShortcuts(JSON.parse(storage()?.getItem(SHORTCUT_STORAGE_KEY) ?? "null"));
+  } catch {
+    return { ...DEFAULT_SHORTCUTS };
+  }
+}
+
+class ShortcutStore {
+  private value: Shortcuts = readCache();
+  private recording = false;
+  private listeners = new Set<() => void>();
+
+  readonly get = (): Shortcuts => this.value;
+
+  readonly subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  /** Adopt the authoritative bindings (validated server-side) and cache them for the next page load. */
+  set(next: unknown) {
+    const normalized = normalizeShortcuts(next);
+    if (normalized.toggle === this.value.toggle && normalized.mute === this.value.mute) return;
+    this.value = normalized;
+    try {
+      storage()?.setItem(SHORTCUT_STORAGE_KEY, JSON.stringify(normalized));
+    } catch {
+      // Private mode or a full quota: the mirror still works for this page.
+    }
+    for (const listener of this.listeners) listener();
+  }
+
+  /** Another window saved new bindings (storage event): pick them up. */
+  refresh() {
+    this.set(readCache());
+  }
+
+  /** While the settings page captures a new combo, the global listener stands down. */
+  isRecording(): boolean {
+    return this.recording;
+  }
+
+  setRecording(on: boolean) {
+    this.recording = on;
+  }
+}
+
+export const shortcutStore = new ShortcutStore();
+
+/** The live bindings, re-rendering when they change. */
+export function useShortcuts(): Shortcuts {
+  return useSyncExternalStore(shortcutStore.subscribe, shortcutStore.get);
+}
+
+/**
+ * Pull the bindings from the kv config and keep them fresh across windows via
+ * the `config-changed` signal. Mounted from the composer button, which is on
+ * nearly every page, so the content-script listener sees edits promptly.
+ */
+export function useShortcutSync() {
+  const rpc = useRpc<typeof rpcContract>();
+  useEffect(() => {
+    rpc.call("getConfig", null).then((config) => shortcutStore.set(config.shortcuts), () => undefined);
+  }, [rpc]);
+  useRealtime("config-changed", () => {
+    rpc.call("getConfig", null).then((config) => shortcutStore.set(config.shortcuts), () => undefined);
+  });
+}

--- a/shortcuts.test.ts
+++ b/shortcuts.test.ts
@@ -1,6 +1,19 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { isMacPlatform, matchShortcut, shortcutLabel } from "./shortcuts.ts";
+import {
+  DEFAULT_SHORTCUTS,
+  canonicalShortcut,
+  comboFromEvent,
+  formatShortcut,
+  isMacPlatform,
+  isValidShortcut,
+  matchShortcut,
+  normalizeShortcuts,
+  parseShortcut,
+  shortcutLabel,
+  shortcutLabelParts,
+  shortcutProblem,
+} from "./shortcuts.ts";
 
 const base = { metaKey: false, ctrlKey: false, shiftKey: false, altKey: false };
 
@@ -22,11 +35,83 @@ test("Mod+Shift+U mutes; plain/alt/repeat/composing keys are ignored", () => {
   assert.equal(matchShortcut({ ...base, key: "x", metaKey: true, shiftKey: true }, true), null);
 });
 
+test("custom bindings are honored and defaults stop matching", () => {
+  const custom = { toggle: "Mod+Alt+K", mute: "F9" };
+  assert.equal(matchShortcut({ ...base, key: "k", metaKey: true, altKey: true }, true, custom), "toggle");
+  assert.equal(matchShortcut({ ...base, key: "F9" }, false, custom), "mute");
+  assert.equal(matchShortcut({ ...base, key: "h", metaKey: true, shiftKey: true }, true, custom), null);
+  assert.equal(matchShortcut({ ...base, key: "u", ctrlKey: true, shiftKey: true }, false, custom), null);
+});
+
+test("letters and digits match by physical key, so Alt/Shift symbols still work", () => {
+  // Alt+K on macOS reports key "˚"; Shift+1 reports "!".
+  const custom = { toggle: "Mod+Alt+K", mute: "Mod+Shift+1" };
+  assert.equal(matchShortcut({ ...base, key: "˚", code: "KeyK", metaKey: true, altKey: true }, true, custom), "toggle");
+  assert.equal(matchShortcut({ ...base, key: "!", code: "Digit1", metaKey: true, shiftKey: true }, true, custom), "mute");
+});
+
+test("capture: bare modifiers and the off-platform modifier are not combos", () => {
+  assert.equal(comboFromEvent({ ...base, key: "Shift", shiftKey: true }, true), null);
+  assert.equal(comboFromEvent({ ...base, key: "Meta", metaKey: true }, true), null);
+  assert.equal(comboFromEvent({ ...base, key: "x", ctrlKey: true }, true), null);
+  assert.equal(comboFromEvent({ ...base, key: "x", metaKey: true }, false), null);
+  const combo = comboFromEvent({ ...base, key: "ArrowUp", ctrlKey: true, altKey: true }, false);
+  assert.deepEqual(combo, { mod: true, shift: false, alt: true, key: "ArrowUp" });
+  assert.equal(formatShortcut(combo!), "Mod+Alt+ArrowUp");
+  assert.equal(formatShortcut(comboFromEvent({ ...base, key: " ", metaKey: true }, true)!), "Mod+Space");
+});
+
+test("parse/format round-trip and canonical spelling", () => {
+  assert.deepEqual(parseShortcut("Mod+Shift+H"), { mod: true, shift: true, alt: false, key: "h" });
+  assert.equal(canonicalShortcut("shift+mod+h"), "Mod+Shift+H");
+  assert.equal(canonicalShortcut("Mod+Alt+ArrowLeft"), "Mod+Alt+ArrowLeft");
+  assert.equal(canonicalShortcut("F5"), "F5");
+  assert.equal(parseShortcut(""), null);
+  assert.equal(parseShortcut("Mod+"), null);
+  assert.equal(parseShortcut("Ctrl+H"), null);
+  assert.equal(parseShortcut("Mod+Shift"), null);
+});
+
+test("validity: needs Mod or Alt unless it's a function key", () => {
+  assert.equal(isValidShortcut("Mod+Shift+H"), true);
+  assert.equal(isValidShortcut("Alt+J"), true);
+  assert.equal(isValidShortcut("F9"), true);
+  assert.equal(isValidShortcut("Shift+H"), false);
+  assert.equal(isValidShortcut("H"), false);
+  assert.equal(isValidShortcut(42), false);
+  assert.equal(isValidShortcut("Mod+Foo+H"), false);
+});
+
+test("problems: unusable, reserved, and colliding combos are explained", () => {
+  const current = { ...DEFAULT_SHORTCUTS };
+  assert.match(shortcutProblem("Shift+H", "toggle", current, true) ?? "", /⌘ or ⌥/);
+  assert.match(shortcutProblem("H", "toggle", current, false) ?? "", /Ctrl or Alt/);
+  assert.match(shortcutProblem("Mod+Shift+P", "toggle", current, true) ?? "", /command palette/);
+  assert.match(shortcutProblem("Mod+Shift+M", "mute", current, false) ?? "", /model picker/);
+  assert.match(shortcutProblem("Mod+Shift+U", "toggle", current, true) ?? "", /already used to mute/);
+  assert.match(shortcutProblem("mod+shift+h", "mute", current, true) ?? "", /already used to start or stop/);
+  assert.equal(shortcutProblem("Mod+Shift+H", "toggle", current, true), null); // rebinding to itself is fine
+  assert.equal(shortcutProblem("Mod+Alt+K", "toggle", current, true), null);
+  assert.equal(shortcutProblem("F9", "mute", current, false), null);
+  assert.match(shortcutProblem("Escape", "mute", current, false) ?? "", /Escape/);
+});
+
+test("normalize: garbage falls back per action, spelling is canonicalized, collisions break toward toggle", () => {
+  assert.deepEqual(normalizeShortcuts(undefined), DEFAULT_SHORTCUTS);
+  assert.deepEqual(normalizeShortcuts("nope"), DEFAULT_SHORTCUTS);
+  assert.deepEqual(normalizeShortcuts({ toggle: "alt+k", mute: 7 }), { toggle: "Alt+K", mute: "Mod+Shift+U" });
+  assert.deepEqual(normalizeShortcuts({ toggle: "Shift+H", mute: "F9" }), { toggle: "Mod+Shift+H", mute: "F9" });
+  assert.deepEqual(normalizeShortcuts({ toggle: "Mod+Alt+K", mute: "Mod+Alt+K" }), { toggle: "Mod+Alt+K", mute: "Mod+Shift+U" });
+  assert.deepEqual(normalizeShortcuts({ toggle: "Mod+Shift+U", mute: "Mod+Shift+U" }), DEFAULT_SHORTCUTS);
+});
+
 test("platform detection and labels", () => {
   assert.equal(isMacPlatform("macOS"), true);
   assert.equal(isMacPlatform("iOS"), true);
   assert.equal(isMacPlatform("Windows"), false);
   assert.equal(isMacPlatform(""), false);
-  assert.equal(shortcutLabel("toggle", true), "⌘+Shift+H");
-  assert.equal(shortcutLabel("mute", false), "Ctrl+Shift+U");
+  assert.equal(shortcutLabel("Mod+Shift+H", true), "⌘+Shift+H");
+  assert.equal(shortcutLabel("Mod+Shift+U", false), "Ctrl+Shift+U");
+  assert.deepEqual(shortcutLabelParts("Mod+Alt+ArrowUp", true), ["⌘", "⌥", "↑"]);
+  assert.deepEqual(shortcutLabelParts("F9", false), ["F9"]);
 });

--- a/shortcuts.ts
+++ b/shortcuts.ts
@@ -1,16 +1,56 @@
 // Keyboard shortcuts for the voice call. bb's keybinding registry is a fixed
 // enum of host commands, so the plugin listens on the window from its content
-// script instead. Mod = Cmd on macOS, Ctrl elsewhere.
+// script instead (see app.tsx); the user can rebind them under Settings →
+// Handsfree → Keyboard shortcuts.
+//
+// Shared between server.ts (validation) and the frontend (matching, labels,
+// capture): plain data, no browser globals.
+//
+// A shortcut is stored as a canonical string such as "Mod+Shift+H": zero or
+// more of Mod / Shift / Alt, then exactly one key. Mod is ⌘ on macOS and iOS
+// and Ctrl elsewhere, so a saved value means the same keystroke on every
+// device.
 
 export type ShortcutAction = "toggle" | "mute";
+export type Shortcuts = Record<ShortcutAction, string>;
 
-export const SHORTCUTS: Record<ShortcutAction, { key: string; label: string }> = {
-  toggle: { key: "h", label: "Mod+Shift+H" },
-  mute: { key: "u", label: "Mod+Shift+U" },
+export const SHORTCUT_ACTIONS: readonly ShortcutAction[] = ["toggle", "mute"];
+
+export const SHORTCUT_ACTION_LABELS: Record<ShortcutAction, string> = {
+  toggle: "Start or stop the call",
+  mute: "Mute or unmute the microphone",
 };
 
+export const DEFAULT_SHORTCUTS: Shortcuts = {
+  toggle: "Mod+Shift+H",
+  mute: "Mod+Shift+U",
+};
+
+/**
+ * Combinations bb binds itself. Refusing them avoids a tug-of-war where both
+ * the host and this plugin react to the same keystroke.
+ */
+export const RESERVED_SHORTCUTS: Readonly<Record<string, string>> = {
+  "Mod+Shift+P": "bb's command palette",
+  "Mod+Shift+M": "bb's model picker",
+};
+
+export interface ShortcutCombo {
+  mod: boolean;
+  shift: boolean;
+  alt: boolean;
+  /**
+   * Single characters are lower-cased ("h", "1", "/"); named keys keep their
+   * DOM name ("F9", "ArrowUp"). Space and "+" are spelled out so they survive
+   * the "+"-joined string form.
+   */
+  key: string;
+}
+
+/** The subset of KeyboardEvent the matcher reads, so tests can pass plain objects. */
 export interface ShortcutKeyEvent {
   key: string;
+  code?: string;
   metaKey: boolean;
   ctrlKey: boolean;
   shiftKey: boolean;
@@ -23,18 +63,210 @@ export function isMacPlatform(platform: string): boolean {
   return /^(mac|iOS|iPhone|iPad)/i.test(platform);
 }
 
+const MODIFIER_KEY_NAMES = new Set([
+  "Shift",
+  "Control",
+  "Alt",
+  "AltGraph",
+  "Meta",
+  "OS",
+  "Fn",
+  "FnLock",
+  "CapsLock",
+  "NumLock",
+  "ScrollLock",
+  "Hyper",
+  "Super",
+  "Symbol",
+  "SymbolLock",
+]);
+
+/** A keydown for a modifier on its own (Shift, Control, …), never a full combo. */
+export function isModifierKey(key: string): boolean {
+  return MODIFIER_KEY_NAMES.has(key);
+}
+
+function normalizeKey(key: string): string {
+  if (key === " " || key === "Spacebar") return "Space";
+  if (key === "+") return "Plus";
+  return key.length === 1 ? key.toLowerCase() : key;
+}
+
+/** Parse a stored string into its parts; null when it isn't well-formed. */
+export function parseShortcut(value: string): ShortcutCombo | null {
+  if (typeof value !== "string") return null;
+  const parts = value.split("+").map((part) => part.trim());
+  const key = normalizeKey(parts.pop() ?? "");
+  if (!key || isModifierKey(key)) return null;
+  const combo: ShortcutCombo = { mod: false, shift: false, alt: false, key };
+  for (const part of parts) {
+    const name = part.toLowerCase();
+    if (name === "mod") combo.mod = true;
+    else if (name === "shift") combo.shift = true;
+    else if (name === "alt") combo.alt = true;
+    else return null;
+  }
+  return combo;
+}
+
+/** The canonical string form: Mod, Shift, Alt, then the key (upper-cased when it's one character). */
+export function formatShortcut(combo: ShortcutCombo): string {
+  const parts: string[] = [];
+  if (combo.mod) parts.push("Mod");
+  if (combo.shift) parts.push("Shift");
+  if (combo.alt) parts.push("Alt");
+  parts.push(combo.key.length === 1 ? combo.key.toUpperCase() : combo.key);
+  return parts.join("+");
+}
+
+/** Canonical spelling of a stored value, or null when it isn't well-formed. */
+export function canonicalShortcut(value: string): string | null {
+  const combo = parseShortcut(value);
+  return combo ? formatShortcut(combo) : null;
+}
+
+/**
+ * Key identity for matching and capture. Letters and digits come from the
+ * physical key (`code`) because Alt on macOS turns "k" into "˚" and Shift turns
+ * "1" into "!"; everything else uses `key` so named keys read naturally.
+ */
+export function eventKey(event: ShortcutKeyEvent): string {
+  const code = event.code ?? "";
+  const letter = /^Key([A-Z])$/.exec(code);
+  if (letter) return letter[1].toLowerCase();
+  const digit = /^Digit(\d)$/.exec(code);
+  if (digit) return digit[1];
+  return normalizeKey(event.key);
+}
+
+/**
+ * The combination a keydown represents, or null when it isn't one we could
+ * bind: a bare modifier, or the platform's *other* primary modifier (Ctrl on
+ * macOS, Meta elsewhere), which isn't part of the Mod/Shift/Alt vocabulary.
+ */
+export function comboFromEvent(event: ShortcutKeyEvent, mac: boolean): ShortcutCombo | null {
+  if (isModifierKey(event.key)) return null;
+  if (mac ? event.ctrlKey : event.metaKey) return null;
+  return {
+    mod: mac ? event.metaKey : event.ctrlKey,
+    shift: event.shiftKey,
+    alt: event.altKey,
+    key: eventKey(event),
+  };
+}
+
+function sameCombo(a: ShortcutCombo, b: ShortcutCombo): boolean {
+  return a.mod === b.mod && a.shift === b.shift && a.alt === b.alt && a.key === b.key;
+}
+
+/** Whether two stored values mean the same keystroke (spelling-insensitive). */
+export function sameShortcut(a: string, b: string): boolean {
+  const canonical = canonicalShortcut(a);
+  return canonical !== null && canonical === canonicalShortcut(b);
+}
+
 /** Map a keydown to a shortcut action, or null when it isn't one of ours. */
-export function matchShortcut(event: ShortcutKeyEvent, mac: boolean): ShortcutAction | null {
-  if (event.repeat || event.isComposing || event.altKey || !event.shiftKey) return null;
-  const mod = mac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey;
-  if (!mod) return null;
-  const key = event.key.toLowerCase();
-  for (const action of Object.keys(SHORTCUTS) as ShortcutAction[]) {
-    if (SHORTCUTS[action].key === key) return action;
+export function matchShortcut(
+  event: ShortcutKeyEvent,
+  mac: boolean,
+  shortcuts: Shortcuts = DEFAULT_SHORTCUTS,
+): ShortcutAction | null {
+  if (event.repeat || event.isComposing) return null;
+  const pressed = comboFromEvent(event, mac);
+  if (!pressed) return null;
+  for (const action of SHORTCUT_ACTIONS) {
+    const combo = parseShortcut(shortcuts[action]);
+    if (combo && sameCombo(combo, pressed)) return action;
   }
   return null;
 }
 
-export function shortcutLabel(action: ShortcutAction, mac: boolean): string {
-  return SHORTCUTS[action].label.replace("Mod", mac ? "⌘" : "Ctrl");
+/** A combination that can't fire while merely typing: Mod or Alt is held, or it's a function key. */
+function usableAlone(combo: ShortcutCombo): boolean {
+  return combo.mod || combo.alt || /^F([1-9]|1[0-9]|2[0-4])$/.test(combo.key);
+}
+
+/** A well-formed stored value that won't fire while merely typing. */
+export function isValidShortcut(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const combo = parseShortcut(value);
+  return combo !== null && usableAlone(combo);
+}
+
+/**
+ * Why `value` can't be bound to `action`, or null when it can. `current` is
+ * the full set, so the other actions' bindings are checked for collisions.
+ */
+export function shortcutProblem(
+  value: string,
+  action: ShortcutAction,
+  current: Shortcuts,
+  mac: boolean,
+): string | null {
+  const combo = parseShortcut(value);
+  if (!combo) return "That isn't a usable key combination.";
+  if (combo.key === "Escape") return "Escape can't be a shortcut.";
+  if (!usableAlone(combo)) {
+    return mac
+      ? "Include ⌘ or ⌥ (or use a function key) so it can't fire while typing."
+      : "Include Ctrl or Alt (or use a function key) so it can't fire while typing.";
+  }
+  const canonical = formatShortcut(combo);
+  const label = shortcutLabel(canonical, mac);
+  const reserved = RESERVED_SHORTCUTS[canonical];
+  if (reserved) return `${label} is ${reserved}.`;
+  for (const other of SHORTCUT_ACTIONS) {
+    if (other !== action && sameShortcut(current[other], canonical)) {
+      return `${label} is already used to ${SHORTCUT_ACTION_LABELS[other].toLowerCase()}.`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Coerce whatever was stored into a full, canonical set: each action falls
+ * back to its default when its value is missing or unusable, and a collision
+ * between the two actions is broken in favor of the toggle.
+ */
+export function normalizeShortcuts(input: unknown): Shortcuts {
+  const source = (input ?? {}) as Partial<Record<ShortcutAction, unknown>>;
+  const result: Shortcuts = { ...DEFAULT_SHORTCUTS };
+  for (const action of SHORTCUT_ACTIONS) {
+    const value = source[action];
+    if (isValidShortcut(value)) result[action] = canonicalShortcut(value) ?? DEFAULT_SHORTCUTS[action];
+  }
+  if (sameShortcut(result.toggle, result.mute)) {
+    result.mute = DEFAULT_SHORTCUTS.mute;
+    if (sameShortcut(result.toggle, result.mute)) result.toggle = DEFAULT_SHORTCUTS.toggle;
+  }
+  return result;
+}
+
+const KEY_DISPLAY: Readonly<Record<string, string>> = {
+  ArrowUp: "↑",
+  ArrowDown: "↓",
+  ArrowLeft: "←",
+  ArrowRight: "→",
+  Escape: "Esc",
+  Plus: "+",
+};
+
+function displayKey(key: string): string {
+  return KEY_DISPLAY[key] ?? (key.length === 1 ? key.toUpperCase() : key);
+}
+
+/** Human-readable parts, e.g. ["⌘", "Shift", "H"] — one keycap each in the settings UI. */
+export function shortcutLabelParts(value: string, mac: boolean): string[] {
+  const combo = parseShortcut(value);
+  if (!combo) return [value];
+  const parts: string[] = [];
+  if (combo.mod) parts.push(mac ? "⌘" : "Ctrl");
+  if (combo.shift) parts.push("Shift");
+  if (combo.alt) parts.push(mac ? "⌥" : "Alt");
+  parts.push(displayKey(combo.key));
+  return parts;
+}
+
+export function shortcutLabel(value: string, mac: boolean): string {
+  return shortcutLabelParts(value, mac).join("+");
 }


### PR DESCRIPTION
Follows #18, which added fixed Mod+Shift+H / Mod+Shift+U bindings. This makes them editable.

## Summary

- New **Keyboard shortcuts** settings section (below Audio). Each action shows its binding as keycaps with a **Change** button that records the next combination pressed. Esc keeps the current binding; a reset link appears when a binding differs from the default.
- A binding must include Mod or Alt, or be a function key, so it can't fire while typing. bb's own Mod+Shift+P and Mod+Shift+M are refused, and the two actions can't share a combo. Problems show inline and recording stays open so the user can try again.
- Bindings live in the kv config next to model/voice/behavior, so they sync across windows and devices via `config-changed`. `shortcut-store.ts` mirrors them in the browser (seeded from a localStorage cache) so the content-script keydown listener reads them synchronously and tooltips update on save, no reload needed.
- While the recorder is active the global listener stands down, so pressing the old binding mid-capture can't start a call.
- `shortcuts.ts` is now a shared, dependency-free module: parse/format a canonical `Mod+Shift+H` string, match keydowns by physical key (Alt+K on macOS still matches despite reporting `˚`), and validate. `server.ts` uses it to validate `setConfig` input and normalize whatever is stored.
- Palette rows no longer bake the shortcut into their title, since they are registered once per frontend generation and would go stale after a rebind. Tooltips carry the live hint instead.

## Verification

- `npm test`: 34/34. `npm run typecheck` clean.
- Against a live server: `getConfig` returns `shortcuts`; `setConfig` with `Shift+H` is rejected with a 400 and `not a usable key combination`; `mod+alt+k` round-trips as `Mod+Alt+K`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
