### PR TITLE
Show mobile threads in a drawer while preserving desktop navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ A voice session is shared across all your bb windows and devices: the sidebar
 shows a live voice bar (with which device the session came through), and any
 window can pick it up or stop it.
 
+## Views beside the call
+
+Ask “show that thread” to open it beside your call. Ask “show all my running
+threads” to keep a collection of threads open. Desktop shows tabs; mobile shows
+one thread with a selector. You can switch or close views by touch or voice;
+closing a view does not stop its thread or the call.
+
+Behavior → Thread tabs controls whether opens replace the current tab or keep
+threads in separate tabs. Automatic reuses on mobile and keeps tabs on desktop.
+“Open it in another tab” overrides the default, and “always keep threads in
+separate tabs” saves the preference. Opening several threads always keeps them
+all. The collection lasts for the current app session.
+
+Views work from Handsfree and supported existing-thread panels. A screen without
+a local panel reports that limitation rather than navigating another window.
+See [the design and phone-test checklist](docs/thread-views.md) for SDK limits,
+logging behavior, and the path to additional view types.
+
 ## Inspecting live threads from the terminal
 
 The same "Live threads" view from the sidebar is available as a CLI, for you
@@ -147,7 +165,7 @@ response.create).
 
 Voice tools: `get_context`, `list_projects`, `list_machines`,
 `list_live_threads`, `list_threads`, `search_threads`, `read_thread`,
-`focus_thread`, `set_pane`, `send_to_thread`, `start_thread`, `stop_thread`,
+`focus_thread`, `focus_threads`, `manage_views`, `set_view_behavior`, `set_pane`, `send_to_thread`, `start_thread`, `stop_thread`,
 `archive_thread`, `rename_thread`, `show_diff`, `update_instructions`,
 `run_plugin_cli`, plus frontend-local `set_composer_text` /
 `append_composer_text`.

--- a/README.md
+++ b/README.md
@@ -61,23 +61,26 @@ A voice session is shared across all your bb windows and devices: the sidebar
 shows a live voice bar (with which device the session came through), and any
 window can pick it up or stop it.
 
-## Views beside the call
+## Mobile views beside the call
 
-Ask “show that thread” to open it beside your call. Ask “show all my running
-threads” to keep a collection of threads open. Desktop shows tabs; mobile shows
-one thread with a selector. You can switch or close views by touch or voice;
-closing a view does not stop its thread or the call.
+On mobile, “show that thread” opens a drawer without leaving the voice call.
+“Show all my running threads” keeps them in the drawer's thread switcher.
+These are views inside one drawer, not separate native bb tabs. Closing a view
+does not stop its thread or the call.
 
-Behavior → Thread tabs controls whether opens replace the current tab or keep
-threads in separate tabs. Automatic reuses on mobile and keeps tabs on desktop.
-“Open it in another tab” overrides the default, and “always keep threads in
-separate tabs” saves the preference. Opening several threads always keeps them
-all. The collection lasts for the current app session.
+Behavior → Mobile thread drawer controls whether a new thread replaces the
+shown one or joins the switcher. “Always keep threads in the mobile drawer”
+saves that preference; an explicit request can override it. The collection lasts
+for the current app session. Supported destinations are the Handsfree page and
+existing thread panels; unsupported mobile surfaces report the limitation.
 
-Views work from Handsfree and supported existing-thread panels. A screen without
-a local panel reports that limitation rather than navigating another window.
-See [the design and phone-test checklist](docs/thread-views.md) for SDK limits,
-logging behavior, and the path to additional view types.
+Desktop `focus_thread` continues navigating to the requested thread from both
+the composer and Handsfree page. Mobile settings do not change that behavior.
+Per-entry-point desktop navigation/side-panel settings and native multi-tab
+behavior are a [separate design](docs/desktop-navigation-plan.md).
+
+See [the mobile design and device checklist](docs/thread-views.md) for SDK limits
+and the shared session/plugin logging behavior.
 
 ## Inspecting live threads from the terminal
 
@@ -165,7 +168,7 @@ response.create).
 
 Voice tools: `get_context`, `list_projects`, `list_machines`,
 `list_live_threads`, `list_threads`, `search_threads`, `read_thread`,
-`focus_thread`, `focus_threads`, `manage_views`, `set_view_behavior`, `set_pane`, `send_to_thread`, `start_thread`, `stop_thread`,
+`focus_thread`, `set_pane`, `send_to_thread`, `start_thread`, `stop_thread`,
 `archive_thread`, `rename_thread`, `show_diff`, `update_instructions`,
 `run_plugin_cli`, plus frontend-local `set_composer_text` /
 `append_composer_text`.
@@ -176,3 +179,6 @@ Dev loop:
 bb plugin dev          # rebuild + reload on save
 bb plugin logs handsfree -f # tool traffic and errors
 ```
+
+Mobile calls additionally expose `focus_threads`, `manage_views`, and
+`set_view_behavior` for the drawer. Desktop retains its navigation tool set.

--- a/app-registration.test.ts
+++ b/app-registration.test.ts
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { build } from "esbuild";
+import { JSDOM } from "jsdom";
+import { loadPluginApp } from "@get-bb/plugin-sdk/testing/app";
+
+test("the actual app registers drawer surfaces only on mobile clients", async () => {
+  // Bundle source only to handle CSS/TSX, retaining the real SDK registration
+  // harness and all actual app registration code. No microphone is started.
+  const directory = mkdtempSync(join(process.cwd(), ".handsfree-registration-test-"));
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", { url: "http://localhost" });
+  const descriptors = ["window", "document", "navigator"].map(name => [name, Object.getOwnPropertyDescriptor(globalThis, name)] as const);
+  try {
+    for (const [name, value] of Object.entries({ window: dom.window, document: dom.window.document, navigator: dom.window.navigator })) {
+      Object.defineProperty(globalThis, name, { value, configurable: true });
+    }
+    const file = join(directory, "app.mjs");
+    await build({ entryPoints: ["app.tsx"], outfile: file, bundle: true, platform: "node", format: "esm", packages: "external", loader: { ".css": "empty" }, jsx: "automatic", logLevel: "silent" });
+    for (const mobile of [false, true]) {
+      Object.defineProperty(dom.window.navigator, "userAgent", { value: mobile ? "Mozilla/5.0 (iPhone) Mobile Safari" : "Mozilla/5.0 (Macintosh; Intel Mac OS X) Chrome", configurable: true });
+      const app = await loadPluginApp(() => import(`${pathToFileURL(file).href}?mobile=${mobile}`));
+      const page = app.navPanels.find(panel => panel.id === "sessions");
+      assert.ok(page);
+      assert.equal(page.fixedTabs?.length ?? 0, mobile ? 1 : 0);
+      assert.equal(app.threadPanelActions.some(action => action.id === "thread-workspace"), mobile);
+    }
+  } finally {
+    for (const [name, descriptor] of descriptors) {
+      if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+      else Reflect.deleteProperty(globalThis, name);
+    }
+    dom.window.close();
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/app.tsx
+++ b/app.tsx
@@ -18,6 +18,7 @@ import {
 } from "@get-bb/plugin-sdk/app";
 import type { PluginThreadListProps } from "@get-bb/plugin-sdk/app";
 import type { rpcContract } from "./server";
+import { clientDescriptor } from "./client-identity";
 import { voiceAgent } from "./voice-agent";
 import { SessionsPanel } from "./sessions-panel";
 import { viewWorkspace } from "./view-workspace";
@@ -48,7 +49,7 @@ function AideVoiceButton() {
   const navigate = useBbNavigate();
   const surface = useRef<HTMLElement | null>(null);
   useEffect(() => {
-    if (scope.kind !== "thread" || scope.threadId !== threadId) return;
+    if (!clientDescriptor.mobile || scope.kind !== "thread" || scope.threadId !== threadId) return;
     return viewWorkspace.registerPresenter({
       available: () => document.visibilityState !== "hidden" && !!surface.current &&
         !surface.current.closest("[data-handsfree-workspace]"),
@@ -369,9 +370,9 @@ export default definePluginApp((app) => {
     id: "aide-voice",
     actions: [{ id: "voice-agent", component: AideVoiceButton }],
   });
-  app.slots.threadPanelAction({
+  if (clientDescriptor.mobile) app.slots.threadPanelAction({
     id: THREAD_WORKSPACE_ACTION,
-    title: "Handsfree views",
+    title: "Handsfree mobile views",
     icon: "PanelRight",
     layout: "flush",
     component: CompanionTab,
@@ -384,9 +385,9 @@ export default definePluginApp((app) => {
     path: "sessions",
     component: SessionsPanel,
     experimental_sidebarAccessory: SidebarLiveIndicator,
-    // A single host panel contains the local collection. bb supplies its
-    // desktop panel/mobile drawer; Handsfree supplies view selection and tabs.
-    fixedTabs: [
+    // Registration is collected in each client: desktop keeps its original
+    // panel chrome, while mobile gains a call-safe drawer view.
+    fixedTabs: clientDescriptor.mobile ? [
       {
         ...COMPANION_TAB,
         title: "Views",
@@ -394,7 +395,7 @@ export default definePluginApp((app) => {
         component: CompanionTab,
         layout: "flush",
       },
-    ],
+    ] : [],
   });
   // --- Global surface trial: multiple always-reachable triggers for the same
   // singleton call. All are pure toggles; the composer button owns the binding.

--- a/app.tsx
+++ b/app.tsx
@@ -19,6 +19,7 @@ import type { PluginThreadListProps } from "@get-bb/plugin-sdk/app";
 import type { rpcContract } from "./server";
 import { voiceAgent } from "./voice-agent";
 import { SessionsPanel } from "./sessions-panel";
+import { COMPANION_TAB, CompanionTab } from "./companion";
 import { AudioSettings, BehaviorSettings, ModelsSettings, ShortcutsSettings } from "./settings-sections";
 import { cn } from "@/lib/utils";
 import { AUDIO_DEVICE_STORAGE_KEY } from "./audio-devices";
@@ -360,6 +361,19 @@ export default definePluginApp((app) => {
     path: "sessions",
     component: SessionsPanel,
     experimental_sidebarAccessory: SidebarLiveIndicator,
+    // The companion surface: on mobile it renders as a drawer beside the call, so
+    // Aide can show a thread during a live call without navigating (which would
+    // background the app and cut the mic). The voice agent drives it via
+    // openFixedTab; see companion.tsx and the focus_thread routing in voice-agent.
+    fixedTabs: [
+      {
+        ...COMPANION_TAB,
+        title: "Companion",
+        icon: "PanelRight",
+        component: CompanionTab,
+        layout: "flush",
+      },
+    ],
   });
   // --- Global surface trial: multiple always-reachable triggers for the same
   // singleton call. All are pure toggles; the composer button owns the binding.

--- a/app.tsx
+++ b/app.tsx
@@ -5,11 +5,12 @@
 // and audio playback happen right here in the bb app); the backend performs
 // the SDP exchange (it holds the API key) and executes bb tools via bb.sdk.
 // The session itself lives in voice-agent.ts and outlives any component.
-import { useEffect, useSyncExternalStore } from "react";
+import { useEffect, useRef, useSyncExternalStore } from "react";
 import {
   definePluginApp,
   experimental_useSidebarThreadActions,
   useBbContext,
+  useBbNavigate,
   useComposer,
   useComposerView,
   useRealtime,
@@ -19,7 +20,8 @@ import type { PluginThreadListProps } from "@get-bb/plugin-sdk/app";
 import type { rpcContract } from "./server";
 import { voiceAgent } from "./voice-agent";
 import { SessionsPanel } from "./sessions-panel";
-import { COMPANION_TAB, CompanionTab } from "./companion";
+import { viewWorkspace } from "./view-workspace";
+import { COMPANION_TAB, CompanionTab, THREAD_WORKSPACE_ACTION } from "./companion";
 import { AudioSettings, BehaviorSettings, ModelsSettings, ShortcutsSettings } from "./settings-sections";
 import { cn } from "@/lib/utils";
 import { AUDIO_DEVICE_STORAGE_KEY } from "./audio-devices";
@@ -39,7 +41,20 @@ function AideVoiceButton() {
   const onNewThreadScreen = scope.kind === "new-thread";
   const scopeProjectId =
     scope.kind === "new-thread" || scope.kind === "side-chat" ? scope.projectId : null;
-  const effectiveProjectId = projectId ?? scopeProjectId;
+  const effectiveThreadId = scope.kind === "thread" ? scope.threadId : threadId;
+  const views = useSyncExternalStore(viewWorkspace.subscribe, viewWorkspace.get);
+  const shownThread = views.views.find(view => view.threadId === effectiveThreadId);
+  const effectiveProjectId = shownThread?.projectId ?? (effectiveThreadId === threadId ? projectId : null) ?? scopeProjectId;
+  const navigate = useBbNavigate();
+  const surface = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    if (scope.kind !== "thread" || scope.threadId !== threadId) return;
+    return viewWorkspace.registerPresenter({
+      available: () => document.visibilityState !== "hidden" && !!surface.current &&
+        !surface.current.closest("[data-handsfree-workspace]"),
+      reveal: () => navigate.openThreadPanel({ actionId: THREAD_WORKSPACE_ACTION, title: "Views", params: {} }),
+    });
+  }, [navigate, scope.kind, effectiveThreadId, threadId]);
   const sidebarActions = experimental_useSidebarThreadActions();
   const state = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
   const activity = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getActivity);
@@ -95,9 +110,9 @@ function AideVoiceButton() {
   // new composer's button mounts and rebinds, so "this thread" and composer
   // edits follow the user while the call keeps running.
   useEffect(() => {
-    voiceAgent.bind({
+    return voiceAgent.bind({
       rpc,
-      context: { threadId, projectId: effectiveProjectId, onNewThreadScreen },
+      context: { threadId: effectiveThreadId, projectId: effectiveProjectId, onNewThreadScreen },
       composer: {
         setText: (text) => composer.setText(text),
         updateText: (updater) => composer.updateText(updater),
@@ -108,7 +123,7 @@ function AideVoiceButton() {
           focusPrompt: true,
         }),
     });
-  }, [rpc, composer, threadId, effectiveProjectId, onNewThreadScreen, sidebarActions]);
+  }, [rpc, composer, effectiveThreadId, effectiveProjectId, onNewThreadScreen, sidebarActions]);
 
   const live = state === "live";
   const muted = state === "muted";
@@ -187,7 +202,7 @@ function AideVoiceButton() {
   }
 
   return (
-    <button
+    <button ref={node => { surface.current = node; }}
       type="button"
       aria-label="Start Aide voice agent"
       title={`Talk to Aide (${toggleHint})`}
@@ -354,6 +369,14 @@ export default definePluginApp((app) => {
     id: "aide-voice",
     actions: [{ id: "voice-agent", component: AideVoiceButton }],
   });
+  app.slots.threadPanelAction({
+    id: THREAD_WORKSPACE_ACTION,
+    title: "Handsfree views",
+    icon: "PanelRight",
+    layout: "flush",
+    component: CompanionTab,
+    run: context => { context.openPanel({ title: "Views", params: {} }); },
+  });
   app.slots.navPanel({
     id: "sessions",
     title: "Handsfree",
@@ -361,14 +384,12 @@ export default definePluginApp((app) => {
     path: "sessions",
     component: SessionsPanel,
     experimental_sidebarAccessory: SidebarLiveIndicator,
-    // The companion surface: on mobile it renders as a drawer beside the call, so
-    // Aide can show a thread during a live call without navigating (which would
-    // background the app and cut the mic). The voice agent drives it via
-    // openFixedTab; see companion.tsx and the focus_thread routing in voice-agent.
+    // A single host panel contains the local collection. bb supplies its
+    // desktop panel/mobile drawer; Handsfree supplies view selection and tabs.
     fixedTabs: [
       {
         ...COMPANION_TAB,
-        title: "Companion",
+        title: "Views",
         icon: "PanelRight",
         component: CompanionTab,
         layout: "flush",

--- a/client-identity.test.ts
+++ b/client-identity.test.ts
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isMobileClient } from "./client-identity.ts";
+
+test("mobile routing includes iPads with desktop Safari while preserving real desktop detection", () => {
+  assert.equal(isMobileClient("Mozilla/5.0 (Macintosh; Intel Mac OS X) Safari/605", false, 5), true);
+  assert.equal(isMobileClient("Mozilla/5.0 (iPad; CPU OS 18) Safari/605"), true);
+  assert.equal(isMobileClient("Mozilla/5.0 (iPhone; CPU iPhone OS) Mobile Safari"), true);
+  assert.equal(isMobileClient("Mozilla/5.0 (Linux; Android 15) Chrome", false), true);
+  assert.equal(isMobileClient("Mozilla/5.0 (Macintosh; Intel Mac OS X) Safari/605", false, 0), false);
+  assert.equal(isMobileClient("Mozilla/5.0 (Windows NT 10.0) Chrome", false, 10), false);
+});

--- a/client-identity.ts
+++ b/client-identity.ts
@@ -83,13 +83,20 @@ function detectDisplayMode(): string {
   return "browser";
 }
 
+/** Include iPads using desktop Safari's user agent in mobile call routing. */
+export function isMobileClient(ua: string, uaMobile = false, maxTouchPoints = 0): boolean {
+  return uaMobile || /\b(iPhone|iPad|iPod|Android)\b|Mobile/.test(ua) ||
+    (/Macintosh/.test(ua) && maxTouchPoints > 1);
+}
+
 function describeClient(): ClientDescriptor {
   const nav = typeof navigator !== "undefined" ? navigator : undefined;
   const ua = nav?.userAgent ?? "";
   const uaData = (nav as { userAgentData?: { platform?: string; mobile?: boolean; brands?: { brand: string }[] } } | undefined)
     ?.userAgentData;
 
-  const platform =
+  const desktopIPad = /Macintosh/.test(ua) && (nav?.maxTouchPoints ?? 0) > 1;
+  const platform = desktopIPad ? "iOS" :
     uaData?.platform ||
     (/\b(iPhone|iPad|iPod)\b/.test(ua)
       ? "iOS"
@@ -103,7 +110,7 @@ function describeClient(): ClientDescriptor {
               ? "Linux"
               : "");
 
-  const mobile = uaData?.mobile ?? /\b(Mobi|iPhone|iPod|Android)\b/.test(ua);
+  const mobile = isMobileClient(ua, uaData?.mobile, nav?.maxTouchPoints);
 
   const brand = uaData?.brands?.map((b) => b.brand).find((b) => b && !/Not.?A.?Brand/i.test(b));
   const browser =

--- a/companion.test.tsx
+++ b/companion.test.tsx
@@ -14,18 +14,18 @@ const { CompanionTab } = await import("./companion.tsx");
 after(() => dom.window.close());
 const view = (id: string): ThreadView => ({ kind: "thread", id: `thread:${id}`, threadId: id, projectId: "project", title: `Thread ${id}` });
 
-test("desktop buttons and the mobile switcher share selection; closing only removes the requested view", () => {
+test("the mobile switcher changes the shown thread; closing only removes the requested view", () => {
   viewWorkspace.clear();
   const unregister = viewWorkspace.registerPresenter({ available: () => true, reveal: () => true });
   const slot = renderSlot({ component: CompanionTab }, {});
   try {
     assert.match(slot.container.textContent ?? "", /all your running threads/);
-    act(() => viewWorkspace.open([view("a"), view("b")], "new", "auto", true));
+    act(() => viewWorkspace.open([view("a"), view("b")], "new", "reuse"));
     assert.equal(slot.getAllByTestId("bb-thread-chat").length, 1);
     assert.equal(slot.getByRole("combobox", { name: "Shown thread" }).getAttribute("aria-label"), "Shown thread");
     fireEvent.change(slot.getByRole("combobox"), { target: { value: "thread:b" } });
     assert.equal(viewWorkspace.get().activeId, "thread:b");
-    fireEvent.click(slot.getByRole("button", { name: "Thread a" }));
+    fireEvent.change(slot.getByRole("combobox"), { target: { value: "thread:a" } });
     assert.equal(viewWorkspace.get().activeId, "thread:a");
     const chat = slot.getByTestId("bb-thread-chat");
     assert.equal(chat.getAttribute("data-thread-id"), "a");
@@ -41,7 +41,7 @@ test("desktop buttons and the mobile switcher share selection; closing only remo
 test("closing and remounting a host panel preserves the collection for the app session", () => {
   viewWorkspace.clear();
   const unregister = viewWorkspace.registerPresenter({ available: () => true, reveal: () => true });
-  viewWorkspace.open([view("a"), view("b")], "new", "auto", true);
+  viewWorkspace.open([view("a"), view("b")], "new", "reuse");
   const first = renderSlot({ component: CompanionTab }, {});
   first.lifecycle.unmount();
   assert.equal(viewWorkspace.current(), null);

--- a/companion.test.tsx
+++ b/companion.test.tsx
@@ -1,0 +1,53 @@
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import { installTestPluginRuntime, renderSlot } from "@get-bb/plugin-sdk/testing/app";
+import { act, fireEvent } from "@testing-library/react";
+import { viewWorkspace, type ThreadView } from "./view-workspace.ts";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", { url: "http://localhost", pretendToBeVisual: true });
+for (const [name, value] of Object.entries({ window: dom.window, document: dom.window.document, navigator: dom.window.navigator, HTMLElement: dom.window.HTMLElement, IS_REACT_ACT_ENVIRONMENT: true })) {
+  Object.defineProperty(globalThis, name, { value, configurable: true, writable: true });
+}
+installTestPluginRuntime();
+const { CompanionTab } = await import("./companion.tsx");
+after(() => dom.window.close());
+const view = (id: string): ThreadView => ({ kind: "thread", id: `thread:${id}`, threadId: id, projectId: "project", title: `Thread ${id}` });
+
+test("desktop buttons and the mobile switcher share selection; closing only removes the requested view", () => {
+  viewWorkspace.clear();
+  const unregister = viewWorkspace.registerPresenter({ available: () => true, reveal: () => true });
+  const slot = renderSlot({ component: CompanionTab }, {});
+  try {
+    assert.match(slot.container.textContent ?? "", /all your running threads/);
+    act(() => viewWorkspace.open([view("a"), view("b")], "new", "auto", true));
+    assert.equal(slot.getAllByTestId("bb-thread-chat").length, 1);
+    assert.equal(slot.getByRole("combobox", { name: "Shown thread" }).getAttribute("aria-label"), "Shown thread");
+    fireEvent.change(slot.getByRole("combobox"), { target: { value: "thread:b" } });
+    assert.equal(viewWorkspace.get().activeId, "thread:b");
+    fireEvent.click(slot.getByRole("button", { name: "Thread a" }));
+    assert.equal(viewWorkspace.get().activeId, "thread:a");
+    const chat = slot.getByTestId("bb-thread-chat");
+    assert.equal(chat.getAttribute("data-thread-id"), "a");
+    fireEvent.click(slot.getAllByRole("button", { name: "Close Thread a" })[0]);
+    assert.equal(viewWorkspace.get().activeId, "thread:b");
+    assert.equal(slot.getByTestId("bb-thread-chat").getAttribute("data-thread-id"), "b");
+    fireEvent.click(slot.getAllByRole("button", { name: "Close Thread b" })[0]);
+    assert.equal(slot.queryByTestId("bb-thread-chat"), null);
+    assert.equal(viewWorkspace.get().views.length, 0);
+  } finally { slot.lifecycle.unmount(); unregister(); }
+});
+
+test("closing and remounting a host panel preserves the collection for the app session", () => {
+  viewWorkspace.clear();
+  const unregister = viewWorkspace.registerPresenter({ available: () => true, reveal: () => true });
+  viewWorkspace.open([view("a"), view("b")], "new", "auto", true);
+  const first = renderSlot({ component: CompanionTab }, {});
+  first.lifecycle.unmount();
+  assert.equal(viewWorkspace.current(), null);
+  const second = renderSlot({ component: CompanionTab }, {});
+  try {
+    assert.equal(second.getAllByRole("option").length, 2);
+    assert.equal(second.getByTestId("bb-thread-chat").getAttribute("data-thread-id"), "a");
+  } finally { second.lifecycle.unmount(); unregister(); viewWorkspace.clear(); }
+});

--- a/companion.test.tsx
+++ b/companion.test.tsx
@@ -2,7 +2,7 @@ import test, { after } from "node:test";
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import { installTestPluginRuntime, renderSlot } from "@get-bb/plugin-sdk/testing/app";
-import { act, fireEvent } from "@testing-library/react";
+import { act, fireEvent, within } from "@testing-library/react";
 import { viewWorkspace, type ThreadView } from "./view-workspace.ts";
 
 const dom = new JSDOM("<!doctype html><html><body></body></html>", { url: "http://localhost", pretendToBeVisual: true });
@@ -11,6 +11,8 @@ for (const [name, value] of Object.entries({ window: dom.window, document: dom.w
 }
 installTestPluginRuntime();
 const { CompanionTab } = await import("./companion.tsx");
+const { voiceAgent } = await import("./voice-agent.ts");
+const { LiveCallControls } = await import("./voice-chrome.tsx");
 after(() => dom.window.close());
 const view = (id: string): ThreadView => ({ kind: "thread", id: `thread:${id}`, threadId: id, projectId: "project", title: `Thread ${id}` });
 
@@ -50,4 +52,43 @@ test("closing and remounting a host panel preserves the collection for the app s
     assert.equal(second.getAllByRole("option").length, 2);
     assert.equal(second.getByTestId("bb-thread-chat").getAttribute("data-thread-id"), "a");
   } finally { second.lifecycle.unmount(); unregister(); viewWorkspace.clear(); }
+});
+
+
+test("drawer controls share call state, survive view changes, and only stop on explicit tap", (t) => {
+  const call = voiceAgent as unknown as { state: "idle" | "connecting" | "live" | "muted"; emitChange(): void };
+  const setState = (state: typeof call.state) => { call.state = state; call.emitChange(); };
+  const mute = t.mock.method(voiceAgent, "toggleMuteFromSurface", () => setState(call.state === "muted" ? "live" : "muted"));
+  const stop = t.mock.method(voiceAgent, "stopFromSurface", () => setState("idle"));
+  viewWorkspace.clear();
+  const unregister = viewWorkspace.registerPresenter({ available: () => true, reveal: () => true });
+  const drawer = renderSlot({ component: CompanionTab }, {});
+  const pageControls = renderSlot({ component: LiveCallControls }, {});
+  const drawerUi = within(drawer.container);
+  const pageUi = within(pageControls.container);
+  try {
+    assert.equal(drawerUi.queryByRole("group", { name: "Aide call controls" }), null);
+    act(() => setState("connecting"));
+    assert.equal(drawerUi.getByRole("button", { name: "Mute Aide microphone" }).hasAttribute("disabled"), true);
+    assert.ok(drawerUi.getByText("Connecting…"));
+    act(() => setState("live"));
+    act(() => viewWorkspace.open([view("a"), view("b")], "new", "reuse"));
+    fireEvent.click(drawerUi.getByRole("button", { name: "Mute Aide microphone" }));
+    assert.equal(mute.mock.callCount(), 1);
+    assert.ok(pageUi.getByRole("button", { name: "Unmute Aide microphone" }));
+    fireEvent.change(drawerUi.getByRole("combobox"), { target: { value: "thread:b" } });
+    assert.ok(drawerUi.getByRole("button", { name: "Unmute Aide microphone" }));
+    act(() => viewWorkspace.clear());
+    assert.ok(drawerUi.getByRole("group", { name: "Aide call controls" }));
+    assert.equal(stop.mock.callCount(), 0);
+    fireEvent.click(pageUi.getByRole("button", { name: "Unmute Aide microphone" }));
+    assert.ok(drawerUi.getByRole("button", { name: "Mute Aide microphone" }));
+    fireEvent.click(drawerUi.getByRole("button", { name: "Stop Aide voice session" }));
+    assert.equal(stop.mock.callCount(), 1);
+    assert.equal(drawerUi.queryByRole("group", { name: "Aide call controls" }), null);
+  } finally {
+    drawer.lifecycle.unmount(); pageControls.lifecycle.unmount(); unregister();
+    setState("idle"); viewWorkspace.clear();
+  }
+  assert.equal(stop.mock.callCount(), 1);
 });

--- a/companion.tsx
+++ b/companion.tsx
@@ -4,6 +4,8 @@ import React, { Component, useEffect, useRef, useSyncExternalStore, type ReactNo
 import { ThreadChat } from "@get-bb/plugin-sdk/app";
 import type { ExperimentalPluginFixedTabReference } from "@get-bb/plugin-sdk/app";
 import { viewWorkspace } from "./view-workspace";
+import { voiceAgent } from "./voice-agent";
+import { LiveCallControls } from "./voice-chrome";
 
 export const COMPANION_TAB: ExperimentalPluginFixedTabReference = { panelId: "sessions", id: "companion" };
 export const THREAD_WORKSPACE_ACTION = "thread-workspace";
@@ -20,6 +22,7 @@ class ViewErrorBoundary extends Component<{ children: ReactNode }, { failed: boo
 
 export function CompanionTab() {
   const { views, activeId } = useSyncExternalStore(viewWorkspace.subscribe, viewWorkspace.get);
+  const callState = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
   const root = useRef<HTMLDivElement>(null);
   const active = views.find(view => view.id === activeId);
   useEffect(() => viewWorkspace.registerVisiblePanel(() =>
@@ -41,9 +44,14 @@ export function CompanionTab() {
             <ThreadChat threadId={active.threadId} variant="compact" layout="contained" />
           </ViewErrorBoundary>
         </div>
-      </> : <div className="flex h-full items-center justify-center p-6 text-center text-sm text-muted-foreground">
+      </> : <div className="flex min-h-0 flex-1 items-center justify-center p-6 text-center text-sm text-muted-foreground">
         Ask Aide to show a thread, or to open all your running threads.
       </div>}
+      {callState !== "idle" && (
+        <div role="group" aria-label="Aide call controls" className="flex shrink-0 justify-center border-t border-border bg-background p-2">
+          <LiveCallControls />
+        </div>
+      )}
     </div>
   );
 }

--- a/companion.tsx
+++ b/companion.tsx
@@ -1,0 +1,50 @@
+// The Handsfree page's mobile companion drawer.
+//
+// The Handsfree nav panel declares a fixed tab (COMPANION_TAB) that the host
+// renders in its companion surface — a bottom drawer on mobile. During a live
+// mobile call the voice agent can't navigate (it would background the app and
+// suspend the mic), so `focus_thread` instead opens the requested thread here
+// via experimental_useAppPanel().openFixedTab({ threadId }); the tab reads that
+// target and shows the thread with <ThreadChat>. Re-targeting with a different
+// threadId swaps which thread is shown, keeping the call alive throughout.
+//
+// The fixed-tab APIs (fixedTabs / useAppPanel / useFixedTabTarget) are all
+// experimental_ SDK surface — expect them to move.
+import {
+  ThreadChat,
+  experimental_useFixedTabTarget,
+} from "@get-bb/plugin-sdk/app";
+import type { ExperimentalPluginFixedTabReference, JsonValue, PluginNavPanelProps } from "@get-bb/plugin-sdk/app";
+
+// Must be JSON-serializable for the host, hence the index signature.
+interface CompanionTarget {
+  threadId: string;
+  [key: string]: JsonValue;
+}
+
+function isCompanionTarget(value: unknown): value is CompanionTarget {
+  return !!value && typeof value === "object" && typeof (value as { threadId?: unknown }).threadId === "string";
+}
+
+/** Shared reference: used both to register the tab (app.tsx) and to open/target it. */
+export const COMPANION_TAB: ExperimentalPluginFixedTabReference<CompanionTarget> = {
+  panelId: "sessions",
+  id: "companion",
+  experimental_target: {
+    validate: (value): value is CompanionTarget => isCompanionTarget(value),
+  },
+};
+
+/** The drawer component. Shows the targeted thread, or a hint when untargeted. */
+export function CompanionTab(_props: PluginNavPanelProps) {
+  const state = experimental_useFixedTabTarget(COMPANION_TAB);
+  const threadId = state?.target.threadId ?? null;
+  if (!threadId) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-center text-sm text-muted-foreground">
+        Ask Aide to show a thread and it appears here beside your call.
+      </div>
+    );
+  }
+  return <ThreadChat threadId={threadId} variant="compact" layout="contained" />;
+}

--- a/companion.tsx
+++ b/companion.tsx
@@ -1,50 +1,57 @@
-// The Handsfree page's mobile companion drawer.
-//
-// The Handsfree nav panel declares a fixed tab (COMPANION_TAB) that the host
-// renders in its companion surface — a bottom drawer on mobile. During a live
-// mobile call the voice agent can't navigate (it would background the app and
-// suspend the mic), so `focus_thread` instead opens the requested thread here
-// via experimental_useAppPanel().openFixedTab({ threadId }); the tab reads that
-// target and shows the thread with <ThreadChat>. Re-targeting with a different
-// threadId swaps which thread is shown, keeping the call alive throughout.
-//
-// The fixed-tab APIs (fixedTabs / useAppPanel / useFixedTabTarget) are all
-// experimental_ SDK surface — expect them to move.
-import {
-  ThreadChat,
-  experimental_useFixedTabTarget,
-} from "@get-bb/plugin-sdk/app";
-import type { ExperimentalPluginFixedTabReference, JsonValue, PluginNavPanelProps } from "@get-bb/plugin-sdk/app";
+// One reusable host panel, with a window-local collection of typed views.
+// Additional first-party renderers can join WorkspaceView when bb supports them.
+import React, { Component, useEffect, useRef, useSyncExternalStore, type ReactNode } from "react";
+import { ThreadChat } from "@get-bb/plugin-sdk/app";
+import type { ExperimentalPluginFixedTabReference } from "@get-bb/plugin-sdk/app";
+import { viewWorkspace } from "./view-workspace";
+import { cn } from "@/lib/utils";
 
-// Must be JSON-serializable for the host, hence the index signature.
-interface CompanionTarget {
-  threadId: string;
-  [key: string]: JsonValue;
-}
+export const COMPANION_TAB: ExperimentalPluginFixedTabReference = { panelId: "sessions", id: "companion" };
+export const THREAD_WORKSPACE_ACTION = "thread-workspace";
 
-function isCompanionTarget(value: unknown): value is CompanionTarget {
-  return !!value && typeof value === "object" && typeof (value as { threadId?: unknown }).threadId === "string";
-}
-
-/** Shared reference: used both to register the tab (app.tsx) and to open/target it. */
-export const COMPANION_TAB: ExperimentalPluginFixedTabReference<CompanionTarget> = {
-  panelId: "sessions",
-  id: "companion",
-  experimental_target: {
-    validate: (value): value is CompanionTarget => isCompanionTarget(value),
-  },
-};
-
-/** The drawer component. Shows the targeted thread, or a hint when untargeted. */
-export function CompanionTab(_props: PluginNavPanelProps) {
-  const state = experimental_useFixedTabTarget(COMPANION_TAB);
-  const threadId = state?.target.threadId ?? null;
-  if (!threadId) {
-    return (
-      <div className="flex h-full items-center justify-center p-6 text-center text-sm text-muted-foreground">
-        Ask Aide to show a thread and it appears here beside your call.
-      </div>
-    );
+class ViewErrorBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+  state = { failed: false };
+  static getDerivedStateFromError() { return { failed: true }; }
+  render() {
+    return this.state.failed
+      ? <p role="alert" className="p-4 text-sm text-destructive">This thread could not be displayed. Close it and try opening it again.</p>
+      : this.props.children;
   }
-  return <ThreadChat threadId={threadId} variant="compact" layout="contained" />;
+}
+
+export function CompanionTab() {
+  const { views, activeId } = useSyncExternalStore(viewWorkspace.subscribe, viewWorkspace.get);
+  const root = useRef<HTMLDivElement>(null);
+  const active = views.find(view => view.id === activeId);
+  useEffect(() => viewWorkspace.registerVisiblePanel(() =>
+    document.visibilityState !== "hidden" && !!root.current?.getClientRects().length,
+  ), []);
+  return (
+    <div ref={root} data-handsfree-workspace className="flex h-full min-h-0 flex-col">
+      {active ? <>
+        <div className="flex shrink-0 items-center gap-2 border-b border-border p-2 md:hidden">
+          <select aria-label="Shown thread" value={activeId ?? ""} onChange={event => viewWorkspace.select(event.target.value)}
+            className="min-w-0 flex-1 rounded-md border border-border bg-background p-2 text-sm">
+            {views.map(view => <option key={view.id} value={view.id}>{view.title}</option>)}
+          </select>
+          <span className="text-xs text-muted-foreground">{views.length}</span>
+          <button type="button" aria-label={`Close ${active.title}`} onClick={() => viewWorkspace.close(active.id)} className="size-11 shrink-0 rounded-md hover:bg-accent">×</button>
+        </div>
+        <div aria-label="Open threads" className="hidden shrink-0 gap-1 overflow-x-auto border-b border-border p-1 md:flex">
+          {views.map(view => <div key={view.id} className={cn("flex shrink-0 items-center rounded-md", view.id === activeId ? "bg-accent" : "hover:bg-muted")}>
+            <button type="button" aria-pressed={view.id === activeId} onClick={() => viewWorkspace.select(view.id)} title={view.title}
+              className="max-w-56 truncate px-3 py-2 text-sm">{view.title}</button>
+            <button type="button" aria-label={`Close ${view.title}`} onClick={() => viewWorkspace.close(view.id)} className="mr-1 size-7 rounded hover:bg-background">×</button>
+          </div>)}
+        </div>
+        <div className="min-h-0 flex-1">
+          <ViewErrorBoundary key={active.id}>
+            <ThreadChat threadId={active.threadId} variant="compact" layout="contained" />
+          </ViewErrorBoundary>
+        </div>
+      </> : <div className="flex h-full items-center justify-center p-6 text-center text-sm text-muted-foreground">
+        Ask Aide to show a thread, or to open all your running threads.
+      </div>}
+    </div>
+  );
 }

--- a/companion.tsx
+++ b/companion.tsx
@@ -1,10 +1,9 @@
-// One reusable host panel, with a window-local collection of typed views.
+// Mobile-only host drawer, with a window-local collection of typed views.
 // Additional first-party renderers can join WorkspaceView when bb supports them.
 import React, { Component, useEffect, useRef, useSyncExternalStore, type ReactNode } from "react";
 import { ThreadChat } from "@get-bb/plugin-sdk/app";
 import type { ExperimentalPluginFixedTabReference } from "@get-bb/plugin-sdk/app";
 import { viewWorkspace } from "./view-workspace";
-import { cn } from "@/lib/utils";
 
 export const COMPANION_TAB: ExperimentalPluginFixedTabReference = { panelId: "sessions", id: "companion" };
 export const THREAD_WORKSPACE_ACTION = "thread-workspace";
@@ -29,20 +28,13 @@ export function CompanionTab() {
   return (
     <div ref={root} data-handsfree-workspace className="flex h-full min-h-0 flex-col">
       {active ? <>
-        <div className="flex shrink-0 items-center gap-2 border-b border-border p-2 md:hidden">
+        <div className="flex shrink-0 items-center gap-2 border-b border-border p-2">
           <select aria-label="Shown thread" value={activeId ?? ""} onChange={event => viewWorkspace.select(event.target.value)}
             className="min-w-0 flex-1 rounded-md border border-border bg-background p-2 text-sm">
             {views.map(view => <option key={view.id} value={view.id}>{view.title}</option>)}
           </select>
           <span className="text-xs text-muted-foreground">{views.length}</span>
           <button type="button" aria-label={`Close ${active.title}`} onClick={() => viewWorkspace.close(active.id)} className="size-11 shrink-0 rounded-md hover:bg-accent">×</button>
-        </div>
-        <div aria-label="Open threads" className="hidden shrink-0 gap-1 overflow-x-auto border-b border-border p-1 md:flex">
-          {views.map(view => <div key={view.id} className={cn("flex shrink-0 items-center rounded-md", view.id === activeId ? "bg-accent" : "hover:bg-muted")}>
-            <button type="button" aria-pressed={view.id === activeId} onClick={() => viewWorkspace.select(view.id)} title={view.title}
-              className="max-w-56 truncate px-3 py-2 text-sm">{view.title}</button>
-            <button type="button" aria-label={`Close ${view.title}`} onClick={() => viewWorkspace.close(view.id)} className="mr-1 size-7 rounded hover:bg-background">×</button>
-          </div>)}
         </div>
         <div className="min-h-0 flex-1">
           <ViewErrorBoundary key={active.id}>

--- a/companion.tsx
+++ b/companion.tsx
@@ -6,6 +6,7 @@ import type { ExperimentalPluginFixedTabReference } from "@get-bb/plugin-sdk/app
 import { viewWorkspace } from "./view-workspace";
 import { voiceAgent } from "./voice-agent";
 import { LiveCallControls } from "./voice-chrome";
+import { useDrawerViewport } from "./hooks/useDrawerViewport";
 
 export const COMPANION_TAB: ExperimentalPluginFixedTabReference = { panelId: "sessions", id: "companion" };
 export const THREAD_WORKSPACE_ACTION = "thread-workspace";
@@ -24,12 +25,13 @@ export function CompanionTab() {
   const { views, activeId } = useSyncExternalStore(viewWorkspace.subscribe, viewWorkspace.get);
   const callState = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
   const root = useRef<HTMLDivElement>(null);
+  useDrawerViewport(root);
   const active = views.find(view => view.id === activeId);
   useEffect(() => viewWorkspace.registerVisiblePanel(() =>
     document.visibilityState !== "hidden" && !!root.current?.getClientRects().length,
   ), []);
   return (
-    <div ref={root} data-handsfree-workspace className="flex h-full min-h-0 flex-col">
+    <div ref={root} data-handsfree-workspace className="flex h-full min-h-0 flex-col overflow-hidden">
       {active ? <>
         <div className="flex shrink-0 items-center gap-2 border-b border-border p-2">
           <select aria-label="Shown thread" value={activeId ?? ""} onChange={event => viewWorkspace.select(event.target.value)}

--- a/docs/desktop-navigation-plan.md
+++ b/docs/desktop-navigation-plan.md
@@ -1,0 +1,76 @@
+# Desktop navigation: separate follow-up
+
+Status: design proposal, not enabled by the mobile drawer PR.
+
+The broader prototype is preserved at commit `0755bcf` on
+`handsfree/desktop-views-exploration`. It is reference material, not the desired
+final desktop behavior: it replaced navigation globally and put multiple views
+inside one tab. The mobile PR restores existing desktop navigation.
+
+## Product contract
+
+Desktop must continue supporting “take me to that thread,” which navigates the
+main UI and reorients the workspace. Users who prefer keeping their current
+workspace in place should be able to choose side-panel presentation instead.
+These choices should depend on where the voice call was started.
+
+Proposed defaults and choices:
+
+| Call entry point | Default | Opt-in alternative |
+| --- | --- | --- |
+| Thread composer | Navigate to the requested thread | Open beside the current work |
+| Aide / Handsfree page | Navigate to the requested thread | Open beside the call |
+| Sidebar / global shortcut | Navigate | Use the current surface's supported panel |
+
+A direct request such as “open it beside me” or “take me there” overrides the
+saved default for that action. A separate tab policy determines whether a
+side-panel open reuses a tab or creates/focuses another native tab. Destination
+and tab reuse are independent choices; one global “companion mode” toggle does
+not express them clearly enough.
+
+An initial settings design can use two explicit rows, “Calls started from the
+composer” and “Calls started from Aide,” each with Navigate / Side panel.
+Decide whether global/sidebar starts need their own row or inherit the current
+surface's preference after trying the flow. Defaults preserve production.
+
+## Implementation boundaries
+
+Capture `callOrigin` once at call creation. Do not infer it from whichever
+composer most recently rebinds the voice singleton. Separately resolve the
+current available destination when a tool executes; the user can navigate
+while the call continues. The owning device/window must receive the action.
+
+For existing thread pages, the installed SDK supports native plugin panel tabs:
+`openThreadPanel` opens distinct tabs for distinct parameters and focuses an
+existing tab for identical parameters. That can implement “open all my running
+threads” as actual host tabs rather than a dropdown inside one tab.
+
+For the Handsfree plugin page, `fixedTabs` is a static declaration. Retargeting a
+fixed tab does not create another native tab. A production API for dynamic plugin
+page tabs is needed for equivalent host-native behavior there. Avoid predeclaring
+an arbitrary pool of empty tabs or silently substituting an internal tab strip.
+
+The existing typed collection and local presenter separation can inform the
+follow-up, but the correct native-tab behavior should drive its implementation.
+Opening arbitrary other plugins needs a supported cross-plugin surface contract
+from bb. Additional first-party renderers can be added as those contracts become
+available; no private component imports or speculative plugin registry.
+
+## Mobile remains independent
+
+Desktop destination settings must never permit mobile call-breaking navigation.
+Mobile continues using its drawer while a call is live. Its view reuse preference
+is separate, and does not control desktop behavior. We should not call switching
+items in the mobile drawer “multiple native tabs.”
+
+## Questions to settle before implementing
+
+- How should a temporary voice override interact with a saved per-origin choice?
+- Where should a sidebar/global call open a side panel if its current page has
+  no supported destination?
+- Should a side-panel destination follow current focus or remain attached to the
+  surface where the call began?
+- What native tab API will bb expose for plugin pages and other plugins?
+
+A separate desktop PR should demonstrate both navigation and side-panel flows
+from each supported origin, plus native tab deduplication and batch opens.

--- a/docs/thread-views.md
+++ b/docs/thread-views.md
@@ -1,0 +1,120 @@
+# Thread views beside a call
+
+Handsfree keeps a collection of views in the calling window. bb supplies the
+host panel (a drawer on compact mobile surfaces); Handsfree supplies its contents,
+selection, and close controls. The initial view type is a thread, rendered by the
+host's `ThreadChat` component.
+
+## Behavior
+
+- `focus_thread({ thread_id, disposition? })` shows or selects one thread.
+- `focus_threads({ thread_ids })` adds a batch and selects the first requested
+  thread. Existing views remain available. Repeated IDs never create duplicates.
+- `manage_views({ action: "list" | "select" | "close" | "clear", view_id? })`
+  lets voice inspect and manage the same collection as the UI. View IDs come from
+  `list`. Closing views does not stop their threads or the voice call.
+- `set_view_behavior({ behavior: "auto" | "reuse" | "new" })` saves a preference
+  only when the user asks for a lasting change. The same preference appears in
+  Handsfree settings under Behavior → Thread tabs.
+
+Automatic behavior replaces the active tab on mobile and keeps separate tabs on
+desktop. Explicit `reuse` or `new` overrides the preference. A batch always keeps
+all its requested threads. Reopening an existing thread selects it even under
+`reuse`; it does not discard a different tab unnecessarily.
+
+“Show all my running threads” uses `list_live_threads`, excludes
+`recently-finished` entries, then calls `focus_threads`. Batches contain at most
+100 IDs; larger lists can be opened in successive batches. Metadata is resolved
+before revealing the collection, and a failed lookup rejects that batch without
+changing its tabs.
+
+Desktop shows buttons for open threads; mobile shows one thread with a selector.
+Only the active thread chat is mounted. bb owns its draft state (scoped to the
+thread), so switching views does not require Handsfree to copy or manage drafts.
+The collection survives panel dismissal/remount during the loaded app session.
+It does not persist across an app refresh, restart, or plugin reload.
+
+## Surfaces and ownership
+
+- Handsfree page: the fixed Views tab via `experimental_useAppPanel`.
+- Existing thread page: one reusable Handsfree views panel via `openThreadPanel`.
+- Embedded thread chats do not register another destination, preventing recursive
+  panels. Their composer bindings use their actual composer scope rather than
+  the outer page route.
+- A call originating in a runtime with no available local presenter reports an
+  error. There is no cross-device or cross-window navigation broadcast.
+
+Web slots share the loaded plugin module. Separate native webviews/windows may
+have separate runtimes. A presenter's local availability is a capability, not
+something inferred from another device's call presence. The prior server relay
+has been removed; no claim is made that it can reveal a view in an arbitrary
+native webview.
+
+The selected **visible** view supplies the thread and project for voice context.
+Once the panel unmounts or is hidden, ordinary surface bindings supply context.
+Unmounted composer bindings are removed, and voice refuses composer edits when
+the bound composer does not belong to the shown thread.
+
+The host's boolean open result confirms acceptance, not completed rendering or
+successful thread loading. We handle declines and exceptions as failures. The
+host chat handles loading/deleted-thread states; a rendering exception is
+contained within the view. A stopped/replaced call cannot reveal the results of
+its late metadata lookup.
+
+## Event consistency
+
+`tool.call` and `tool.result` describe both local and server-handled actions.
+Their shared call ID pairs results without relying on tool names or arrival
+order. New tool results carry explicit success/error status. Human labels can
+name the thread; transport details remain outside the product flow.
+
+`logEvent` persists each event, then mirrors that exact event with its database
+ID, timestamp, session ID, and client/runtime identity into the plugin log.
+Server-side tool execution no longer writes a competing `voice tool:` entry.
+Session error filtering includes failed tool results. Legacy transcripts without
+call IDs or explicit status retain a compatibility reader.
+
+Client writes are ordered and do not block audio. Persistence is still dependent
+on the RPC connection; failed writes surface in the client console. Plugin logs
+rotate separately from the durable session database, so historical retention is
+not identical and old events are not retroactively copied into plugin logs.
+
+## Extension boundary
+
+`WorkspaceView` is a discriminated union, initially containing `ThreadView`.
+Collection operations (add, replace, select, close) and host presentation are
+separate from rendering. A future supported first-party view can add a target
+shape and renderer without changing the thread-opening preference or tab logic.
+
+There is no public cross-plugin tab registry in this implementation. Embedding
+arbitrary other plugins, revealing native terminals, and controlling the host's
+drawer geometry require the relevant bb APIs. Once bb exposes a supported
+cross-plugin surface contract, adapt that contract into a new view type; do not
+load another plugin's private components or imitate its UI.
+
+The current host API exposes static, non-closable fixed-tab declarations, so the
+Views host tab is also present on desktop. Individual views inside it are
+closable. Neither the plugin nor this API can guarantee audio while the OS
+suspends the app.
+
+## Validation
+
+Automated coverage includes collection behavior, preferences, duplicate and
+batch opens, rejected/throwing/missing presenters, runtime isolation, context and
+binding cleanup, late call results, event correlation, actual database/log
+parity through the SDK fake host, and desktop/mobile UI controls through the SDK
+React harness. The harness does not emulate native panel layout or microphones.
+
+Before merging, exercise these in the real app:
+
+1. Start a call from Handsfree. Open two threads in separate tabs, switch,
+   close one, dismiss/reopen the drawer, and confirm the call stays live.
+2. Repeat from an existing thread composer, including a different project.
+   Ask “what thread am I looking at?” after each switch and after dismissal.
+3. Dictate a draft, switch tabs, and return; confirm the draft is preserved.
+4. Ask to show all running threads; confirm recently finished threads are
+   excluded and every requested thread appears once.
+5. Change the tab preference by voice and in settings; test explicit reuse/new.
+6. Keep another device/window open; its view collection must not change.
+7. Inspect that phone session and `bb plugin logs handsfree`: tool call IDs,
+   result status, and device/session identity should agree.

--- a/docs/thread-views.md
+++ b/docs/thread-views.md
@@ -36,6 +36,11 @@ the batch without changing the current views. Only the active chat mounts; bb
 owns drafts scoped to their threads. The collection survives drawer remounts
 within the loaded app session, but not refresh/restart/plugin reload.
 
+The drawer keeps call status, elapsed time, mute/unmute, and end-call controls
+in a footer outside the scrolling thread. It shares the Aide page's controls and
+call state. Controls remain available when switching or closing thread views,
+including after closing the last view; ending the call hides them.
+
 ## Desktop compatibility
 
 The frontend sends its mobile classification at call creation. Desktop sessions
@@ -99,7 +104,11 @@ The harness does not reproduce native microphone or drawer behavior.
 Before merging:
 
 1. On mobile, start from Handsfree; open/swap threads, dismiss/reopen the drawer,
-   and keep talking. Repeat from a thread composer.
+   and keep talking. Mute/unmute from the drawer, verify the page reflects the
+   same state, then end the call from the drawer. Confirm controls stay visible
+   while scrolling and using the keyboard. The native mobile composer has
+   reported no available drawer presenter; verify it explains the limitation
+   without navigating away or interrupting the call.
 2. Switch across projects, ask what thread is shown, then dismiss the drawer and
    verify context returns to the underlying surface.
 3. Draft text, switch away and return; verify the draft is preserved.

--- a/docs/thread-views.md
+++ b/docs/thread-views.md
@@ -41,6 +41,14 @@ in a footer outside the scrolling thread. It shares the Aide page's controls and
 call state. Controls remain available when switching or closing thread views,
 including after closing the last view; ending the call hides them.
 
+The content height is capped to the visual viewport below the drawer's own
+top edge. This keeps the embedded reply field and call controls above an iOS
+keyboard when BB's portaled drawer retains its full height. Viewport resize,
+pan, and host resize update that cap without remounting the chat or touching
+its draft/focus. Pinch zoom retains the host's normal layout. Native iOS still
+needs a device regression check; a browser fixture cannot reproduce its audio
+or keyboard lifecycle.
+
 ## Desktop compatibility
 
 The frontend sends its mobile classification at call creation. Desktop sessions

--- a/docs/thread-views.md
+++ b/docs/thread-views.md
@@ -1,120 +1,111 @@
-# Thread views beside a call
+# Mobile thread views beside a call
 
-Handsfree keeps a collection of views in the calling window. bb supplies the
-host panel (a drawer on compact mobile surfaces); Handsfree supplies its contents,
-selection, and close controls. The initial view type is a thread, rendered by the
-host's `ThreadChat` component.
+This PR changes mobile thread presentation. Desktop `focus_thread` retains the
+existing `bb.sdk.threads.open` navigation, whether the call starts from the
+composer or Handsfree page. Desktop destination preferences are a separate
+proposal in [desktop-navigation-plan.md](desktop-navigation-plan.md).
 
-## Behavior
+On mobile, the merged implementation refused `focus_thread` during a live call
+and told the user what to tap, because navigating away could suspend the owning
+webview's microphone. The drawer replaces that refusal without navigating away.
+The previous phone test confirmed opening and swapping threads with a live call.
+This implementation still needs a device regression test before merging.
+
+## Mobile behavior
 
 - `focus_thread({ thread_id, disposition? })` shows or selects one thread.
+  The default replaces the shown thread; `new` preserves existing views, and
+  `auto` uses the saved mobile preference.
 - `focus_threads({ thread_ids })` adds a batch and selects the first requested
-  thread. Existing views remain available. Repeated IDs never create duplicates.
+  thread. Existing views remain available; repeated IDs are deduplicated.
 - `manage_views({ action: "list" | "select" | "close" | "clear", view_id? })`
-  lets voice inspect and manage the same collection as the UI. View IDs come from
-  `list`. Closing views does not stop their threads or the voice call.
-- `set_view_behavior({ behavior: "auto" | "reuse" | "new" })` saves a preference
-  only when the user asks for a lasting change. The same preference appears in
-  Handsfree settings under Behavior → Thread tabs.
+  controls the same mobile collection as the UI. Closing a view does not stop
+  its thread or the call.
+- `set_view_behavior({ behavior: "reuse" | "new" })` saves a preference only
+  when the user asks for a lasting mobile change. Settings → Behavior → Mobile
+  thread drawer exposes the same `mobileViewBehavior` preference.
 
-Automatic behavior replaces the active tab on mobile and keeps separate tabs on
-desktop. Explicit `reuse` or `new` overrides the preference. A batch always keeps
-all its requested threads. Reopening an existing thread selects it even under
-`reuse`; it does not discard a different tab unnecessarily.
+The drawer shows one thread with a selector when retaining several. These are
+views inside one host drawer, **not separate native bb tabs**. A batch always
+keeps all requested threads. To show all running threads, the model uses
+`list_live_threads`, excludes `recently-finished` entries, and passes the IDs to
+`focus_threads` (up to 100 per batch, splitting larger lists).
 
-“Show all my running threads” uses `list_live_threads`, excludes
-`recently-finished` entries, then calls `focus_threads`. Batches contain at most
-100 IDs; larger lists can be opened in successive batches. Metadata is resolved
-before revealing the collection, and a failed lookup rejects that batch without
-changing its tabs.
+Metadata is resolved before revealing the collection. A failed lookup rejects
+the batch without changing the current views. Only the active chat mounts; bb
+owns drafts scoped to their threads. The collection survives drawer remounts
+within the loaded app session, but not refresh/restart/plugin reload.
 
-Desktop shows buttons for open threads; mobile shows one thread with a selector.
-Only the active thread chat is mounted. bb owns its draft state (scoped to the
-thread), so switching views does not require Handsfree to copy or manage drafts.
-The collection survives panel dismissal/remount during the loaded app session.
-It does not persist across an app refresh, restart, or plugin reload.
+## Desktop compatibility
 
-## Surfaces and ownership
+The frontend sends its mobile classification at call creation. Desktop sessions
+receive the original navigation-oriented `focus_thread` schema, without a tab
+disposition parameter or mobile view-management tools. Mobile settings cannot
+change desktop navigation. The client also rejects mobile-only tools from stale
+desktop sessions that may still know about them.
 
-- Handsfree page: the fixed Views tab via `experimental_useAppPanel`.
-- Existing thread page: one reusable Handsfree views panel via `openThreadPanel`.
-- Embedded thread chats do not register another destination, preventing recursive
-  panels. Their composer bindings use their actual composer scope rather than
-  the outer page route.
-- A call originating in a runtime with no available local presenter reports an
-  error. There is no cross-device or cross-window navigation broadcast.
+App registration runs in each client. Only mobile clients register the Handsfree
+fixed drawer tab and thread-page panel action. Desktop therefore gains no new
+Views tab or panel launcher entry. This is supported with static registrations
+chosen at client initialization; it does not imply an API for dynamically
+creating arbitrary native tabs on a plugin page.
 
-Web slots share the loaded plugin module. Separate native webviews/windows may
-have separate runtimes. A presenter's local availability is a capability, not
-something inferred from another device's call presence. The prior server relay
-has been removed; no claim is made that it can reveal a view in an arbitrary
-native webview.
+## Local surfaces and context
 
-The selected **visible** view supplies the thread and project for voice context.
-Once the panel unmounts or is hidden, ordinary surface bindings supply context.
-Unmounted composer bindings are removed, and voice refuses composer edits when
-the bound composer does not belong to the shown thread.
+- Handsfree page: its fixed drawer view through `experimental_useAppPanel`.
+- Existing mobile thread page: a reusable local panel through `openThreadPanel`.
+- Embedded chats never register recursive panel destinations.
+- A runtime with no available local presenter reports the limitation. It does
+  not broadcast navigation or fall back to navigating away from a mobile call.
 
-The host's boolean open result confirms acceptance, not completed rendering or
-successful thread loading. We handle declines and exceptions as failures. The
-host chat handles loading/deleted-thread states; a rendering exception is
-contained within the view. A stopped/replaced call cannot reveal the results of
-its late metadata lookup.
+Ordinary web slots share their plugin module. Separate native webviews/windows
+may have separate runtimes. Call presence does not establish that another
+runtime is a valid destination, so the old server-wide view relay is removed.
 
-## Event consistency
+On mobile, the selected visible view supplies voice thread/project context.
+After the drawer is hidden/unmounted, ordinary surface bindings supply context.
+Embedded composers use their actual composer scope, bindings unregister on
+unmount, and voice refuses edits into a composer belonging to a different
+thread. Desktop continues to use normal surface context.
 
-`tool.call` and `tool.result` describe both local and server-handled actions.
-Their shared call ID pairs results without relying on tool names or arrival
-order. New tool results carry explicit success/error status. Human labels can
-name the thread; transport details remain outside the product flow.
+A host boolean confirms acceptance, not completed rendering. Declines and
+exceptions return a tool error; a late lookup after the call stops cannot open
+anything. The host chat handles loading/deleted-thread states, with a local
+error boundary containing rendering exceptions.
 
-`logEvent` persists each event, then mirrors that exact event with its database
-ID, timestamp, session ID, and client/runtime identity into the plugin log.
-Server-side tool execution no longer writes a competing `voice tool:` entry.
-Session error filtering includes failed tool results. Legacy transcripts without
-call IDs or explicit status retain a compatibility reader.
+## Shared event consistency
 
-Client writes are ordered and do not block audio. Persistence is still dependent
-on the RPC connection; failed writes surface in the client console. Plugin logs
-rotate separately from the durable session database, so historical retention is
-not identical and old events are not retroactively copied into plugin logs.
+`tool.call` and `tool.result` describe local and server-handled actions. They
+share call IDs, session/device identity, and explicit success/error outcomes.
+Results pair by call ID; a compatibility reader handles historical sessions.
 
-## Extension boundary
+`logEvent` persists an event and mirrors that same event with its database ID
+and timestamp into the plugin log. The separate server-only `voice tool:` line
+is removed. Failed tool results also mark the session's error filter.
 
-`WorkspaceView` is a discriminated union, initially containing `ThreadView`.
-Collection operations (add, replace, select, close) and host presentation are
-separate from rendering. A future supported first-party view can add a target
-shape and renderer without changing the thread-opening preference or tab logic.
-
-There is no public cross-plugin tab registry in this implementation. Embedding
-arbitrary other plugins, revealing native terminals, and controlling the host's
-drawer geometry require the relevant bb APIs. Once bb exposes a supported
-cross-plugin surface contract, adapt that contract into a new view type; do not
-load another plugin's private components or imitate its UI.
-
-The current host API exposes static, non-closable fixed-tab declarations, so the
-Views host tab is also present on desktop. Individual views inside it are
-closable. Neither the plugin nor this API can guarantee audio while the OS
-suspends the app.
+Client writes are ordered without blocking audio. They still depend on the RPC
+connection; failed persistence is reported in the client console. Plugin logs
+rotate independently of the durable database. Historical retention differs,
+and old events are not copied retroactively.
 
 ## Validation
 
-Automated coverage includes collection behavior, preferences, duplicate and
-batch opens, rejected/throwing/missing presenters, runtime isolation, context and
-binding cleanup, late call results, event correlation, actual database/log
-parity through the SDK fake host, and desktop/mobile UI controls through the SDK
-React harness. The harness does not emulate native panel layout or microphones.
+Tests cover desktop navigation from both call entry points, device-specific
+registration and tool schemas, mobile preferences/batches/switching, rejected
+opens, runtime isolation, context and binding cleanup, late results, database/log
+parity using the SDK fake host, and drawer controls using its React harness.
+The harness does not reproduce native microphone or drawer behavior.
 
-Before merging, exercise these in the real app:
+Before merging:
 
-1. Start a call from Handsfree. Open two threads in separate tabs, switch,
-   close one, dismiss/reopen the drawer, and confirm the call stays live.
-2. Repeat from an existing thread composer, including a different project.
-   Ask “what thread am I looking at?” after each switch and after dismissal.
-3. Dictate a draft, switch tabs, and return; confirm the draft is preserved.
-4. Ask to show all running threads; confirm recently finished threads are
-   excluded and every requested thread appears once.
-5. Change the tab preference by voice and in settings; test explicit reuse/new.
-6. Keep another device/window open; its view collection must not change.
-7. Inspect that phone session and `bb plugin logs handsfree`: tool call IDs,
-   result status, and device/session identity should agree.
+1. On mobile, start from Handsfree; open/swap threads, dismiss/reopen the drawer,
+   and keep talking. Repeat from a thread composer.
+2. Switch across projects, ask what thread is shown, then dismiss the drawer and
+   verify context returns to the underlying surface.
+3. Draft text, switch away and return; verify the draft is preserved.
+4. Show all running threads; verify recently finished entries are excluded and
+   each requested thread appears once in the switcher.
+5. Change the mobile preference in settings and by voice. On desktop, verify
+   `focus_thread` still navigates from both Handsfree and a composer regardless.
+6. Keep another window/device open; a mobile drawer request must not change it.
+7. Match tool call IDs and outcomes in the session transcript and plugin logs.

--- a/drawer-viewport.test.tsx
+++ b/drawer-viewport.test.tsx
@@ -1,0 +1,87 @@
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+import React, { useRef } from "react";
+import { JSDOM } from "jsdom";
+import { useDrawerViewport } from "./hooks/useDrawerViewport";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", { pretendToBeVisual: true });
+for (const [name, value] of Object.entries({ window: dom.window, document: dom.window.document, HTMLElement: dom.window.HTMLElement, IS_REACT_ACT_ENVIRONMENT: true })) {
+  Object.defineProperty(globalThis, name, { value, configurable: true, writable: true });
+}
+after(() => dom.window.close());
+// React DOM detects input-event support at import time.
+const { act, render } = await import("@testing-library/react");
+
+function Drawer() {
+  const root = useRef<HTMLDivElement>(null);
+  useDrawerViewport(root);
+  return <div ref={root}><textarea aria-label="Reply" defaultValue="Draft" /></div>;
+}
+
+test("drawer fits above an overlay keyboard, accounts for panning, and restores on dismissal", (t) => {
+  const viewport = Object.assign(new dom.window.EventTarget(), { height: 800, offsetTop: 0, scale: 1 });
+  Object.defineProperty(window, "visualViewport", { value: viewport, configurable: true });
+  let top = 160;
+  t.mock.method(dom.window.HTMLElement.prototype, "getBoundingClientRect", () => ({ top, height: 640 }) as DOMRect);
+  const frames = new Map<number, FrameRequestCallback>();
+  let nextFrame = 0;
+  t.mock.method(window, "requestAnimationFrame", (callback: FrameRequestCallback) => { frames.set(++nextFrame, callback); return nextFrame; });
+  t.mock.method(window, "cancelAnimationFrame", (id: number) => { frames.delete(id); });
+  const flush = () => act(() => {
+    for (const [id, callback] of frames) { frames.delete(id); callback(0); }
+  });
+  const resize = (height: number) => {
+    viewport.height = height;
+    viewport.dispatchEvent(new dom.window.Event("resize"));
+    flush();
+  };
+  const slot = render(<Drawer />);
+  const root = slot.container.firstElementChild as HTMLElement;
+  try {
+    assert.equal(root.style.maxHeight, "640px");
+    const input = slot.getByRole("textbox", { name: "Reply" }) as HTMLTextAreaElement;
+    input.focus();
+    resize(480);
+    assert.equal(root.style.maxHeight, "320px");
+    assert.equal(document.activeElement, input);
+    assert.equal(input.value, "Draft");
+
+    viewport.offsetTop = 30;
+    viewport.dispatchEvent(new dom.window.Event("scroll"));
+    flush();
+    assert.equal(root.style.maxHeight, "350px");
+
+    // If BB also moves/resizes the host, measure the new top instead of
+    // subtracting a keyboard inset from a height that's already reduced.
+    top = 100;
+    window.dispatchEvent(new dom.window.Event("resize"));
+    flush();
+    assert.equal(root.style.maxHeight, "410px");
+
+    viewport.scale = 2;
+    resize(240);
+    assert.equal(root.style.maxHeight, "");
+    viewport.scale = 1;
+    viewport.offsetTop = 0;
+    top = 160;
+    resize(800);
+    assert.equal(root.style.maxHeight, "640px");
+
+    viewport.dispatchEvent(new dom.window.Event("resize"));
+    assert.equal(frames.size, 1);
+  } finally {
+    slot.unmount();
+    assert.equal(frames.size, 0);
+    assert.equal(root.style.maxHeight, "");
+    viewport.dispatchEvent(new dom.window.Event("resize"));
+    assert.equal(frames.size, 0);
+    Reflect.deleteProperty(window, "visualViewport");
+  }
+});
+
+test("drawer uses host sizing when visualViewport is unavailable", () => {
+  const slot = render(<Drawer />);
+  try {
+    assert.equal((slot.container.firstElementChild as HTMLElement).style.maxHeight, "");
+  } finally { slot.unmount(); }
+});

--- a/hooks/useDrawerViewport.ts
+++ b/hooks/useDrawerViewport.ts
@@ -1,0 +1,52 @@
+import { useLayoutEffect, type RefObject } from "react";
+
+/** Keep the embedded composer and call footer above the software keyboard.
+ * BB's portaled drawer can retain its layout-viewport height on iOS even when
+ * the visual viewport shrinks. Only constrain our content, not the host drawer.
+ */
+export function useDrawerViewport(ref: RefObject<HTMLDivElement | null>) {
+  useLayoutEffect(() => {
+    const root = ref.current;
+    const win = root?.ownerDocument.defaultView;
+    const viewport = win?.visualViewport;
+    if (!root || !win || !viewport) return;
+
+    const previousMaxHeight = root.style.maxHeight;
+    let frame: number | null = null;
+    const update = () => {
+      frame = null;
+      const bounds = root.getBoundingClientRect();
+      const available = Math.floor(viewport.offsetTop + viewport.height - bounds.top);
+      // Let pinch zoom behave normally. Hidden/offscreen persistent panels
+      // must not retain a zero-height constraint when opened again.
+      root.style.maxHeight = viewport.scale === 1 && bounds.height > 0 && available > 0
+        ? `${available}px`
+        : previousMaxHeight;
+    };
+    const schedule = () => {
+      if (frame === null) frame = win.requestAnimationFrame(update);
+    };
+    const observer = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(schedule);
+    observer?.observe(root);
+    if (root.parentElement) observer?.observe(root.parentElement);
+    viewport.addEventListener("resize", schedule);
+    viewport.addEventListener("scroll", schedule);
+    win.addEventListener("resize", schedule);
+    // BB may move the drawer without resizing its content during opening.
+    win.addEventListener("transitionend", schedule);
+    root.addEventListener("focusin", schedule);
+    root.addEventListener("focusout", schedule);
+    update();
+    return () => {
+      observer?.disconnect();
+      viewport.removeEventListener("resize", schedule);
+      viewport.removeEventListener("scroll", schedule);
+      win.removeEventListener("resize", schedule);
+      win.removeEventListener("transitionend", schedule);
+      root.removeEventListener("focusin", schedule);
+      root.removeEventListener("focusout", schedule);
+      if (frame !== null) win.cancelAnimationFrame(frame);
+      root.style.maxHeight = previousMaxHeight;
+    };
+  }, [ref]);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,22 +27,635 @@
         "@radix-ui/react-popover": "^1.1.19",
         "@radix-ui/react-select": "^2.3.3",
         "@radix-ui/react-tooltip": "^1.2.12",
+        "@testing-library/react": "^16.3.3",
         "@types/better-sqlite3": "^7.6.12",
+        "@types/jsdom": "^21.1.7",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "better-sqlite3": "^12.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cron-parser": "^5.10.0",
         "hono": "^4.11.9",
+        "jsdom": "^26.1.0",
         "sonner": "^1.7.4",
         "tailwind-merge": "^3.4.0",
+        "tsx": "^4.23.13",
         "typescript": "^5.7.0",
         "vaul": "^1.1.2"
       },
       "engines": {
         "bb": ">=0.40",
         "bbPluginSdk": ">=0.4.21"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -174,6 +787,7 @@
       "integrity": "sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw==",
       "dev": true,
       "license": "apache-2.0",
+      "peer": true,
       "engines": {
         "vscode": "^1.0.0"
       }
@@ -1228,6 +1842,7 @@
       "integrity": "sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@shikijs/types": "4.4.3"
       },
@@ -1270,12 +1885,70 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.3.tgz",
+      "integrity": "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1288,6 +1961,18 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
       }
     },
     "node_modules/@types/mdast": {
@@ -1316,6 +2001,7 @@
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1326,9 +2012,17 @@
       "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -1344,6 +2038,39 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -1355,6 +2082,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/base64-js": {
@@ -1385,6 +2122,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -1514,11 +2252,78 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cron-parser": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-5.10.0.tgz",
+      "integrity": "sha512-izNAxJyRWUP8ljBoDSub5WyrVOUlT4SLGShswE7eoRBpp6QUsSycYxLBMJlbshgPBMcPT/nrfgjNY2918ayv2A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "luxon": "^3.7.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/decompress-response": {
@@ -1598,6 +2403,13 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -1606,6 +2418,61 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
       }
     },
     "node_modules/expand-template": {
@@ -1631,6 +2498,21 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/get-nonce": {
       "version": "1.0.1",
@@ -1693,8 +2575,22 @@
       "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/html-void-elements": {
@@ -1706,6 +2602,47 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -1743,12 +2680,93 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/lru_map": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
       "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
     },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
@@ -1896,6 +2914,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -1915,6 +2940,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.27",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.27.tgz",
+      "integrity": "sha512-gQPNF78qebCQ6tvVFBYrvJdBNOrYZm90ZlXgpIFm06p6qHDHq/XC4TnJftN6OMbxVE0UTBAoRgcsDeJBBooITw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -1945,6 +2977,26 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -1973,6 +3025,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
@@ -1993,6 +3060,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/rc": {
@@ -2033,6 +3110,13 @@
       "peerDependencies": {
         "react": "^19.2.8"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -2148,6 +3232,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2169,12 +3260,31 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -2195,6 +3305,7 @@
       "integrity": "sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@shikijs/core": "4.4.3",
         "@shikijs/engine-javascript": "4.4.3",
@@ -2313,6 +3424,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
@@ -2354,6 +3472,52 @@
         "node": ">=6"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -2371,6 +3535,25 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.13",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.13.tgz",
+      "integrity": "sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -2575,6 +3758,67 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -2582,11 +3826,51 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/zod": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.2.tgz",
       "integrity": "sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cron-parser": "^5.10.0",
+        "esbuild": "^0.28.2",
         "hono": "^4.11.9",
         "jsdom": "^26.1.0",
         "sonner": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cron-parser": "^5.10.0",
+    "esbuild": "^0.28.2",
     "hono": "^4.11.9",
     "jsdom": "^26.1.0",
     "sonner": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.5",
   "type": "module",
   "scripts": {
-    "test": "node --test audio-devices.test.ts voice-agent.test.ts shortcuts.test.ts",
+    "test": "node --import tsx --test *.test.ts *.test.tsx",
     "typecheck": "tsc --noEmit"
   },
   "engines": {
@@ -29,13 +29,6 @@
   },
   "devDependencies": {
     "@get-bb/plugin-sdk": "0.4.21",
-    "@types/better-sqlite3": "^7.6.12",
-    "@types/node": "^22.0.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "better-sqlite3": "^12.0.0",
-    "hono": "^4.11.9",
-    "typescript": "^5.7.0",
     "@pierre/diffs": "^1.2.9",
     "@radix-ui/react-alert-dialog": "^1.1.19",
     "@radix-ui/react-context-menu": "^2.3.3",
@@ -47,10 +40,22 @@
     "@radix-ui/react-popover": "^1.1.19",
     "@radix-ui/react-select": "^2.3.3",
     "@radix-ui/react-tooltip": "^1.2.12",
+    "@testing-library/react": "^16.3.3",
+    "@types/better-sqlite3": "^7.6.12",
+    "@types/jsdom": "^21.1.7",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "better-sqlite3": "^12.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cron-parser": "^5.10.0",
+    "hono": "^4.11.9",
+    "jsdom": "^26.1.0",
     "sonner": "^1.7.4",
     "tailwind-merge": "^3.4.0",
+    "tsx": "^4.23.13",
+    "typescript": "^5.7.0",
     "vaul": "^1.1.2"
   }
 }

--- a/server.test.ts
+++ b/server.test.ts
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createFakePluginHost, makeThreadResponse } from "@get-bb/plugin-sdk/testing";
+import plugin from "./server.ts";
+
+test("session history and plugin logs describe the same stored action, and failed tools mark sessions", async () => {
+  const { bb, harness } = createFakePluginHost({ pluginId: "handsfree" });
+  try {
+    await plugin(bb);
+    for (const kind of ["tool.call", "tool.result"]) await harness.behavior.callRpc("logEvent", {
+      sessionId: "phone-call", kind,
+      payload: { name: "focus_thread", callId: "tool-1", _id: { client: "phone", realm: "page" },
+        ...(kind === "tool.result" ? { status: "error", output: "Could not open" } : { args: { thread_id: "a" } }) },
+    });
+    const { events } = await harness.behavior.callRpc("getSessionEvents", { sessionId: "phone-call" }) as { events: { id: number; ts: number; kind: string; payload: string }[] };
+    const logs = harness.inspection.logEntries.filter(log => log.message.includes('"sessionId":"phone-call"'));
+    assert.equal(logs.length, 2);
+    events.forEach((event, index) => assert.deepEqual(JSON.parse(logs[index].message), {
+      ...event, sessionId: "phone-call", payload: JSON.parse(event.payload),
+    }));
+    assert.equal(logs[1].level, "error");
+    const { sessions } = await harness.behavior.callRpc("listSessions", null) as { sessions: { id: string; hasError: boolean }[] };
+    assert.equal(sessions.find(session => session.id === "phone-call")?.hasError, true);
+  } finally { await harness.lifecycle.dispose(); }
+});
+
+test("thread metadata is resolved once per ID and the saved preference applies immediately", async () => {
+  const { bb, harness } = createFakePluginHost({ pluginId: "handsfree", sdk: {
+    threads: { get: async ({ threadId }) => makeThreadResponse({ id: threadId, title: `Title ${threadId}`, projectId: "project" }) },
+  } });
+  try {
+    await plugin(bb);
+    let result = await harness.behavior.callRpc("resolveThreadViews", { threadIds: ["a", "b", "a"] }) as any;
+    assert.equal(result.preference, "auto");
+    assert.deepEqual(result.views.map((view: any) => view.id), ["thread:a", "thread:b"]);
+    assert.equal(harness.inspection.sdk.callsTo("threads.get").length, 2);
+    const saved = await harness.behavior.callRpc("runTool", {
+      name: "set_view_behavior", args: { behavior: "new" }, threadId: null, projectId: null,
+    }) as any;
+    assert.equal(saved.status, "success");
+    result = await harness.behavior.callRpc("resolveThreadViews", { threadIds: ["a"] }) as any;
+    assert.equal(result.preference, "new");
+    assert.ok(harness.inspection.realtimeSignals.some(signal => signal.channel === "config-changed"));
+    await assert.rejects(harness.behavior.callRpc("resolveThreadViews", { threadIds: [] }));
+  } finally { await harness.lifecycle.dispose(); }
+});
+
+test("server tool failures carry explicit status and do not create a separate server-only action log", async () => {
+  const { bb, harness } = createFakePluginHost({ pluginId: "handsfree", sdk: {
+    threads: { get: async () => { throw new Error("Thread was deleted"); } },
+  } });
+  try {
+    await plugin(bb);
+    await assert.rejects(harness.behavior.callRpc("resolveThreadViews", { threadIds: ["deleted"] }), /deleted/);
+    const result = await harness.behavior.callRpc("runTool", { name: "read_thread", args: { thread_id: "deleted" }, threadId: null, projectId: null }) as any;
+    assert.equal(result.status, "error");
+    assert.match(result.output, /deleted/);
+    assert.equal(harness.inspection.logEntries.some(log => log.message.includes("voice tool")), false);
+    const unknown = await harness.behavior.callRpc("runTool", { name: "not-a-tool", args: {}, threadId: null, projectId: null }) as any;
+    assert.equal(unknown.status, "error");
+  } finally { await harness.lifecycle.dispose(); }
+});

--- a/server.test.ts
+++ b/server.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createFakePluginHost, makeThreadResponse } from "@get-bb/plugin-sdk/testing";
-import plugin from "./server.ts";
+import plugin, { toolSchemas, threadViewInstructions } from "./server.ts";
 
 test("session history and plugin logs describe the same stored action, and failed tools mark sessions", async () => {
   const { bb, harness } = createFakePluginHost({ pluginId: "handsfree" });
@@ -31,7 +31,7 @@ test("thread metadata is resolved once per ID and the saved preference applies i
   try {
     await plugin(bb);
     let result = await harness.behavior.callRpc("resolveThreadViews", { threadIds: ["a", "b", "a"] }) as any;
-    assert.equal(result.preference, "auto");
+    assert.equal(result.preference, "reuse");
     assert.deepEqual(result.views.map((view: any) => view.id), ["thread:a", "thread:b"]);
     assert.equal(harness.inspection.sdk.callsTo("threads.get").length, 2);
     const saved = await harness.behavior.callRpc("runTool", {
@@ -58,5 +58,49 @@ test("server tool failures carry explicit status and do not create a separate se
     assert.equal(harness.inspection.logEntries.some(log => log.message.includes("voice tool")), false);
     const unknown = await harness.behavior.callRpc("runTool", { name: "not-a-tool", args: {}, threadId: null, projectId: null }) as any;
     assert.equal(unknown.status, "error");
+  } finally { await harness.lifecycle.dispose(); }
+});
+
+test("desktop calls retain the original focus tool and exclude mobile-only controls", () => {
+  const desktop = toolSchemas([], false);
+  const mobile = toolSchemas([], true);
+  for (const name of ["focus_threads", "manage_views", "set_view_behavior"]) {
+    assert.equal(desktop.some(tool => tool.name === name), false);
+    assert.equal(mobile.some(tool => tool.name === name), true);
+  }
+  const focusDesktop = desktop.find(tool => tool.name === "focus_thread") as any;
+  const focusMobile = mobile.find(tool => tool.name === "focus_thread") as any;
+  assert.equal("disposition" in focusDesktop.parameters.properties, false);
+  assert.equal("disposition" in focusMobile.parameters.properties, true);
+  assert.match(threadViewInstructions(false), /navigates to the requested thread/);
+  assert.match(threadViewInstructions(true), /do not navigate away/);
+  assert.deepEqual(toolSchemas(), desktop);
+});
+
+test("mobile settings never replace desktop navigation and migrate the prototype preference", async () => {
+  const { bb, harness } = createFakePluginHost({ pluginId: "handsfree" });
+  try {
+    await bb.storage.kv.set("config", { viewBehavior: "new" });
+    await plugin(bb);
+    const current = await harness.behavior.callRpc("getConfig", null) as any;
+    assert.equal(current.mobileViewBehavior, "new");
+    assert.equal("viewBehavior" in current, false);
+    const saved = await harness.behavior.callRpc("setConfig", { mobileViewBehavior: "reuse" }) as any;
+    assert.equal(saved.mobileViewBehavior, "reuse");
+    await assert.rejects(harness.behavior.callRpc("setConfig", { mobileViewBehavior: "auto" }));
+  } finally { await harness.lifecycle.dispose(); }
+});
+
+test("desktop focus still opens the real bb thread through the original SDK operation", async () => {
+  const { bb, harness } = createFakePluginHost({ pluginId: "handsfree", sdk: {
+    threads: { open: async () => ({ delivered: 1 }) },
+  } });
+  try {
+    await plugin(bb);
+    const result = await harness.behavior.callRpc("runTool", {
+      name: "focus_thread", args: { thread_id: "target" }, threadId: "source", projectId: "project",
+    }) as any;
+    assert.deepEqual(result, { output: "Focused.", status: "success" });
+    assert.equal(harness.inspection.sdk.callsTo("threads.open").length, 1);
   } finally { await harness.lifecycle.dispose(); }
 });

--- a/server.ts
+++ b/server.ts
@@ -19,6 +19,7 @@ import {
   type RealtimeModel,
   type Voice,
 } from "./models";
+import { sessionEventLog } from "./session-events.ts";
 import { DEFAULT_SHORTCUTS, isValidShortcut, normalizeShortcuts, type Shortcuts } from "./shortcuts";
 
 /**
@@ -120,6 +121,7 @@ export const rpcContract = defineRpcContract({
         model: z.enum(MODEL_OPTIONS),
         voice: z.enum(VOICE_OPTIONS),
         notifications: z.boolean(),
+        viewBehavior: z.enum(["auto", "reuse", "new"]),
         pluginCommands: z.string(),
         credentialPreference: z.enum(["auto", "apiKey", "subscription"]),
         shortcuts: shortcutsSchema,
@@ -133,6 +135,7 @@ export const rpcContract = defineRpcContract({
         model: z.enum(MODEL_OPTIONS).optional(),
         voice: z.enum(VOICE_OPTIONS).optional(),
         notifications: z.boolean().optional(),
+        viewBehavior: z.enum(["auto", "reuse", "new"]).optional(),
         pluginCommands: z.string().max(2000).optional(),
         credentialPreference: z.enum(["auto", "apiKey", "subscription"]).optional(),
         shortcuts: shortcutsSchema.optional(),
@@ -143,6 +146,7 @@ export const rpcContract = defineRpcContract({
         model: z.enum(MODEL_OPTIONS),
         voice: z.enum(VOICE_OPTIONS),
         notifications: z.boolean(),
+        viewBehavior: z.enum(["auto", "reuse", "new"]),
         pluginCommands: z.string(),
         credentialPreference: z.enum(["auto", "apiKey", "subscription"]),
         shortcuts: shortcutsSchema,
@@ -238,20 +242,16 @@ export const rpcContract = defineRpcContract({
       .strict(),
     output: z.object({ ok: z.literal(true) }).strict(),
   },
-  /**
-   * Relay a "show this thread in the companion drawer" request to whichever realm
-   * has the Handsfree page mounted (the call may be owned by a composer realm
-   * that has no page of its own).
-   */
-  sendCompanion: {
-    input: z
-      .object({
-        threadId: z.string().min(1),
-        client: z.string().optional(),
-        realm: z.string().optional(),
-      })
-      .strict(),
-    output: z.object({ ok: z.literal(true) }).strict(),
+  /** Resolve real thread metadata and the current opening preference. */
+  resolveThreadViews: {
+    input: z.object({ threadIds: z.array(z.string().min(1)).min(1).max(100) }).strict(),
+    output: z.object({
+      views: z.array(z.object({
+        kind: z.literal("thread"), id: z.string(), threadId: z.string(),
+        projectId: z.string().nullable(), title: z.string(),
+      }).strict()),
+      preference: z.enum(["auto", "reuse", "new"]),
+    }).strict(),
   },
   /**
    * End a call authoritatively, without needing its owner realm to act — the
@@ -321,7 +321,7 @@ export const rpcContract = defineRpcContract({
         onNewThreadScreen: z.boolean().optional(),
       })
       .strict(),
-    output: z.object({ output: z.string() }).strict(),
+    output: z.object({ output: z.string(), status: z.enum(["success", "error"]) }).strict(),
   },
 });
 
@@ -411,7 +411,10 @@ function toolSchemas(pluginCommands: PluginCommandInfo[] = []) {
     { type: "function", name: "list_threads", description: "List recent bb threads (id, title, status). Optionally filter by project id.", parameters: { type: "object", properties: { project_id: { type: "string" }, limit: { type: "number", description: "Max threads to return (default 15)." } } } },
     { type: "function", name: "search_threads", description: "Full-text search bb threads by title/content. Returns matching thread ids and titles.", parameters: { type: "object", properties: { query: { type: "string" } }, required: ["query"] } },
     { type: "function", name: "read_thread", description: "Read a thread's details and its latest assistant output.", parameters: { type: "object", properties: { thread_id: { type: "string" } }, required: ["thread_id"] } },
-    { type: "function", name: "focus_thread", description: "Open/focus a thread in the user's bb app window.", parameters: { type: "object", properties: { thread_id: { type: "string" } }, required: ["thread_id"] } },
+    { type: "function", name: "focus_thread", description: "Show a thread beside the call on this device. Reopening a thread selects its existing tab. disposition: auto uses the saved preference, reuse replaces the active tab, new keeps existing tabs.", parameters: { type: "object", properties: { thread_id: { type: "string" }, disposition: { type: "string", enum: ["auto", "reuse", "new"] } }, required: ["thread_id"] } },
+    { type: "function", name: "focus_threads", description: "Show several threads as tabs beside the call, preserving existing tabs. To show all running threads, first call list_live_threads and exclude recently-finished entries; pass their IDs here. Up to 100 per batch; split larger lists into batches.", parameters: { type: "object", properties: { thread_ids: { type: "array", items: { type: "string" }, minItems: 1, maxItems: 100 } }, required: ["thread_ids"] } },
+    { type: "function", name: "manage_views", description: "List, select, or close the views open on this device. Get view IDs using list. clear closes all views only when the user asks. Closing a view does not stop its thread or the call.", parameters: { type: "object", properties: { action: { type: "string", enum: ["list", "select", "close", "clear"] }, view_id: { type: "string" } }, required: ["action"] } },
+    { type: "function", name: "set_view_behavior", description: "Save how future thread opens behave. Use only when the user asks for a lasting preference: auto reuses on mobile and keeps tabs on desktop; reuse replaces the active tab; new keeps tabs on either device. Explicit requests and batches override this preference.", parameters: { type: "object", properties: { behavior: { type: "string", enum: ["auto", "reuse", "new"] } }, required: ["behavior"] } },
     { type: "function", name: "set_pane", description: "Change a thread pane's presentation in the bb app: spotlight, clear-spotlight, maximize, restore, or toggle.", parameters: { type: "object", properties: { thread_id: { type: "string" }, action: { type: "string", enum: ["spotlight", "clear-spotlight", "maximize", "restore", "toggle"] } }, required: ["thread_id", "action"] } },
     { type: "function", name: "send_to_thread", description: "Send a message to a thread's agent. Starts a turn if idle, queues/steers if running.", parameters: { type: "object", properties: { thread_id: { type: "string" }, message: { type: "string" } }, required: ["thread_id", "message"] } },
     { type: "function", name: "start_thread", description: "Start a new agent thread in a project. Only pass prompt when the user dictated actual work; With no prompt, this opens bb's New thread screen for the user to type their own. Runs on the project's default machine unless machine_id is given — if the project lives on several connected machines and the user didn't say which, check list_machines and ask one short question instead of guessing.", parameters: { type: "object", properties: { project_id: { type: "string", description: "Project id; defaults to the user's current project." }, prompt: { type: "string", description: "The user's own instruction for the agent, verbatim. Omit if they didn't give one." }, title: { type: "string" }, machine_id: { type: "string", description: "Machine (host) id to run on, from list_machines. Omit to use the project's default machine." } } } },
@@ -498,6 +501,7 @@ export default async function plugin(bb: BbPluginApi) {
     model: RealtimeModel;
     voice: Voice;
     notifications: boolean;
+    viewBehavior: "auto" | "reuse" | "new";
     pluginCommands: string;
     credentialPreference: CredentialPreference;
     shortcuts: Shortcuts;
@@ -507,6 +511,7 @@ export default async function plugin(bb: BbPluginApi) {
     model: DEFAULT_MODEL,
     voice: DEFAULT_VOICE,
     notifications: true,
+    viewBehavior: "auto",
     pluginCommands: "all",
     credentialPreference: "auto",
     shortcuts: { ...DEFAULT_SHORTCUTS },
@@ -518,6 +523,7 @@ export default async function plugin(bb: BbPluginApi) {
       voice: isVoice(stored.voice) ? stored.voice : CONFIG_DEFAULTS.voice,
       notifications:
         typeof stored.notifications === "boolean" ? stored.notifications : CONFIG_DEFAULTS.notifications,
+      viewBehavior: stored.viewBehavior === "reuse" || stored.viewBehavior === "new" ? stored.viewBehavior : "auto",
       pluginCommands:
         typeof stored.pluginCommands === "string" ? stored.pluginCommands : CONFIG_DEFAULTS.pluginCommands,
       credentialPreference: isCredentialPreference(stored.credentialPreference)
@@ -912,14 +918,26 @@ export default async function plugin(bb: BbPluginApi) {
         const [described] = await withMachines([describeThread(thread)]);
         return JSON.stringify({ ...described, lastAssistantOutput: output ? truncate(output) : null });
       }
+      case "set_view_behavior": {
+        const behavior = str("behavior");
+        if (behavior !== "auto" && behavior !== "reuse" && behavior !== "new") throw new Error("Invalid view behavior.");
+        await writeConfig({ viewBehavior: behavior });
+        bb.realtime.publish("config-changed", {});
+        return "Saved the thread-opening preference.";
+      }
+      case "focus_threads":
+      case "manage_views":
+        throw new Error("This tool requires an updated Handsfree frontend on the calling device.");
       case "focus_thread": {
         const { delivered } = await bb.sdk.threads.open({ threadId: str("thread_id"), file: null });
-        return delivered > 0 ? "Focused." : "No connected bb window received the action.";
+        if (delivered <= 0) throw new Error("No connected bb window received the action.");
+        return "Focused.";
       }
       case "set_pane": {
         const action = str("action") as "spotlight" | "clear-spotlight" | "maximize" | "restore" | "toggle";
         const { delivered } = await bb.sdk.threads.paneAction({ threadId: str("thread_id"), action });
-        return delivered > 0 ? `Pane ${action} applied.` : "No connected bb window received the action.";
+        if (delivered <= 0) throw new Error("No connected bb window received the action.");
+        return `Pane ${action} applied.`;
       }
       case "send_to_thread": {
         await bb.sdk.threads.send({
@@ -931,11 +949,11 @@ export default async function plugin(bb: BbPluginApi) {
       }
       case "start_thread": {
         const projectId = typeof args.project_id === "string" && args.project_id ? args.project_id : context.projectId;
-        if (!projectId) return "Error: no project_id given and no current project. Ask the user or call list_projects.";
+        if (!projectId) throw new Error("No project selected. Ask the user or call list_projects.");
         const prompt = typeof args.prompt === "string" && args.prompt.trim() ? args.prompt : undefined;
         // Promptless start_thread is handled in the frontend (opens the New
         // thread screen); reaching here without one means that path failed.
-        if (!prompt) return "No prompt given. Ask the user what the new thread should work on.";
+        if (!prompt) throw new Error("No prompt given. Ask the user what the new thread should work on.");
         const machineId =
           typeof args.machine_id === "string" && args.machine_id ? args.machine_id : null;
         const thread = await bb.sdk.threads.spawn({
@@ -966,7 +984,7 @@ export default async function plugin(bb: BbPluginApi) {
             : {
                 started,
                 focused: false,
-                note: "Started and running, but NOT brought on screen (that would drop the live call on this phone). Tell the user in one short sentence that it's running and they can tap it in the thread list.",
+                note: "Started and running, but not brought on screen. Call focus_thread with its ID if the user wants to see it beside the call.",
               },
         );
       }
@@ -987,7 +1005,7 @@ export default async function plugin(bb: BbPluginApi) {
         const available = await exposedPluginCommands();
         const command = available.find((c) => c.id === requested || c.name === requested);
         if (!command) {
-          return `Plugin "${requested}" is not available. Available plugins: ${available.map((c) => c.id).join(", ") || "none"}.`;
+          throw new Error(`Plugin "${requested}" is not available. Available plugins: ${available.map((c) => c.id).join(", ") || "none"}.`);
         }
         const argv = Array.isArray(args.argv)
           ? (args.argv as unknown[]).filter((v): v is string => typeof v === "string")
@@ -1011,17 +1029,17 @@ export default async function plugin(bb: BbPluginApi) {
           error?: string;
         } | null;
         if (!response.ok || result === null) {
-          return `Error running bb ${command.name}: HTTP ${response.status}${result?.error ? ` — ${result.error}` : ""}`;
+          throw new Error(`Error running bb ${command.name}: HTTP ${response.status}${result?.error ? ` — ${result.error}` : ""}`);
         }
         const out = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
         if (result.exitCode !== 0) {
-          return truncate(`bb ${command.name} ${argv.join(" ")} failed (exit ${result.exitCode ?? "?"}):\n${out || "(no output)"}`);
+          throw new Error(truncate(`bb ${command.name} ${argv.join(" ")} failed (exit ${result.exitCode ?? "?"}):\n${out || "(no output)"}`));
         }
         return truncate(out || "(no output)");
       }
       case "update_instructions": {
         const content = str("instructions");
-        if (content.length > 20000) return "Error: instructions too long (max 20000 characters).";
+        if (content.length > 20000) throw new Error("Instructions too long (max 20000 characters).");
         savePromptVersion(content, "agent", str("reason"));
         return "Instructions updated. They apply from the next voice session.";
       }
@@ -1048,7 +1066,7 @@ export default async function plugin(bb: BbPluginApi) {
         return JSON.stringify({ shortstat: diff.shortstat, files: files.slice(0, 50) });
       }
       default:
-        return `Unknown tool: ${name}`;
+        throw new Error(`Unknown tool: ${name}`);
     }
   }
 
@@ -1162,7 +1180,7 @@ export default async function plugin(bb: BbPluginApi) {
       const session = {
         type: "realtime",
         model,
-        instructions: `${activePrompt()}${pluginSection}\n\nCurrent context: threadId=${threadId ?? "none"}, projectId=${projectId ?? "none"}${onNewThreadScreen ? " — the user is on the New thread screen (no thread exists yet; they're composing the prompt for one)" : ""}. Call get_context for fresh context — the user navigates while talking.`,
+        instructions: `${activePrompt()}${pluginSection}\n\nThread views: focus_thread shows a thread beside the call; disposition new preserves other tabs and reuse replaces the active tab. focus_threads opens a batch while preserving every requested thread. For all running threads, use list_live_threads and exclude recently-finished entries. Use manage_views to list, select, or close views. Use set_view_behavior only for an explicitly requested lasting preference. Call get_context for the thread currently shown; never assume the original call context is still current.\n\nCurrent context: threadId=${threadId ?? "none"}, projectId=${projectId ?? "none"}${onNewThreadScreen ? " — the user is on the New thread screen (no thread exists yet; they're composing the prompt for one)" : ""}. Call get_context for fresh context — the user navigates while talking.`,
         audio: {
           input: {
             noise_reduction: { type: "near_field" },
@@ -1282,22 +1300,14 @@ export default async function plugin(bb: BbPluginApi) {
       return { effective, preference, hasApiKey, envKeyPresent, subscriptionAvailable };
     },
     async logEvent({ sessionId, kind, payload }) {
-      db.prepare(
+      const ts = Date.now();
+      const result = db.prepare(
         "INSERT INTO session_events (session_id, ts, kind, payload) VALUES (?, ?, ?, ?)",
-      ).run(sessionId, Date.now(), kind, JSON.stringify(payload));
-      // Mirror audio/mic lifecycle diagnostics to the plugin log so `bb plugin
-      // logs handsfree` surfaces mic/speaker/backgrounding problems (HF-2)
-      // without opening the DB.
-      if (
-        kind.startsWith("audio.") ||
-        kind.startsWith("mic.") ||
-        kind.startsWith("page.") ||
-        kind.startsWith("client.")
-      ) {
-        const detail = JSON.stringify(payload);
-        if (kind.endsWith(".failed")) bb.log.error(`${kind} ${detail}`);
-        else bb.log.info(`${kind} ${detail}`);
-      }
+      ).run(sessionId, ts, kind, JSON.stringify(payload));
+      // Both views describe this exact persisted event, including client/session
+      // and tool call identity. Client-handled tools must be visible here too.
+      const entry = sessionEventLog({ id: Number(result.lastInsertRowid), ts, sessionId, kind, payload });
+      bb.log[entry.level](entry.message);
       bb.realtime.publish("aide-log", { sessionId });
       return { ok: true as const };
     },
@@ -1313,9 +1323,18 @@ export default async function plugin(bb: BbPluginApi) {
       bb.realtime.publish("voice-command", { nonce, action, client, realm });
       return { ok: true as const };
     },
-    async sendCompanion({ threadId, client, realm }) {
-      bb.realtime.publish("voice-companion", { threadId, client, realm });
-      return { ok: true as const };
+    async resolveThreadViews({ threadIds }) {
+      const views: { kind: "thread"; id: string; threadId: string; projectId: string | null; title: string }[] = [];
+      const ids = [...new Set(threadIds)];
+      // Bound backend concurrency; resolve everything before changing the UI.
+      for (let i = 0; i < ids.length; i += 8) {
+        views.push(...await Promise.all(ids.slice(i, i + 8).map(async threadId => {
+          const thread = await bb.sdk.threads.get({ threadId });
+          return { kind: "thread" as const, id: `thread:${threadId}`, threadId,
+            projectId: thread.projectId, title: thread.title || thread.titleFallback || threadId };
+        })));
+      }
+      return { views, preference: (await readConfig()).viewBehavior };
     },
     async forceStop({ nonce }) {
       // Durable end-marker so listSessions stops showing it live even if the
@@ -1349,7 +1368,15 @@ export default async function plugin(bb: BbPluginApi) {
         "SELECT payload FROM session_events WHERE session_id = ? AND kind IN ('user', 'assistant') ORDER BY (kind = 'assistant'), ts, id LIMIT 1",
       );
       const errorStmt = db.prepare(
-        "SELECT 1 FROM session_events WHERE session_id = ? AND kind = 'error' LIMIT 1",
+        `SELECT 1 FROM session_events WHERE session_id = ? AND (
+          kind = 'error' OR (kind = 'tool.result' AND (
+            json_extract(payload, '$.status') = 'error' OR
+            (json_extract(payload, '$.status') IS NULL AND (
+              json_extract(payload, '$.output') LIKE 'Tool error%' OR
+              json_extract(payload, '$.output') LIKE 'Error:%'
+            ))
+          ))
+        ) LIMIT 1`,
       );
       const deviceStmt = db.prepare(
         "SELECT payload FROM session_events WHERE session_id = ? AND kind = 'session.started' ORDER BY ts LIMIT 1",
@@ -1433,14 +1460,12 @@ export default async function plugin(bb: BbPluginApi) {
       return { ok: true as const };
     },
     async runTool({ name, args, threadId, projectId, onNewThreadScreen }) {
-      bb.log.info(`voice tool: ${name} ${JSON.stringify(args).slice(0, 300)}`);
       try {
         const output = await runTool(name, args, { threadId, projectId, onNewThreadScreen });
-        return { output };
+        return { output, status: "success" as const };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        bb.log.warn(`voice tool ${name} failed: ${message}`);
-        return { output: `Tool error: ${message}` };
+        return { output: `Tool error: ${message}`, status: "error" as const };
       }
     },
   });

--- a/server.ts
+++ b/server.ts
@@ -44,6 +44,8 @@ export const rpcContract = defineRpcContract({
         projectId: z.string().nullable(),
         /** True when the user is on the New thread screen (no thread yet). */
         onNewThreadScreen: z.boolean().optional(),
+        /** Device policy is fixed for the call, independently of its entry point. */
+        mobile: z.boolean().optional(),
         /** Unique per call; broadcast so every other window ends its session. */
         nonce: z.string().min(1),
       })
@@ -121,7 +123,7 @@ export const rpcContract = defineRpcContract({
         model: z.enum(MODEL_OPTIONS),
         voice: z.enum(VOICE_OPTIONS),
         notifications: z.boolean(),
-        viewBehavior: z.enum(["auto", "reuse", "new"]),
+        mobileViewBehavior: z.enum(["reuse", "new"]),
         pluginCommands: z.string(),
         credentialPreference: z.enum(["auto", "apiKey", "subscription"]),
         shortcuts: shortcutsSchema,
@@ -135,7 +137,7 @@ export const rpcContract = defineRpcContract({
         model: z.enum(MODEL_OPTIONS).optional(),
         voice: z.enum(VOICE_OPTIONS).optional(),
         notifications: z.boolean().optional(),
-        viewBehavior: z.enum(["auto", "reuse", "new"]).optional(),
+        mobileViewBehavior: z.enum(["reuse", "new"]).optional(),
         pluginCommands: z.string().max(2000).optional(),
         credentialPreference: z.enum(["auto", "apiKey", "subscription"]).optional(),
         shortcuts: shortcutsSchema.optional(),
@@ -146,7 +148,7 @@ export const rpcContract = defineRpcContract({
         model: z.enum(MODEL_OPTIONS),
         voice: z.enum(VOICE_OPTIONS),
         notifications: z.boolean(),
-        viewBehavior: z.enum(["auto", "reuse", "new"]),
+        mobileViewBehavior: z.enum(["reuse", "new"]),
         pluginCommands: z.string(),
         credentialPreference: z.enum(["auto", "apiKey", "subscription"]),
         shortcuts: shortcutsSchema,
@@ -250,7 +252,7 @@ export const rpcContract = defineRpcContract({
         kind: z.literal("thread"), id: z.string(), threadId: z.string(),
         projectId: z.string().nullable(), title: z.string(),
       }).strict()),
-      preference: z.enum(["auto", "reuse", "new"]),
+      preference: z.enum(["reuse", "new"]),
     }).strict(),
   },
   /**
@@ -383,7 +385,7 @@ interface PluginCommandInfo {
   summary: string;
 }
 
-function toolSchemas(pluginCommands: PluginCommandInfo[] = []) {
+export function toolSchemas(pluginCommands: PluginCommandInfo[] = [], mobile = false) {
   const pluginTool =
     pluginCommands.length === 0
       ? []
@@ -411,10 +413,10 @@ function toolSchemas(pluginCommands: PluginCommandInfo[] = []) {
     { type: "function", name: "list_threads", description: "List recent bb threads (id, title, status). Optionally filter by project id.", parameters: { type: "object", properties: { project_id: { type: "string" }, limit: { type: "number", description: "Max threads to return (default 15)." } } } },
     { type: "function", name: "search_threads", description: "Full-text search bb threads by title/content. Returns matching thread ids and titles.", parameters: { type: "object", properties: { query: { type: "string" } }, required: ["query"] } },
     { type: "function", name: "read_thread", description: "Read a thread's details and its latest assistant output.", parameters: { type: "object", properties: { thread_id: { type: "string" } }, required: ["thread_id"] } },
-    { type: "function", name: "focus_thread", description: "Show a thread beside the call on this device. Reopening a thread selects its existing tab. disposition: auto uses the saved preference, reuse replaces the active tab, new keeps existing tabs.", parameters: { type: "object", properties: { thread_id: { type: "string" }, disposition: { type: "string", enum: ["auto", "reuse", "new"] } }, required: ["thread_id"] } },
-    { type: "function", name: "focus_threads", description: "Show several threads as tabs beside the call, preserving existing tabs. To show all running threads, first call list_live_threads and exclude recently-finished entries; pass their IDs here. Up to 100 per batch; split larger lists into batches.", parameters: { type: "object", properties: { thread_ids: { type: "array", items: { type: "string" }, minItems: 1, maxItems: 100 } }, required: ["thread_ids"] } },
-    { type: "function", name: "manage_views", description: "List, select, or close the views open on this device. Get view IDs using list. clear closes all views only when the user asks. Closing a view does not stop its thread or the call.", parameters: { type: "object", properties: { action: { type: "string", enum: ["list", "select", "close", "clear"] }, view_id: { type: "string" } }, required: ["action"] } },
-    { type: "function", name: "set_view_behavior", description: "Save how future thread opens behave. Use only when the user asks for a lasting preference: auto reuses on mobile and keeps tabs on desktop; reuse replaces the active tab; new keeps tabs on either device. Explicit requests and batches override this preference.", parameters: { type: "object", properties: { behavior: { type: "string", enum: ["auto", "reuse", "new"] } }, required: ["behavior"] } },
+    { type: "function", name: "focus_thread", description: mobile ? "Show a thread in the mobile drawer without leaving the call. Reopening a thread selects its existing view. disposition: auto uses the mobile preference, reuse replaces the active view, new keeps existing views." : "Open/focus a thread in the user's bb app window, navigating to that thread.", parameters: { type: "object", properties: { thread_id: { type: "string" }, ...(mobile ? { disposition: { type: "string", enum: ["auto", "reuse", "new"] } } : {}) }, required: ["thread_id"] } },
+    { type: "function", name: "focus_threads", description: "Show several threads in the mobile drawer switcher, preserving existing views. To show all running threads, first call list_live_threads and exclude recently-finished entries; pass their IDs here. Up to 100 per batch; split larger lists into batches.", parameters: { type: "object", properties: { thread_ids: { type: "array", items: { type: "string" }, minItems: 1, maxItems: 100 } }, required: ["thread_ids"] } },
+    { type: "function", name: "manage_views", description: "List, select, or close the views in the mobile drawer. Get view IDs using list. clear closes all views only when the user asks. Closing a view does not stop its thread or the call.", parameters: { type: "object", properties: { action: { type: "string", enum: ["list", "select", "close", "clear"] }, view_id: { type: "string" } }, required: ["action"] } },
+    { type: "function", name: "set_view_behavior", description: "Save how future mobile drawer opens behave. Use only when the user asks for a lasting mobile preference: reuse replaces the active view; new keeps views in the switcher. Desktop always navigates normally. Explicit mobile requests and batches override this preference.", parameters: { type: "object", properties: { behavior: { type: "string", enum: ["reuse", "new"] } }, required: ["behavior"] } },
     { type: "function", name: "set_pane", description: "Change a thread pane's presentation in the bb app: spotlight, clear-spotlight, maximize, restore, or toggle.", parameters: { type: "object", properties: { thread_id: { type: "string" }, action: { type: "string", enum: ["spotlight", "clear-spotlight", "maximize", "restore", "toggle"] } }, required: ["thread_id", "action"] } },
     { type: "function", name: "send_to_thread", description: "Send a message to a thread's agent. Starts a turn if idle, queues/steers if running.", parameters: { type: "object", properties: { thread_id: { type: "string" }, message: { type: "string" } }, required: ["thread_id", "message"] } },
     { type: "function", name: "start_thread", description: "Start a new agent thread in a project. Only pass prompt when the user dictated actual work; With no prompt, this opens bb's New thread screen for the user to type their own. Runs on the project's default machine unless machine_id is given — if the project lives on several connected machines and the user didn't say which, check list_machines and ask one short question instead of guessing.", parameters: { type: "object", properties: { project_id: { type: "string", description: "Project id; defaults to the user's current project." }, prompt: { type: "string", description: "The user's own instruction for the agent, verbatim. Omit if they didn't give one." }, title: { type: "string" }, machine_id: { type: "string", description: "Machine (host) id to run on, from list_machines. Omit to use the project's default machine." } } } },
@@ -426,7 +428,13 @@ function toolSchemas(pluginCommands: PluginCommandInfo[] = []) {
     // Handled locally in the bb app frontend, never reaches runTool:
     { type: "function", name: "set_composer_text", description: "Replace the text in the user's message composer (the box they type prompts into).", parameters: { type: "object", properties: { text: { type: "string" } }, required: ["text"] } },
     { type: "function", name: "append_composer_text", description: "Append text to the user's message composer.", parameters: { type: "object", properties: { text: { type: "string" } }, required: ["text"] } },
-  ];
+  ].filter(tool => mobile || !["focus_threads", "manage_views", "set_view_behavior"].includes(tool.name));
+}
+
+export function threadViewInstructions(mobile: boolean) {
+  return mobile
+    ? "Mobile thread views: focus_thread shows a thread in the drawer without navigating away from the call. disposition new preserves other views and reuse replaces the selected view. focus_threads opens a batch into the drawer switcher, not separate native bb tabs. For all running threads, use list_live_threads and exclude recently-finished entries. Use manage_views to list, select, or close mobile views. Use set_view_behavior only for an explicitly requested lasting mobile preference. Call get_context for the thread currently shown. If the drawer is unavailable, report the limitation; do not navigate away from the mobile call."
+    : "Desktop navigation: focus_thread opens and navigates to the requested thread, as usual, regardless of where the call started. There is no desktop companion-view mode in this version. Call get_context after navigation for the current thread. Mobile drawer preferences do not apply to desktop.";
 }
 
 const DEFAULT_PROMPT = `You are Aide, a concise voice operator for bb — the user's agentic IDE where coding agents run in threads inside projects.
@@ -501,7 +509,7 @@ export default async function plugin(bb: BbPluginApi) {
     model: RealtimeModel;
     voice: Voice;
     notifications: boolean;
-    viewBehavior: "auto" | "reuse" | "new";
+    mobileViewBehavior: "reuse" | "new";
     pluginCommands: string;
     credentialPreference: CredentialPreference;
     shortcuts: Shortcuts;
@@ -511,19 +519,19 @@ export default async function plugin(bb: BbPluginApi) {
     model: DEFAULT_MODEL,
     voice: DEFAULT_VOICE,
     notifications: true,
-    viewBehavior: "auto",
+    mobileViewBehavior: "reuse",
     pluginCommands: "all",
     credentialPreference: "auto",
     shortcuts: { ...DEFAULT_SHORTCUTS },
   };
   async function readConfig(): Promise<VoiceConfig> {
-    const stored = (await bb.storage.kv.get<Partial<VoiceConfig>>(CONFIG_KEY)) ?? {};
+    const stored = (await bb.storage.kv.get<Partial<VoiceConfig> & { viewBehavior?: string }>(CONFIG_KEY)) ?? {};
     return {
       model: isModel(stored.model) ? stored.model : CONFIG_DEFAULTS.model,
       voice: isVoice(stored.voice) ? stored.voice : CONFIG_DEFAULTS.voice,
       notifications:
         typeof stored.notifications === "boolean" ? stored.notifications : CONFIG_DEFAULTS.notifications,
-      viewBehavior: stored.viewBehavior === "reuse" || stored.viewBehavior === "new" ? stored.viewBehavior : "auto",
+      mobileViewBehavior: (stored.mobileViewBehavior ?? stored.viewBehavior) === "new" ? "new" : "reuse",
       pluginCommands:
         typeof stored.pluginCommands === "string" ? stored.pluginCommands : CONFIG_DEFAULTS.pluginCommands,
       credentialPreference: isCredentialPreference(stored.credentialPreference)
@@ -920,10 +928,10 @@ export default async function plugin(bb: BbPluginApi) {
       }
       case "set_view_behavior": {
         const behavior = str("behavior");
-        if (behavior !== "auto" && behavior !== "reuse" && behavior !== "new") throw new Error("Invalid view behavior.");
-        await writeConfig({ viewBehavior: behavior });
+        if (behavior !== "reuse" && behavior !== "new") throw new Error("Invalid view behavior.");
+        await writeConfig({ mobileViewBehavior: behavior });
         bb.realtime.publish("config-changed", {});
-        return "Saved the thread-opening preference.";
+        return "Saved the mobile drawer preference. Desktop navigation is unchanged.";
       }
       case "focus_threads":
       case "manage_views":
@@ -1169,7 +1177,7 @@ export default async function plugin(bb: BbPluginApi) {
   });
 
   bb.rpc.register(rpcContract, {
-    async createCall({ sdp, threadId, projectId, onNewThreadScreen, nonce }) {
+    async createCall({ sdp, threadId, projectId, onNewThreadScreen, nonce, mobile = false }) {
       const key = await apiKey();
       const { model, voice } = await readConfig();
       const pluginCommands = await exposedPluginCommands();
@@ -1180,7 +1188,7 @@ export default async function plugin(bb: BbPluginApi) {
       const session = {
         type: "realtime",
         model,
-        instructions: `${activePrompt()}${pluginSection}\n\nThread views: focus_thread shows a thread beside the call; disposition new preserves other tabs and reuse replaces the active tab. focus_threads opens a batch while preserving every requested thread. For all running threads, use list_live_threads and exclude recently-finished entries. Use manage_views to list, select, or close views. Use set_view_behavior only for an explicitly requested lasting preference. Call get_context for the thread currently shown; never assume the original call context is still current.\n\nCurrent context: threadId=${threadId ?? "none"}, projectId=${projectId ?? "none"}${onNewThreadScreen ? " — the user is on the New thread screen (no thread exists yet; they're composing the prompt for one)" : ""}. Call get_context for fresh context — the user navigates while talking.`,
+        instructions: `${activePrompt()}${pluginSection}\n\n${threadViewInstructions(mobile)}\n\nCurrent context: threadId=${threadId ?? "none"}, projectId=${projectId ?? "none"}${onNewThreadScreen ? " — the user is on the New thread screen (no thread exists yet; they're composing the prompt for one)" : ""}. Call get_context for fresh context — the user navigates while talking.`,
         audio: {
           input: {
             noise_reduction: { type: "near_field" },
@@ -1197,7 +1205,7 @@ export default async function plugin(bb: BbPluginApi) {
           },
           output: { voice },
         },
-        tools: toolSchemas(pluginCommands),
+        tools: toolSchemas(pluginCommands, mobile),
       };
       const form = new FormData();
       form.set("sdp", sdp);
@@ -1334,7 +1342,7 @@ export default async function plugin(bb: BbPluginApi) {
             projectId: thread.projectId, title: thread.title || thread.titleFallback || threadId };
         })));
       }
-      return { views, preference: (await readConfig()).viewBehavior };
+      return { views, preference: (await readConfig()).mobileViewBehavior };
     },
     async forceStop({ nonce }) {
       // Durable end-marker so listSessions stops showing it live even if the

--- a/server.ts
+++ b/server.ts
@@ -239,6 +239,21 @@ export const rpcContract = defineRpcContract({
     output: z.object({ ok: z.literal(true) }).strict(),
   },
   /**
+   * Relay a "show this thread in the companion drawer" request to whichever realm
+   * has the Handsfree page mounted (the call may be owned by a composer realm
+   * that has no page of its own).
+   */
+  sendCompanion: {
+    input: z
+      .object({
+        threadId: z.string().min(1),
+        client: z.string().optional(),
+        realm: z.string().optional(),
+      })
+      .strict(),
+    output: z.object({ ok: z.literal(true) }).strict(),
+  },
+  /**
    * End a call authoritatively, without needing its owner realm to act — the
    * owner may be a frozen, backgrounded mobile webview that can no longer receive
    * commands. Marks the session stopped (so the list stops showing it live) and
@@ -1296,6 +1311,10 @@ export default async function plugin(bb: BbPluginApi) {
     },
     async sendVoiceCommand({ nonce, action, client, realm }) {
       bb.realtime.publish("voice-command", { nonce, action, client, realm });
+      return { ok: true as const };
+    },
+    async sendCompanion({ threadId, client, realm }) {
+      bb.realtime.publish("voice-companion", { threadId, client, realm });
       return { ok: true as const };
     },
     async forceStop({ nonce }) {

--- a/session-events.test.ts
+++ b/session-events.test.ts
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { actionStatus, pairToolEvents, sessionEventLog } from "./session-events.ts";
+
+const event = (id: number, kind: string, payload: object) => ({ id, kind, payload: JSON.stringify(payload) });
+test("same-named calls pair by identity even when results arrive in reverse order", () => {
+  const pairs = pairToolEvents([
+    event(1, "tool.result", { name: "focus_thread", callId: "b", output: "B" }),
+    event(2, "tool.call", { name: "focus_thread", callId: "a" }),
+    event(3, "tool.call", { name: "focus_thread", callId: "b" }),
+    event(4, "tool.result", { name: "focus_thread", callId: "a", output: "A" }),
+  ]);
+  assert.equal(pairs.get(2)?.payload.output, "A");
+  assert.equal(pairs.get(3)?.payload.output, "B");
+});
+test("a missing result stays pending, and legacy results are consumed only once", () => {
+  const pairs = pairToolEvents([
+    event(1, "tool.call", { name: "focus_thread", callId: "a" }),
+    event(2, "tool.call", { name: "focus_thread" }),
+    event(3, "tool.call", { name: "focus_thread" }),
+    event(4, "tool.result", { name: "focus_thread", output: "Focused." }),
+  ]);
+  assert.equal(pairs.has(1), false);
+  assert.equal(pairs.get(2)?.id, 4);
+  assert.equal(pairs.has(3), false);
+});
+test("new outcomes use status rather than English text; old sessions remain readable", () => {
+  assert.equal(actionStatus({ output: "Everything worked", status: "error" }), "error");
+  assert.equal(actionStatus({ output: "Error: quoted from a document", status: "success" }), "success");
+  assert.equal(actionStatus({ output: "Tool error: failed" }), "error");
+  assert.equal(actionStatus({ output: "Focused." }), "success");
+  const event = { id: 42, ts: 123, sessionId: "phone-call", kind: "tool.result", payload: { callId: "open-a", status: "error", output: "Could not open", _id: { client: "phone", realm: "page" } } };
+  const log = sessionEventLog(event);
+  assert.equal(log.level, "error");
+  assert.deepEqual(JSON.parse(log.message), event);
+});

--- a/session-events.ts
+++ b/session-events.ts
@@ -1,0 +1,39 @@
+// One outcome vocabulary for the transcript, error filter, and plugin log.
+export type ActionStatus = "success" | "error";
+export function actionStatus(payload: Record<string, unknown>): ActionStatus {
+  if (payload.status === "success" || payload.status === "error") return payload.status;
+  // Older sessions and legacy tool outputs have no structured status.
+  return /^(tool error\b|error:|no connected bb window|no composer|no bb surface|no thread_id)/i.test(String(payload.output ?? ""))
+    ? "error" : "success";
+}
+/** Pair each result once, including out-of-order arrivals and legacy sessions. */
+export function pairToolEvents(events: readonly { id: number; kind: string; payload: string }[]) {
+  const parse = (text: string): Record<string, unknown> => {
+    try { return JSON.parse(text) ?? {}; } catch { return {}; }
+  };
+  const byKey = new Map<string, { id: number; payload: Record<string, unknown> }[]>();
+  const key = (payload: Record<string, unknown>) => typeof payload.callId === "string" && payload.callId
+    ? `id:${payload.callId}` : `legacy:${payload.name}`;
+  for (const event of events) {
+    if (event.kind !== "tool.result") continue;
+    const payload = parse(event.payload);
+    const group = key(payload);
+    const queue = byKey.get(group) ?? [];
+    queue.push({ id: event.id, payload });
+    byKey.set(group, queue);
+  }
+  const pairs = new Map<number, { id: number; payload: Record<string, unknown> }>();
+  for (const event of events) {
+    if (event.kind !== "tool.call") continue;
+    const result = byKey.get(key(parse(event.payload)))?.shift();
+    if (result) pairs.set(event.id, result);
+  }
+  return pairs;
+}
+export function sessionEventLog(event: {
+  id: number; sessionId: string; ts: number; kind: string; payload: Record<string, unknown>;
+}) {
+  const error = event.kind === "error" || event.kind.endsWith(".failed") ||
+    (event.kind === "tool.result" && actionStatus(event.payload) === "error");
+  return { level: error ? "error" as const : "info" as const, message: JSON.stringify(event) };
+}

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -15,7 +15,7 @@ import {
 import type { rpcContract } from "./server";
 import { clientDescriptor } from "./client-identity";
 import { voiceAgent } from "./voice-agent";
-import { MicIcon, StopIcon, WaveformIcon, useCallElapsed } from "./voice-chrome";
+import { LiveCallControls, MicIcon, WaveformIcon } from "./voice-chrome";
 import { viewWorkspace } from "./view-workspace";
 import { actionStatus, pairToolEvents } from "./session-events";
 import { COMPANION_TAB } from "./companion";
@@ -144,10 +144,7 @@ function GearIcon() {
  */
 function CallConsole({ onViewTranscript, selectedId }: { onViewTranscript: (sessionId: string) => void; selectedId: string | null }) {
   const state = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
-  const activity = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getActivity);
-  const micSuspended = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getMicSuspended);
   const lastActivity = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getLastActivity);
-  const elapsed = useCallElapsed();
   const live = state === "live";
   const muted = state === "muted";
   const active = live || muted;
@@ -171,24 +168,6 @@ function CallConsole({ onViewTranscript, selectedId }: { onViewTranscript: (sess
     );
   }
 
-  const speaking = activity === "aide";
-  const listening = activity === "you";
-  const activityColor = micSuspended
-    ? "text-destructive" // uplink down (iOS backgrounded the mic)
-    : speaking
-      ? "text-[color:var(--success,#6faf76)]" // Aide
-      : listening
-        ? "text-foreground" // you
-        : "text-muted-foreground/70";
-  const label = micSuspended
-    ? "Mic paused"
-    : speaking
-      ? "Aide speaking…"
-      : listening
-        ? "Listening…"
-        : muted
-          ? "Muted"
-          : "Connected";
   const liveId = voiceAgent.getSessionId();
   const ticker = tickerFor(lastActivity);
   // When you're already reading the live transcript, the ticker (and the pill's
@@ -215,40 +194,7 @@ function CallConsole({ onViewTranscript, selectedId }: { onViewTranscript: (sess
           </svg>
         </button>
       ) : null}
-      <div className="flex h-11 max-w-full items-center overflow-hidden rounded-full border border-border bg-card shadow-lg">
-      <button
-          type="button"
-          aria-label={muted ? "Unmute Aide microphone" : "Mute Aide microphone"}
-          title={muted ? "Unmute" : "Mute"}
-          onClick={() => voiceAgent.toggleMuteFromSurface()}
-          className={cn(
-            "flex size-11 shrink-0 items-center justify-center transition-colors",
-            muted
-              ? "text-destructive hover:bg-destructive/15"
-              : "text-muted-foreground hover:bg-accent hover:text-foreground",
-          )}
-        >
-          <MicIcon slashed={muted} />
-        </button>
-        <span className="h-5 w-px bg-border" />
-        <span className="flex min-w-0 items-center gap-2 px-3">
-          <span className={cn("flex shrink-0 items-center", activityColor)} title={label} aria-label={label}>
-            <WaveformIcon live={speaking || listening} />
-          </span>
-          <span className="truncate text-sm text-foreground">{label}</span>
-          <span className="shrink-0 tabular-nums text-xs text-muted-foreground">{elapsed ?? ""}</span>
-        </span>
-        <span className="h-5 w-px bg-border" />
-        <button
-          type="button"
-          aria-label="Stop Aide voice session"
-          title="Stop"
-          onClick={() => voiceAgent.stopFromSurface()}
-          className="flex size-11 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:bg-destructive/15 hover:text-destructive"
-        >
-          <StopIcon />
-        </button>
-      </div>
+      <LiveCallControls />
     </div>
   );
 }

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -15,6 +15,8 @@ import {
 import type { rpcContract } from "./server";
 import { voiceAgent } from "./voice-agent";
 import { MicIcon, StopIcon, WaveformIcon, useCallElapsed } from "./voice-chrome";
+import { viewWorkspace } from "./view-workspace";
+import { actionStatus, pairToolEvents } from "./session-events";
 import { COMPANION_TAB } from "./companion";
 import { cn } from "@/lib/utils";
 
@@ -268,7 +270,10 @@ const ACTIONS: Record<string, { family: ActionFamily; verb: string }> = {
   list_threads: { family: "inspect", verb: "Listed threads" },
   search_threads: { family: "inspect", verb: "Searched threads" },
   read_thread: { family: "inspect", verb: "Read a thread" },
-  focus_thread: { family: "navigate", verb: "Focused a thread" },
+  focus_thread: { family: "navigate", verb: "Showed a thread" },
+  focus_threads: { family: "navigate", verb: "Showed threads" },
+  manage_views: { family: "navigate", verb: "Updated views" },
+  set_view_behavior: { family: "self", verb: "Changed thread-opening preference" },
   set_pane: { family: "navigate", verb: "Changed the layout" },
   show_diff: { family: "navigate", verb: "Opened a diff" },
   send_to_thread: { family: "mutate", verb: "Sent a message" },
@@ -344,7 +349,7 @@ function Chevron() {
 
 type Row =
   | { kind: "speech"; id: number; ts: number; who: "you" | "aide"; text: string }
-  | { kind: "action"; id: number; ts: number; name: string; args: Record<string, unknown>; output: string | null }
+  | { kind: "action"; id: number; ts: number; name: string; args: Record<string, unknown>; output: string | null; status?: "success" | "error"; label?: string }
   | { kind: "notice"; id: number; ts: number; text: string }
   | { kind: "error"; id: number; ts: number; message: string }
   | { kind: "sysgroup"; id: number; ts: number; events: EventRow[] };
@@ -359,14 +364,15 @@ const CONVERSATION_KINDS = new Set(["user", "assistant", "tool.call", "tool.resu
  */
 function buildRows(events: EventRow[]): Row[] {
   const rows: Row[] = [];
-  const consumed = new Set<number>();
+  const pairs = pairToolEvents(events);
+  const pairedResults = new Set([...pairs.values()].map(result => result.id));
   let diagnostics: EventRow[] = [];
   const flush = () => {
     if (diagnostics.length === 0) return;
     rows.push({ kind: "sysgroup", id: diagnostics[0].id, ts: diagnostics[0].ts, events: diagnostics });
     diagnostics = [];
   };
-  events.forEach((event, index) => {
+  events.forEach((event) => {
     if (!CONVERSATION_KINDS.has(event.kind)) {
       diagnostics.push(event);
       return;
@@ -380,23 +386,16 @@ function buildRows(events: EventRow[]): Row[] {
         break;
       case "tool.call": {
         const name = String(payload.name ?? "?");
-        let output: string | null = null;
-        for (let j = index + 1; j < events.length; j++) {
-          const later = events[j];
-          if (later.kind !== "tool.result" || consumed.has(later.id)) continue;
-          const lp = parsePayload(later.payload);
-          if (String(lp.name ?? "?") === name) {
-            output = String(lp.output ?? "");
-            consumed.add(later.id);
-            break;
-          }
-        }
-        rows.push({ kind: "action", id: event.id, ts: event.ts, name, args: (payload.args as Record<string, unknown>) ?? {}, output });
+        const result = pairs.get(event.id)?.payload;
+        const output = result ? String(result.output ?? "") : null;
+        const status = result ? actionStatus(result) : undefined;
+        const label = typeof result?.label === "string" ? result.label : undefined;
+        rows.push({ kind: "action", id: event.id, ts: event.ts, name, args: (payload.args as Record<string, unknown>) ?? {}, output, status, label });
         break;
       }
       case "tool.result":
-        if (consumed.has(event.id)) break; // already merged into its call
-        rows.push({ kind: "action", id: event.id, ts: event.ts, name: String(payload.name ?? "?"), args: {}, output: String(payload.output ?? "") });
+        if (pairedResults.has(event.id)) break; // already merged into its call
+        rows.push({ kind: "action", id: event.id, ts: event.ts, name: String(payload.name ?? "?"), args: {}, output: String(payload.output ?? ""), status: actionStatus(payload), label: typeof payload.label === "string" ? payload.label : undefined });
         break;
       case "notice":
         rows.push({ kind: "notice", id: event.id, ts: event.ts, text: String(payload.text ?? "") });
@@ -440,15 +439,15 @@ function SpeechRow({ row }: { row: Extract<Row, { kind: "speech" }> }) {
 function ActionRow({ row, plugins }: { row: Extract<Row, { kind: "action" }>; plugins: Map<string, PluginMeta> }) {
   const meta = actionMeta(row.name);
   const pending = row.output === null;
-  const isError = !pending && /^tool error/i.test(row.output ?? "");
+  const isError = !pending && row.status === "error";
   const hasArgs = Object.keys(row.args).length > 0;
 
   // run_plugin_command reads as "Used plugin [chip]": the left square keeps the
   // generic plugin glyph (consistent with every action row), and the plugin's
   // real name + icon (from listPlugins) ride in a chip next to it.
   const isPlugin = row.name === "run_plugin_command";
-  let verb = meta.verb;
-  let object = actionObject(row.name, row.args);
+  let verb = pending ? "Working…" : isError ? "Couldn’t complete action" : row.label ?? meta.verb;
+  let object = row.label ? "" : actionObject(row.name, row.args);
   let pluginName = "";
   let pluginIcon: string | null = null;
   if (isPlugin) {
@@ -542,7 +541,7 @@ const FILTERS: { id: TranscriptFilter; label: string }[] = [
 ];
 
 function rowMatchesFilter(row: Row, filter: TranscriptFilter): boolean {
-  const actionErrored = row.kind === "action" && row.output !== null && /^tool error/i.test(row.output);
+  const actionErrored = row.kind === "action" && row.status === "error";
   switch (filter) {
     case "talk":
       return row.kind === "speech" || row.kind === "notice";
@@ -644,7 +643,7 @@ export function SessionsPanel() {
   // back. Everything else (thread focus, starting work, diffs) runs through rpc,
   // which works from anywhere.
   useEffect(() => {
-    voiceAgent.bindFallback({
+    return voiceAgent.bindFallback({
       rpc,
       context: { threadId: threadId ?? null, projectId: projectId ?? null, onNewThreadScreen: false },
       openNewThread: (targetProjectId) =>
@@ -655,17 +654,10 @@ export function SessionsPanel() {
     });
   }, [rpc, threadId, projectId, sidebarActions]);
 
-  // Register the companion-drawer opener OUTSIDE the voice binding, so a composer's
-  // bind() (which replaces the whole bindings object) can't clobber it. On mobile
-  // focus_thread runs in whichever realm owns the call and relays over
-  // voice-companion; the realm with the page mounted (this one) opens the drawer.
-  useEffect(() => {
-    voiceAgent.setCompanionOpener((id) =>
-      appPanel.openFixedTab({ surface: { kind: "current" }, tab: COMPANION_TAB, target: { threadId: id } }),
-    );
-    return () => voiceAgent.setCompanionOpener(null);
-  }, [appPanel]);
-  useRealtime("voice-companion", (payload) => voiceAgent.applyCompanion(payload));
+  useEffect(() => viewWorkspace.registerPresenter({
+    available: () => document.visibilityState !== "hidden",
+    reveal: () => appPanel.openFixedTab({ surface: { kind: "current" }, tab: COMPANION_TAB }),
+  }), [appPanel]);
   const [sessions, setSessions] = useState<SessionRow[] | null>(null);
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -6,6 +6,7 @@
 // (which collapses on mobile) or switch sidebars to talk.
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import {
+  experimental_useAppPanel,
   experimental_useSidebarThreadActions,
   useBbContext,
   useRealtime,
@@ -14,6 +15,7 @@ import {
 import type { rpcContract } from "./server";
 import { voiceAgent } from "./voice-agent";
 import { MicIcon, StopIcon, WaveformIcon, useCallElapsed } from "./voice-chrome";
+import { COMPANION_TAB } from "./companion";
 import { cn } from "@/lib/utils";
 
 interface DeviceInfo {
@@ -630,6 +632,7 @@ export function SessionsPanel() {
   const rpc = useRpc<typeof rpcContract>();
   const { threadId, projectId } = useBbContext();
   const sidebarActions = experimental_useSidebarThreadActions();
+  const appPanel = experimental_useAppPanel();
   useEscapeToClose();
 
   // The Handsfree page has no composer, so nothing else binds the voice agent
@@ -651,6 +654,18 @@ export function SessionsPanel() {
         }),
     });
   }, [rpc, threadId, projectId, sidebarActions]);
+
+  // Register the companion-drawer opener OUTSIDE the voice binding, so a composer's
+  // bind() (which replaces the whole bindings object) can't clobber it. On mobile
+  // focus_thread runs in whichever realm owns the call and relays over
+  // voice-companion; the realm with the page mounted (this one) opens the drawer.
+  useEffect(() => {
+    voiceAgent.setCompanionOpener((id) =>
+      appPanel.openFixedTab({ surface: { kind: "current" }, tab: COMPANION_TAB, target: { threadId: id } }),
+    );
+    return () => voiceAgent.setCompanionOpener(null);
+  }, [appPanel]);
+  useRealtime("voice-companion", (payload) => voiceAgent.applyCompanion(payload));
   const [sessions, setSessions] = useState<SessionRow[] | null>(null);
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -13,6 +13,7 @@ import {
   useRpc,
 } from "@get-bb/plugin-sdk/app";
 import type { rpcContract } from "./server";
+import { clientDescriptor } from "./client-identity";
 import { voiceAgent } from "./voice-agent";
 import { MicIcon, StopIcon, WaveformIcon, useCallElapsed } from "./voice-chrome";
 import { viewWorkspace } from "./view-workspace";
@@ -655,7 +656,7 @@ export function SessionsPanel() {
   }, [rpc, threadId, projectId, sidebarActions]);
 
   useEffect(() => viewWorkspace.registerPresenter({
-    available: () => document.visibilityState !== "hidden",
+    available: () => clientDescriptor.mobile && document.visibilityState !== "hidden",
     reveal: () => appPanel.openFixedTab({ surface: { kind: "current" }, tab: COMPANION_TAB }),
   }), [appPanel]);
   const [sessions, setSessions] = useState<SessionRow[] | null>(null);

--- a/settings-sections.tsx
+++ b/settings-sections.tsx
@@ -53,7 +53,7 @@ interface VoiceConfig {
   model: RealtimeModel;
   voice: Voice;
   notifications: boolean;
-  viewBehavior: "auto" | "reuse" | "new";
+  mobileViewBehavior: "reuse" | "new";
   pluginCommands: string;
   credentialPreference: CredentialPreference;
   shortcuts: Shortcuts;
@@ -328,13 +328,12 @@ export function BehaviorSettings() {
     <div className="space-y-5">
       <PromptEditor />
 
-      <Group label="Thread tabs" hint="Choose what happens when you ask Aide to show a thread. Requests for several threads always keep them all open.">
-        <label htmlFor="handsfree-view-behavior" className="mb-2 block text-sm">When opening a thread</label>
-        <select id="handsfree-view-behavior" className={selectClass} disabled={loading} value={config?.viewBehavior ?? "auto"}
-          onChange={event => void update({ viewBehavior: event.target.value as VoiceConfig["viewBehavior"] })}>
-          <option value="auto">Automatic — reuse on mobile, keep tabs on desktop</option>
-          <option value="reuse">Replace the current tab</option>
-          <option value="new">Keep threads in separate tabs</option>
+      <Group label="Mobile thread drawer" hint="On mobile, show threads without leaving the call. Desktop still navigates directly to threads.">
+        <label htmlFor="handsfree-view-behavior" className="mb-2 block text-sm">When showing a thread on mobile</label>
+        <select id="handsfree-view-behavior" className={selectClass} disabled={loading} value={config?.mobileViewBehavior ?? "reuse"}
+          onChange={event => void update({ mobileViewBehavior: event.target.value as VoiceConfig["mobileViewBehavior"] })}>
+          <option value="reuse">Replace the shown thread</option>
+          <option value="new">Keep threads in the drawer switcher</option>
         </select>
       </Group>
 

--- a/settings-sections.tsx
+++ b/settings-sections.tsx
@@ -53,6 +53,7 @@ interface VoiceConfig {
   model: RealtimeModel;
   voice: Voice;
   notifications: boolean;
+  viewBehavior: "auto" | "reuse" | "new";
   pluginCommands: string;
   credentialPreference: CredentialPreference;
   shortcuts: Shortcuts;
@@ -326,6 +327,16 @@ export function BehaviorSettings() {
   return (
     <div className="space-y-5">
       <PromptEditor />
+
+      <Group label="Thread tabs" hint="Choose what happens when you ask Aide to show a thread. Requests for several threads always keep them all open.">
+        <label htmlFor="handsfree-view-behavior" className="mb-2 block text-sm">When opening a thread</label>
+        <select id="handsfree-view-behavior" className={selectClass} disabled={loading} value={config?.viewBehavior ?? "auto"}
+          onChange={event => void update({ viewBehavior: event.target.value as VoiceConfig["viewBehavior"] })}>
+          <option value="auto">Automatic — reuse on mobile, keep tabs on desktop</option>
+          <option value="reuse">Replace the current tab</option>
+          <option value="new">Keep threads in separate tabs</option>
+        </select>
+      </Group>
 
       <Group label="Announcements">
         <label className="flex items-center justify-between gap-3">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,8 @@
     "app.tsx",
     "components",
     "lib",
-    "hooks"
+    "hooks",
+    "*.test.ts",
+    "*.test.tsx"
   ]
 }

--- a/view-workspace.test.ts
+++ b/view-workspace.test.ts
@@ -9,56 +9,56 @@ function workspace() {
   return store;
 }
 
-test("automatic opens reuse on mobile and accumulate on desktop; duplicates focus existing tabs", () => {
-  const mobile = workspace();
-  mobile.open([view("a")], "auto", "auto", true);
-  mobile.open([view("b")], "auto", "auto", true);
-  assert.deepEqual(mobile.get().views, [view("b")]);
-  const desktop = workspace();
-  desktop.open([view("a")], "auto", "auto", false);
-  desktop.open([view("b")], "auto", "auto", false);
-  desktop.open([view("a")], "new", "auto", false);
-  assert.deepEqual(desktop.get(), { views: [view("a"), view("b")], activeId: "thread:a" });
+test("mobile default reuses the shown thread; keeping views deduplicates by thread", () => {
+  const replace = workspace();
+  replace.open([view("a")], "auto", "reuse");
+  replace.open([view("b")], "auto", "reuse");
+  assert.deepEqual(replace.get().views, [view("b")]);
+  const keep = workspace();
+  keep.open([view("a")], "auto", "new");
+  keep.open([view("b")], "auto", "new");
+  keep.open([view("a")], "new", "new");
+  assert.deepEqual(keep.get(), { views: [view("a"), view("b")], activeId: "thread:a" });
 });
 
 test("explicit disposition overrides preference; batches preserve all threads despite reuse", () => {
   const store = workspace();
-  store.open([view("a")], "auto", "new", true);
-  store.open([view("b")], "auto", "new", true);
-  store.open([view("c")], "reuse", "new", true);
+  store.open([view("a")], "auto", "new");
+  store.open([view("b")], "auto", "new");
+  store.open([view("c")], "reuse", "new");
   assert.deepEqual(store.get().views, [view("a"), view("c")]);
-  store.open([view("d"), view("e"), view("d")], "auto", "reuse", true);
+  store.open([view("d"), view("e"), view("d")], "auto", "reuse");
   assert.deepEqual(store.get().views, [view("a"), view("c"), view("d"), view("e")]);
   assert.equal(store.get().activeId, "thread:d");
 });
 
 test("declined or throwing opens leave tabs and selection unchanged", () => {
   const store = workspace();
-  store.open([view("a")], "auto", "auto", true);
+  store.open([view("a")], "auto", "reuse");
   const before = store.get();
   const unregister = store.registerPresenter({ available: () => true, reveal: () => false });
-  assert.throws(() => store.open([view("b")], "reuse", "auto", true), /declined/);
+  assert.throws(() => store.open([view("b")], "reuse", "reuse"), /declined/);
   assert.equal(store.get(), before);
   unregister();
   store.registerPresenter({ available: () => true, reveal: () => { throw new Error("Host unavailable"); } });
-  assert.throws(() => store.open([view("b")], "reuse", "auto", true), /Host unavailable/);
+  assert.throws(() => store.open([view("b")], "reuse", "reuse"), /Host unavailable/);
   assert.equal(store.get(), before);
 });
 
 test("windows are isolated and unmounted or unavailable presenters cannot receive opens", () => {
   const otherWindow = workspace();
   const ownWindow = new ViewWorkspace();
-  assert.throws(() => ownWindow.open([view("a")], "auto", "auto", true), /cannot show/);
+  assert.throws(() => ownWindow.open([view("a")], "auto", "reuse"), /cannot show/);
   assert.equal(otherWindow.get().views.length, 0);
   const unregister = ownWindow.registerPresenter({ available: () => true, reveal: () => true });
   unregister();
   ownWindow.registerPresenter({ available: () => false, reveal: () => { throw new Error("Must not run"); } });
-  assert.throws(() => ownWindow.open([view("a")], "auto", "auto", true), /cannot show/);
+  assert.throws(() => ownWindow.open([view("a")], "auto", "reuse"), /cannot show/);
 });
 
 test("context follows selected views only while a panel is visible; closing restores another tab", () => {
   const store = workspace();
-  store.open([view("a"), view("b"), view("c")], "new", "auto", true);
+  store.open([view("a"), view("b"), view("c")], "new", "reuse");
   assert.equal(store.current(), null);
   let visible = true;
   const unmount = store.registerVisiblePanel(() => visible);

--- a/view-workspace.test.ts
+++ b/view-workspace.test.ts
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { ViewWorkspace, type ThreadView } from "./view-workspace.ts";
+
+const view = (id: string): ThreadView => ({ kind: "thread", id: `thread:${id}`, threadId: id, projectId: `project-${id}`, title: `Thread ${id}` });
+function workspace() {
+  const store = new ViewWorkspace();
+  store.registerPresenter({ available: () => true, reveal: () => true });
+  return store;
+}
+
+test("automatic opens reuse on mobile and accumulate on desktop; duplicates focus existing tabs", () => {
+  const mobile = workspace();
+  mobile.open([view("a")], "auto", "auto", true);
+  mobile.open([view("b")], "auto", "auto", true);
+  assert.deepEqual(mobile.get().views, [view("b")]);
+  const desktop = workspace();
+  desktop.open([view("a")], "auto", "auto", false);
+  desktop.open([view("b")], "auto", "auto", false);
+  desktop.open([view("a")], "new", "auto", false);
+  assert.deepEqual(desktop.get(), { views: [view("a"), view("b")], activeId: "thread:a" });
+});
+
+test("explicit disposition overrides preference; batches preserve all threads despite reuse", () => {
+  const store = workspace();
+  store.open([view("a")], "auto", "new", true);
+  store.open([view("b")], "auto", "new", true);
+  store.open([view("c")], "reuse", "new", true);
+  assert.deepEqual(store.get().views, [view("a"), view("c")]);
+  store.open([view("d"), view("e"), view("d")], "auto", "reuse", true);
+  assert.deepEqual(store.get().views, [view("a"), view("c"), view("d"), view("e")]);
+  assert.equal(store.get().activeId, "thread:d");
+});
+
+test("declined or throwing opens leave tabs and selection unchanged", () => {
+  const store = workspace();
+  store.open([view("a")], "auto", "auto", true);
+  const before = store.get();
+  const unregister = store.registerPresenter({ available: () => true, reveal: () => false });
+  assert.throws(() => store.open([view("b")], "reuse", "auto", true), /declined/);
+  assert.equal(store.get(), before);
+  unregister();
+  store.registerPresenter({ available: () => true, reveal: () => { throw new Error("Host unavailable"); } });
+  assert.throws(() => store.open([view("b")], "reuse", "auto", true), /Host unavailable/);
+  assert.equal(store.get(), before);
+});
+
+test("windows are isolated and unmounted or unavailable presenters cannot receive opens", () => {
+  const otherWindow = workspace();
+  const ownWindow = new ViewWorkspace();
+  assert.throws(() => ownWindow.open([view("a")], "auto", "auto", true), /cannot show/);
+  assert.equal(otherWindow.get().views.length, 0);
+  const unregister = ownWindow.registerPresenter({ available: () => true, reveal: () => true });
+  unregister();
+  ownWindow.registerPresenter({ available: () => false, reveal: () => { throw new Error("Must not run"); } });
+  assert.throws(() => ownWindow.open([view("a")], "auto", "auto", true), /cannot show/);
+});
+
+test("context follows selected views only while a panel is visible; closing restores another tab", () => {
+  const store = workspace();
+  store.open([view("a"), view("b"), view("c")], "new", "auto", true);
+  assert.equal(store.current(), null);
+  let visible = true;
+  const unmount = store.registerVisiblePanel(() => visible);
+  assert.equal(store.current()?.threadId, "a");
+  store.select("thread:b");
+  assert.equal(store.current()?.threadId, "b");
+  store.close("thread:b");
+  assert.equal(store.current()?.threadId, "c");
+  visible = false;
+  assert.equal(store.current(), null);
+  visible = true;
+  unmount();
+  assert.equal(store.current(), null);
+  assert.deepEqual(store.get().views, [view("a"), view("c")]);
+  store.clear();
+  assert.deepEqual(store.get(), { views: [], activeId: null });
+});

--- a/view-workspace.ts
+++ b/view-workspace.ts
@@ -1,0 +1,84 @@
+// A window-local collection of views. Host panels present this collection;
+// voice and UI controls use the same operations. Never broadcast navigation.
+export type OpenDisposition = "auto" | "reuse" | "new";
+export type ThreadView = {
+  kind: "thread";
+  id: string;
+  threadId: string;
+  projectId: string | null;
+  title: string;
+};
+// Extend this union when another supported first-party renderer is available.
+export type WorkspaceView = ThreadView;
+export interface WorkspaceSnapshot {
+  views: readonly WorkspaceView[];
+  activeId: string | null;
+}
+type Presenter = { reveal: () => boolean; available: () => boolean };
+
+export class ViewWorkspace {
+  private value: WorkspaceSnapshot = { views: [], activeId: null };
+  private listeners = new Set<() => void>();
+  private presenters = new Map<symbol, Presenter>();
+  private visiblePanels = new Map<symbol, () => boolean>();
+  readonly get = () => this.value;
+  readonly subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+    return () => { this.listeners.delete(listener); };
+  };
+  private set(value: WorkspaceSnapshot) {
+    this.value = value;
+    for (const listener of this.listeners) listener();
+  }
+  registerPresenter(presenter: Presenter) {
+    const key = Symbol();
+    this.presenters.set(key, presenter);
+    return () => { this.presenters.delete(key); };
+  }
+  registerVisiblePanel(visible: () => boolean) {
+    const key = Symbol();
+    this.visiblePanels.set(key, visible);
+    return () => { this.visiblePanels.delete(key); };
+  }
+  /** Only a mounted, visible panel can supply conversational context. */
+  current(): WorkspaceView | null {
+    if (![...this.visiblePanels.values()].some(visible => visible())) return null;
+    return this.value.views.find(view => view.id === this.value.activeId) ?? null;
+  }
+  open(views: readonly WorkspaceView[], disposition: OpenDisposition, preference: OpenDisposition, mobile: boolean) {
+    if (!views.length) throw new Error("No threads were selected.");
+    const presenter = [...this.presenters.values()].reverse().find(p => p.available());
+    if (!presenter) throw new Error("This screen cannot show threads beside the call. Start a call from Handsfree or a thread page.");
+    // A batch always preserves every requested item, regardless of the default.
+    const mode = disposition === "auto" ? preference : disposition;
+    const reuse = views.length === 1 && (mode === "reuse" || (mode === "auto" && mobile));
+    const next = [...this.value.views];
+    for (const view of views) {
+      const existing = next.findIndex(item => item.id === view.id);
+      if (existing >= 0) next[existing] = view;
+      else {
+        const replace = reuse ? next.findIndex(item => item.id === this.value.activeId) : -1;
+        if (replace >= 0) next[replace] = view;
+        else next.push(view);
+      }
+    }
+    // Reveal first; a rejected/throwing host must leave the collection intact.
+    if (!presenter.reveal()) throw new Error("This screen declined to open the thread panel. The call is still running.");
+    this.set({ views: next, activeId: views[0].id });
+  }
+  select(id: string) {
+    if (this.value.views.some(view => view.id === id)) this.set({ ...this.value, activeId: id });
+  }
+  close(id: string) {
+    const index = this.value.views.findIndex(view => view.id === id);
+    if (index < 0) return;
+    const views = this.value.views.filter(view => view.id !== id);
+    const activeId = this.value.activeId === id
+      ? views[Math.min(index, views.length - 1)]?.id ?? null
+      : this.value.activeId;
+    this.set({ views, activeId });
+  }
+  clear() { this.set({ views: [], activeId: null }); }
+}
+
+export const viewWorkspace = new ViewWorkspace();

--- a/view-workspace.ts
+++ b/view-workspace.ts
@@ -45,13 +45,13 @@ export class ViewWorkspace {
     if (![...this.visiblePanels.values()].some(visible => visible())) return null;
     return this.value.views.find(view => view.id === this.value.activeId) ?? null;
   }
-  open(views: readonly WorkspaceView[], disposition: OpenDisposition, preference: OpenDisposition, mobile: boolean) {
+  open(views: readonly WorkspaceView[], disposition: OpenDisposition, preference: "reuse" | "new") {
     if (!views.length) throw new Error("No threads were selected.");
     const presenter = [...this.presenters.values()].reverse().find(p => p.available());
     if (!presenter) throw new Error("This screen cannot show threads beside the call. Start a call from Handsfree or a thread page.");
     // A batch always preserves every requested item, regardless of the default.
     const mode = disposition === "auto" ? preference : disposition;
-    const reuse = views.length === 1 && (mode === "reuse" || (mode === "auto" && mobile));
+    const reuse = views.length === 1 && mode === "reuse";
     const next = [...this.value.views];
     for (const view of views) {
       const existing = next.findIndex(item => item.id === view.id);

--- a/voice-agent.test.ts
+++ b/voice-agent.test.ts
@@ -298,7 +298,7 @@ test("stopping during the SDP exchange closes the mic and cancels startup", asyn
         return { ok: true };
       }) as never,
     },
-    context: { threadId: null, projectId: null },
+    context: { threadId: null, projectId: null, onNewThreadScreen: false },
     composer: { setText() {}, updateText() {} },
     openNewThread() {},
   });
@@ -310,12 +310,12 @@ test("stopping during the SDP exchange closes the mic and cancels startup", asyn
     agent.stop();
 
     assert.equal(track.stopped, true);
-    assert.equal(peer?.closed, true);
+    assert.equal((peer as FakePeerConnection | null)?.closed, true);
 
     resolveCall();
     await new Promise((resolve) => setImmediate(resolve));
     // Stopped mid-exchange: the answer must never be applied.
-    assert.equal(peer?.setRemoteCalls, 0);
+    assert.equal((peer as FakePeerConnection | null)?.setRemoteCalls, 0);
     assert.equal(agent.getState(), "idle");
   } finally {
     resolveCall();

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -1,8 +1,6 @@
-// The voice session singleton for a plugin realm. Lives in its own module so
-// both the composer button (app.tsx) and the Handsfree page (sessions-panel.tsx)
-// can reach it without a circular import. Note: bb renders each surface in a
-// separate realm, so this is one instance PER surface; cross-surface state is
-// shared over realtime presence/command channels (see VoiceAgent below).
+// Voice session singleton for one loaded plugin module. Web slots share it;
+// separate windows/native webviews have separate instances. Presence and call
+// controls cross those boundaries, but opening views stays local to the caller.
 import { toast } from "sonner";
 import type { useRpc } from "@get-bb/plugin-sdk/app";
 import type { rpcContract } from "./server";
@@ -15,6 +13,8 @@ import {
   writeAudioDevicePreferences,
   type AudioDevicePreferences,
 } from "./audio-devices.ts";
+import { actionStatus } from "./session-events.ts";
+import { ViewWorkspace, viewWorkspace, type OpenDisposition } from "./view-workspace.ts";
 import { clientId, realmId, identityTag, clientDescriptor, deviceSummary } from "./client-identity.ts";
 
 export type VoiceState = "idle" | "connecting" | "live" | "muted";
@@ -37,18 +37,6 @@ interface RemotePresence {
   ownerClient?: string;
   ownerRealm?: string;
 }
-
-/**
- * Tools measured to background the owner realm on mobile (→ iOS suspends the mic
- * → the call dies). Verified on 2026-09-01: `focus_thread` backgrounds the app;
- * `set_pane` and `start_thread` do NOT. On mobile these don't navigate during a
- * live call — `focus_thread` instead opens the thread in the companion drawer
- * beside the call (see handleToolCall), which keeps the mic alive. If a new/other
- * tool ever backgrounds us anyway, `mic.suspend.teardown {cause}` names it in the
- * logs and the call still ends cleanly — so this list can stay small and be
- * extended from evidence, not guesswork.
- */
-const MOBILE_NAV_TOOLS = new Set(["focus_thread"]);
 
 /**
  * Tools that do real work AND navigate (spawn/diff, then `bb.sdk.threads.open`).
@@ -180,15 +168,9 @@ function waitForIceGathering(pc: RTCPeerConnection, timeoutMs = 2000): Promise<v
 }
 
 /**
- * Voice session for one plugin realm. bb renders each surface (composer,
- * sidebar, the Handsfree page) in its own JS realm, so this singleton is
- * per-surface, not truly app-global: the realm that starts a call OWNS the
- * WebRTC session; the call keeps running there as the user navigates within
- * that realm. Other realms don't hold the session — they mirror its coarse
- * state over the `voice-presence` broadcast and relay stop/mute back to the
- * owner via `voice-command`, so every surface reflects and can control the one
- * live call. Mounted buttons keep `bindings` fresh (latest composer + route
- * context win) so tool calls act on what the user is currently looking at.
+ * Owns WebRTC in the runtime where a call starts. Other runtimes mirror call
+ * presence and relay explicit stop/mute controls. Mounted composer bindings
+ * and the visible view supply local tool context; unmounting releases bindings.
  */
 export class VoiceAgent {
   private state: VoiceState = "idle";
@@ -245,13 +227,11 @@ export class VoiceAgent {
   private remoteExpiryTimer: ReturnType<typeof setInterval> | null = null;
   /** Guards the once-per-realm `client.hello` observability record. */
   private helloed = false;
-  /**
-   * Opens a thread in the Handsfree page's companion surface (a bottom drawer on
-   * mobile). Set by the page surface independently of `bindings` (so a composer's
-   * bind() can't clobber it) and cleared on unmount. Null in realms without a
-   * mounted Handsfree page.
-   */
-  private companionOpener: ((threadId: string) => void) | null = null;
+  private workspace: ViewWorkspace;
+  private bindingSources = new Map<symbol, { bindings: Bindings; fallback: boolean }>();
+  private logQueue: Promise<unknown> | null = null;
+
+  constructor(workspace: ViewWorkspace = viewWorkspace) { this.workspace = workspace; }
   /** The most recent tool call, so a suspend/teardown can name its likely cause. */
   private lastTool: { name: string; at: number } | null = null;
 
@@ -348,22 +328,20 @@ export class VoiceAgent {
 
   readonly getAudioPreferences = (): AudioDevicePreferences => this.audioPreferences;
 
-  bind(bindings: Bindings) {
-    this.bindings = bindings;
-    this.helloOnce("composer");
-  }
+  bind(bindings: Bindings) { return this.registerBindings(bindings, false); }
+  bindFallback(bindings: Bindings) { return this.registerBindings(bindings, true); }
 
-  /**
-   * Bind a surface only if nothing is bound yet. The Handsfree page uses this so
-   * a call can be started with no composer mounted (its FAB), without clobbering
-   * the richer binding a real composer installs — a live composer's text tools
-   * must keep targeting that composer, not the page's new-thread fallback.
-   */
-  bindFallback(bindings: Bindings) {
-    if (!this.bindings) this.bindings = bindings;
-    this.helloOnce("page");
+  private registerBindings(bindings: Bindings, fallback: boolean) {
+    const key = Symbol();
+    this.bindingSources.set(key, { bindings, fallback });
+    const refresh = () => {
+      const sources = [...this.bindingSources.values()].reverse();
+      this.bindings = (sources.find(source => !source.fallback) ?? sources[0])?.bindings ?? null;
+    };
+    refresh();
+    this.helloOnce(fallback ? "page" : "composer");
+    return () => { this.bindingSources.delete(key); refresh(); };
   }
-
   /**
    * Announce this realm once it can talk to the backend, so every surface (even
    * idle ones that never start a call) leaves a durable record of its client +
@@ -523,37 +501,6 @@ export class VoiceAgent {
     }
   }
 
-  // ---- companion drawer (the Handsfree page's mobile companion surface) ----
-
-  /** The Handsfree page registers (and clears) its drawer opener here. */
-  setCompanionOpener(opener: ((threadId: string) => void) | null) {
-    this.companionOpener = opener;
-  }
-
-  /**
-   * Show a thread in the companion drawer. If this realm hosts the page, open it
-   * directly; otherwise relay over the bus so whichever realm has the mounted
-   * page opens it (the call may be owned by a composer realm with no page).
-   */
-  private openCompanion(threadId: string) {
-    if (this.companionOpener) {
-      this.companionOpener(threadId);
-      return;
-    }
-    const rpc = this.bindings?.rpc;
-    if (rpc) {
-      void rpc.call("sendCompanion", { threadId, client: clientId, realm: realmId }).catch(() => undefined);
-    }
-  }
-
-  /** Handle a relayed companion request; only a realm with a mounted page acts. */
-  applyCompanion(payload: unknown) {
-    const threadId = (payload as { threadId?: unknown } | null)?.threadId;
-    if (typeof threadId === "string" && threadId && this.companionOpener) {
-      this.companionOpener(threadId);
-    }
-  }
-
   /** Apply a relayed command — but only if THIS realm owns that call. */
   applyVoiceCommand(payload: unknown) {
     const p = payload as { nonce?: unknown; action?: unknown } | null;
@@ -708,9 +655,7 @@ export class VoiceAgent {
     this.noteActivity(kind, payload);
     // Stamp which client/realm produced this event (see client-identity.ts) so
     // the transcript/DB shows where things actually happened across surfaces.
-    void bindings.rpc
-      .call("logEvent", { sessionId, kind, payload: { ...payload, _id: identityTag() } })
-      .catch(() => undefined);
+    this.writeEvent(bindings.rpc, sessionId, kind, payload);
   }
 
   /** Track the latest meaningful event for the dock ticker (ignores diagnostics). */
@@ -733,13 +678,17 @@ export class VoiceAgent {
   private logDiag(kind: string, payload: Record<string, unknown> = {}) {
     const rpc = this.bindings?.rpc;
     if (!rpc) return;
-    void rpc
-      .call("logEvent", {
-        sessionId: this.nonce ?? "audio-diagnostics",
-        kind,
-        payload: { ...payload, _id: identityTag() },
-      })
-      .catch(() => undefined);
+    this.writeEvent(rpc, this.nonce ?? "audio-diagnostics", kind, payload);
+  }
+
+  private writeEvent(rpc: RpcClient, sessionId: string, kind: string, payload: Record<string, unknown>) {
+    const event = { sessionId, kind, payload: { ...payload, _id: identityTag() } };
+    const send = () => rpc.call("logEvent", event);
+    // Preserve call/result ordering while letting the realtime audio proceed.
+    const pending = (this.logQueue ? this.logQueue.then(send) : Promise.resolve().then(send))
+      .catch(error => { console.warn("Handsfree session event could not be saved", { sessionId, kind, error }); });
+    this.logQueue = pending;
+    void pending.finally(() => { if (this.logQueue === pending) this.logQueue = null; });
   }
 
   // ---- audio lifecycle: keep inbound audio playing and the mic alive across
@@ -994,87 +943,121 @@ export class VoiceAgent {
   }
 
   private async handleToolCall(dc: RTCDataChannel, event: Record<string, unknown>) {
+    if (dc.readyState !== "open" || !this.nonce) return;
     const bindings = this.bindings;
     const name = String(event.name ?? "");
     const callId = String(event.call_id ?? "");
+    const toolSessionId = this.nonce;
     let args: Record<string, unknown> = {};
     try {
       args = JSON.parse(typeof event.arguments === "string" ? event.arguments : "{}");
     } catch {
       /* keep {} */
     }
-    this.log("tool.call", { name, args });
+    this.log("tool.call", { name, args, callId });
     this.lastTool = { name, at: Date.now() };
     let output: string;
-    if (!bindings) {
-      output = "Tool error: no bb surface is bound right now.";
-    } else if (name === "set_composer_text") {
-      if (!bindings.composer) {
-        output = "No composer is focused right now — open or start a thread to draft a message.";
+    let status: "success" | "error" | undefined;
+    let presentation: string | undefined;
+    let label: string | undefined;
+    const shown = this.workspace.current();
+    const context = shown
+      ? { threadId: shown.threadId, projectId: shown.projectId, onNewThreadScreen: false }
+      : bindings?.context;
+    try {
+      if (!bindings) {
+        throw new Error("No bb surface is bound right now.");
+      } else if (name === "set_composer_text") {
+        if (!bindings.composer || (shown && bindings.context.threadId !== shown.threadId)) {
+          throw new Error("No matching composer is available. Tap the shown thread’s composer to draft a message.");
+        } else {
+          bindings.composer.setText(String(args.text ?? ""));
+          output = "Composer text replaced.";
+        }
+      } else if (name === "append_composer_text") {
+        if (!bindings.composer || (shown && bindings.context.threadId !== shown.threadId)) {
+          throw new Error("No matching composer is available. Tap the shown thread’s composer to draft a message.");
+        } else {
+          const text = String(args.text ?? "");
+          bindings.composer.updateText((current) => (current ? `${current}\n${text}` : text));
+          output = "Text appended to composer.";
+        }
+      } else if (
+        name === "start_thread" &&
+        !(typeof args.prompt === "string" && args.prompt.trim())
+      ) {
+        // No dictated prompt: never fabricate one — open bb's New thread screen
+        // with the project preselected and let the user type it themselves.
+        const projectId =
+          typeof args.project_id === "string" && args.project_id
+            ? args.project_id
+            : context?.projectId ?? null;
+        bindings.openNewThread(projectId);
+        output =
+          "Opened the New thread screen with the project preselected. The user will type the prompt themselves; no thread exists yet.";
+      } else if (name === "focus_thread" || name === "focus_threads") {
+        const ids = name === "focus_thread" ? [args.thread_id] : args.thread_ids;
+        if (!Array.isArray(ids) || !ids.length || ids.length > 100 || ids.some(id => typeof id !== "string" || !id.trim())) {
+          throw new Error("Provide between 1 and 100 valid thread IDs.");
+        }
+        const disposition = name === "focus_threads" ? "new" : args.disposition ?? "auto";
+        if (disposition !== "auto" && disposition !== "reuse" && disposition !== "new") throw new Error("Invalid tab disposition.");
+        const { views, preference } = await bindings.rpc.call("resolveThreadViews", { threadIds: ids as string[] });
+        if (dc.readyState !== "open" || this.nonce !== toolSessionId) throw new Error("The call ended before the threads could be shown.");
+        this.workspace.open(views, disposition as OpenDisposition, preference, clientDescriptor.mobile);
+        output = views.length === 1 ? `Showing ${views[0].title}.` : `Showing ${views.length} threads. ${views[0].title} is selected.`;
+        label = views.length === 1 ? `Showed ${views[0].title}` : `Showed ${views.length} threads`;
+        status = "success";
+        presentation = "panel";
+      } else if (name === "manage_views") {
+        const current = this.workspace.get();
+        const id = typeof args.view_id === "string" ? args.view_id : "";
+        const view = current.views.find(item => item.id === id);
+        if (args.action === "list") {
+          output = JSON.stringify(current);
+        } else if (args.action === "clear") {
+          this.workspace.clear();
+          output = "Closed all views. Threads and the call are still running.";
+        } else if (!view) {
+          throw new Error("That view is not open. List the open views first.");
+        } else if (args.action === "select") {
+          this.workspace.open([view], "new", "new", clientDescriptor.mobile);
+          output = `Showing ${view.title}.`;
+        } else if (args.action === "close") {
+          this.workspace.close(id);
+          output = `Closed ${view.title}. The thread is still running.`;
+        } else throw new Error("Unknown view action.");
+      } else if (name === "get_context") {
+        const result = await bindings.rpc.call("runTool", { name, args, ...context! });
+        output = result.output;
+        status = result.status;
       } else {
-        bindings.composer.setText(String(args.text ?? ""));
-        output = "Composer text replaced.";
-      }
-    } else if (name === "append_composer_text") {
-      if (!bindings.composer) {
-        output = "No composer is focused right now — open or start a thread to draft a message.";
-      } else {
-        const text = String(args.text ?? "");
-        bindings.composer.updateText((current) => (current ? `${current}\n${text}` : text));
-        output = "Text appended to composer.";
-      }
-    } else if (
-      name === "start_thread" &&
-      !(typeof args.prompt === "string" && args.prompt.trim())
-    ) {
-      // No dictated prompt: never fabricate one — open bb's New thread screen
-      // with the project preselected and let the user type it themselves.
-      const projectId =
-        typeof args.project_id === "string" && args.project_id
-          ? args.project_id
-          : bindings.context.projectId;
-      bindings.openNewThread(projectId);
-      output =
-        "Opened the New thread screen with the project preselected. The user will type the prompt themselves; no thread exists yet.";
-    } else if (
-      MOBILE_NAV_TOOLS.has(name) &&
-      clientDescriptor.mobile &&
-      (this.state === "live" || this.state === "muted")
-    ) {
-      // On mobile this tool would background the realm that owns the call and iOS
-      // would suspend the mic — the call would die. So during a live mobile call
-      // focus_thread doesn't navigate; it opens the thread in the companion drawer
-      // beside the call instead, which keeps the mic alive.
-      const threadId = String(args.thread_id ?? "");
-      if (!threadId) {
-        output = "No thread_id given.";
-      } else {
-        this.logDiag("companion.opened", { name, threadId });
-        this.openCompanion(threadId);
-        output = "Opened the thread in the drawer beside the call.";
-      }
-    } else {
-      // These tools navigate (…→ threads.open) which would background a live
-      // mobile call — tell the server not to focus so the work still happens but
-      // nothing navigates. (The promptless start_thread is handled above.)
-      const suppressFocus =
-        FOCUS_SUPPRESSIBLE_TOOLS.has(name) &&
-        clientDescriptor.mobile &&
-        (this.state === "live" || this.state === "muted");
-      if (suppressFocus) this.logDiag("nav.suppressedFocus", { name });
-      try {
+        // These tools navigate (…→ threads.open) which would background a live
+        // mobile call — tell the server not to focus so the work still happens but
+        // nothing navigates. (The promptless start_thread is handled above.)
+        const suppressFocus =
+          FOCUS_SUPPRESSIBLE_TOOLS.has(name) &&
+          clientDescriptor.mobile &&
+          (this.state === "live" || this.state === "muted");
+        if (suppressFocus) this.logDiag("nav.suppressedFocus", { name });
         const result = await bindings.rpc.call("runTool", {
           name,
           args: suppressFocus ? { ...args, focus: false } : args,
-          ...bindings.context,
+          ...context!,
         });
         output = result.output;
-      } catch (error) {
-        output = `Tool error: ${error instanceof Error ? error.message : String(error)}`;
+        status = result.status;
       }
+    } catch (error) {
+      status = "error";
+      output = `Tool error: ${error instanceof Error ? error.message : String(error)}`;
     }
-    this.log("tool.result", { name, output: output.slice(0, 4000) });
-    if (!callId || dc.readyState !== "open") return;
+    // Use the captured session: a stopped call's late result must not land in a new one.
+    if (toolSessionId && bindings) this.writeEvent(bindings.rpc, toolSessionId, "tool.result", {
+      name, callId, output: output.slice(0, 4000), status: status ?? actionStatus({ output }),
+      ...(presentation ? { presentation } : {}), ...(label ? { label } : {}),
+    });
+    if (!callId || dc.readyState !== "open" || this.nonce !== toolSessionId) return;
     // Creating the output item is always safe; only response.create must wait.
     dc.send(
       JSON.stringify({

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -960,7 +960,7 @@ export class VoiceAgent {
     let status: "success" | "error" | undefined;
     let presentation: string | undefined;
     let label: string | undefined;
-    const shown = this.workspace.current();
+    const shown = clientDescriptor.mobile ? this.workspace.current() : null;
     const context = shown
       ? { threadId: shown.threadId, projectId: shown.projectId, onNewThreadScreen: false }
       : bindings?.context;
@@ -995,7 +995,12 @@ export class VoiceAgent {
         bindings.openNewThread(projectId);
         output =
           "Opened the New thread screen with the project preselected. The user will type the prompt themselves; no thread exists yet.";
-      } else if (name === "focus_thread" || name === "focus_threads") {
+      } else if (!clientDescriptor.mobile && ["focus_threads", "manage_views", "set_view_behavior"].includes(name)) {
+        throw new Error("Drawer tools are mobile-only. On desktop, use focus_thread to navigate to a thread.");
+      } else if (
+        clientDescriptor.mobile && (this.state === "live" || this.state === "muted") &&
+        (name === "focus_thread" || name === "focus_threads")
+      ) {
         const ids = name === "focus_thread" ? [args.thread_id] : args.thread_ids;
         if (!Array.isArray(ids) || !ids.length || ids.length > 100 || ids.some(id => typeof id !== "string" || !id.trim())) {
           throw new Error("Provide between 1 and 100 valid thread IDs.");
@@ -1004,7 +1009,7 @@ export class VoiceAgent {
         if (disposition !== "auto" && disposition !== "reuse" && disposition !== "new") throw new Error("Invalid tab disposition.");
         const { views, preference } = await bindings.rpc.call("resolveThreadViews", { threadIds: ids as string[] });
         if (dc.readyState !== "open" || this.nonce !== toolSessionId) throw new Error("The call ended before the threads could be shown.");
-        this.workspace.open(views, disposition as OpenDisposition, preference, clientDescriptor.mobile);
+        this.workspace.open(views, disposition as OpenDisposition, preference);
         output = views.length === 1 ? `Showing ${views[0].title}.` : `Showing ${views.length} threads. ${views[0].title} is selected.`;
         label = views.length === 1 ? `Showed ${views[0].title}` : `Showed ${views.length} threads`;
         status = "success";
@@ -1021,7 +1026,7 @@ export class VoiceAgent {
         } else if (!view) {
           throw new Error("That view is not open. List the open views first.");
         } else if (args.action === "select") {
-          this.workspace.open([view], "new", "new", clientDescriptor.mobile);
+          this.workspace.open([view], "new", "new");
           output = `Showing ${view.title}.`;
         } else if (args.action === "close") {
           this.workspace.close(id);
@@ -1047,6 +1052,10 @@ export class VoiceAgent {
         });
         output = result.output;
         status = result.status;
+        if (name === "focus_thread") {
+          presentation = "navigation";
+          if (status === "success") label = "Focused a thread";
+        }
       }
     } catch (error) {
       status = "error";
@@ -1274,6 +1283,7 @@ export class VoiceAgent {
       const { sdp } = await bindings.rpc.call("createCall", {
         sdp: localSdp,
         nonce,
+        mobile: clientDescriptor.mobile,
         ...bindings.context,
       });
       if (this.session?.pc !== pc) return; // stopped while exchanging

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -40,12 +40,13 @@ interface RemotePresence {
 
 /**
  * Tools measured to background the owner realm on mobile (→ iOS suspends the mic
- * → the call dies), so they're refused during a live mobile call. Verified on
- * 2026-09-01: `focus_thread` backgrounds the app; `set_pane` and `start_thread`
- * do NOT. This is the correctness-optimization list; if a new/other tool ever
- * backgrounds us anyway, `mic.suspend.teardown {cause}` names it in the logs and
- * the call still ends cleanly — so this list can stay small and be extended from
- * evidence, not guesswork.
+ * → the call dies). Verified on 2026-09-01: `focus_thread` backgrounds the app;
+ * `set_pane` and `start_thread` do NOT. On mobile these don't navigate during a
+ * live call — `focus_thread` instead opens the thread in the companion drawer
+ * beside the call (see handleToolCall), which keeps the mic alive. If a new/other
+ * tool ever backgrounds us anyway, `mic.suspend.teardown {cause}` names it in the
+ * logs and the call still ends cleanly — so this list can stay small and be
+ * extended from evidence, not guesswork.
  */
 const MOBILE_NAV_TOOLS = new Set(["focus_thread"]);
 
@@ -244,6 +245,13 @@ export class VoiceAgent {
   private remoteExpiryTimer: ReturnType<typeof setInterval> | null = null;
   /** Guards the once-per-realm `client.hello` observability record. */
   private helloed = false;
+  /**
+   * Opens a thread in the Handsfree page's companion surface (a bottom drawer on
+   * mobile). Set by the page surface independently of `bindings` (so a composer's
+   * bind() can't clobber it) and cleared on unmount. Null in realms without a
+   * mounted Handsfree page.
+   */
+  private companionOpener: ((threadId: string) => void) | null = null;
   /** The most recent tool call, so a suspend/teardown can name its likely cause. */
   private lastTool: { name: string; at: number } | null = null;
 
@@ -512,6 +520,37 @@ export class VoiceAgent {
       this.remotePresence = null;
       this.disarmRemoteExpiry();
       this.emitChange();
+    }
+  }
+
+  // ---- companion drawer (the Handsfree page's mobile companion surface) ----
+
+  /** The Handsfree page registers (and clears) its drawer opener here. */
+  setCompanionOpener(opener: ((threadId: string) => void) | null) {
+    this.companionOpener = opener;
+  }
+
+  /**
+   * Show a thread in the companion drawer. If this realm hosts the page, open it
+   * directly; otherwise relay over the bus so whichever realm has the mounted
+   * page opens it (the call may be owned by a composer realm with no page).
+   */
+  private openCompanion(threadId: string) {
+    if (this.companionOpener) {
+      this.companionOpener(threadId);
+      return;
+    }
+    const rpc = this.bindings?.rpc;
+    if (rpc) {
+      void rpc.call("sendCompanion", { threadId, client: clientId, realm: realmId }).catch(() => undefined);
+    }
+  }
+
+  /** Handle a relayed companion request; only a realm with a mounted page acts. */
+  applyCompanion(payload: unknown) {
+    const threadId = (payload as { threadId?: unknown } | null)?.threadId;
+    if (typeof threadId === "string" && threadId && this.companionOpener) {
+      this.companionOpener(threadId);
     }
   }
 
@@ -1002,12 +1041,18 @@ export class VoiceAgent {
       clientDescriptor.mobile &&
       (this.state === "live" || this.state === "muted")
     ) {
-      // On mobile, this tool backgrounds the realm that owns the call and iOS
-      // suspends the mic — the call dies. So don't run it during a live mobile
-      // call; have the model point the user to the tap target instead.
-      this.logDiag("nav.blocked", { name });
-      output =
-        "On mobile you can't navigate the app during a live call — it would background the call and cut the mic. Do NOT navigate. Instead, tell the user in one short sentence exactly what to tap to get there themselves.";
+      // On mobile this tool would background the realm that owns the call and iOS
+      // would suspend the mic — the call would die. So during a live mobile call
+      // focus_thread doesn't navigate; it opens the thread in the companion drawer
+      // beside the call instead, which keeps the mic alive.
+      const threadId = String(args.thread_id ?? "");
+      if (!threadId) {
+        output = "No thread_id given.";
+      } else {
+        this.logDiag("companion.opened", { name, threadId });
+        this.openCompanion(threadId);
+        output = "Opened the thread in the drawer beside the call.";
+      }
     } else {
       // These tools navigate (…→ threads.open) which would background a live
       // mobile call — tell the server not to focus so the work still happens but

--- a/voice-chrome.tsx
+++ b/voice-chrome.tsx
@@ -1,8 +1,8 @@
 // Shared voice-call chrome: the waveform/mic/stop icons and the live-duration
-// ticker, used by both the composer button (app.tsx) and the on-page call
-// console (sessions-panel.tsx) so every surface speaks the same visual
+// ticker, used by the composer button, on-page call console, and mobile
+// drawer so every surface speaks the same visual
 // language — neutral chrome, activity color only on the waveform.
-import { useEffect, useState, useSyncExternalStore } from "react";
+import React, { useEffect, useState, useSyncExternalStore } from "react";
 import { voiceAgent } from "./voice-agent";
 import { cn } from "@/lib/utils";
 
@@ -60,4 +60,75 @@ export function useCallElapsed(): string | null {
     return () => clearInterval(id);
   }, [startedAt]);
   return startedAt == null ? null : formatElapsed(now - startedAt);
+}
+
+/** Controls for an existing call. Mounting/unmounting never starts or stops it. */
+export function LiveCallControls() {
+  const state = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
+  const activity = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getActivity);
+  const micSuspended = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getMicSuspended);
+  const elapsed = useCallElapsed();
+  const muted = state === "muted";
+  const connecting = state === "connecting";
+  if (state === "idle") return null;
+
+  const speaking = activity === "aide";
+  const listening = activity === "you";
+  const activityColor = micSuspended
+    ? "text-destructive" // uplink down (iOS backgrounded the mic)
+    : speaking
+      ? "text-[color:var(--success,#6faf76)]" // Aide
+      : listening
+        ? "text-foreground" // you
+        : "text-muted-foreground/70";
+  const label = connecting
+    ? "Connecting…"
+    : micSuspended
+      ? "Mic paused"
+      : speaking
+        ? "Aide speaking…"
+        : listening
+          ? "Listening…"
+          : muted
+            ? "Muted"
+            : "Connected";
+
+  return (
+    <div className="flex h-11 max-w-full items-center overflow-hidden rounded-full border border-border bg-card shadow-lg">
+      <button
+        type="button"
+        aria-label={muted ? "Unmute Aide microphone" : "Mute Aide microphone"}
+        title={muted ? "Unmute" : "Mute"}
+        aria-pressed={muted}
+        disabled={connecting}
+        onClick={() => voiceAgent.toggleMuteFromSurface()}
+        className={cn(
+          "flex size-11 shrink-0 items-center justify-center transition-colors disabled:opacity-50",
+          muted
+            ? "text-destructive hover:bg-destructive/15"
+            : "text-muted-foreground hover:bg-accent hover:text-foreground",
+        )}
+      >
+        <MicIcon slashed={muted} />
+      </button>
+      <span className="h-5 w-px bg-border" />
+      <span className="flex min-w-0 items-center gap-2 px-3">
+        <span className={cn("flex shrink-0 items-center", activityColor)} title={label} aria-label={label}>
+          <WaveformIcon live={speaking || listening} />
+        </span>
+        <span className="truncate text-sm text-foreground">{label}</span>
+        <span className="shrink-0 tabular-nums text-xs text-muted-foreground">{elapsed ?? ""}</span>
+      </span>
+      <span className="h-5 w-px bg-border" />
+      <button
+        type="button"
+        aria-label="Stop Aide voice session"
+        title="Stop"
+        onClick={() => voiceAgent.stopFromSurface()}
+        className="flex size-11 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:bg-destructive/15 hover:text-destructive"
+      >
+        <StopIcon />
+      </button>
+    </div>
+  );
 }

--- a/voice-views.test.ts
+++ b/voice-views.test.ts
@@ -5,7 +5,8 @@ import { ViewWorkspace } from "./view-workspace.ts";
 import { clientDescriptor } from "./client-identity.ts";
 
 type Call = { method: string; args: any };
-function fixture() {
+function fixture(mobile = true) {
+  clientDescriptor.mobile = mobile;
   const workspace = new ViewWorkspace();
   const agent = new VoiceAgent(workspace);
   const internal = agent as unknown as {
@@ -21,7 +22,7 @@ function fixture() {
     calls.push({ method, args });
     if (method === "resolveThreadViews") return {
       views: [...new Set(args.threadIds as string[])].map(threadId => ({ kind: "thread", id: `thread:${threadId}`, threadId, projectId: `project-${threadId}`, title: `Title ${threadId}` })),
-      preference: "auto",
+      preference: "reuse",
     };
     if (method === "runTool") return { output: JSON.stringify(args), status: "success" };
     return { ok: true };
@@ -39,24 +40,42 @@ function fixture() {
   return { workspace, agent, internal, calls, sent, dc, base, execute };
 }
 
-test("mobile and desktop openings use local panels, preserving correlated tool events", async () => {
-  const oldMobile = clientDescriptor.mobile;
-  try {
-    for (const mobile of [true, false]) {
-      clientDescriptor.mobile = mobile;
-      const f = fixture();
-      f.workspace.registerPresenter({ available: () => true, reveal: () => true });
-      const result = await f.execute("focus_thread", { thread_id: "a" });
-      assert.equal(result.status, "success");
-      assert.equal(result.label, "Showed Title a");
-      assert.equal(result.presentation, "panel");
-      const events = f.calls.filter(call => call.method === "logEvent" && call.args.sessionId === "call-session");
-      assert.deepEqual(events.map(event => event.args.kind), ["tool.call", "tool.result"]);
-      assert.equal(events[0].args.payload.callId, result.callId);
-      assert.deepEqual(events[0].args.payload._id, result._id);
-      assert.equal(f.calls.some(call => call.method === "runTool" || call.method === "sendCompanion"), false);
-    }
-  } finally { clientDescriptor.mobile = oldMobile; }
+test("mobile openings use local drawers with correlated tool events", async () => {
+  const f = fixture();
+  f.workspace.registerPresenter({ available: () => true, reveal: () => true });
+  const result = await f.execute("focus_thread", { thread_id: "a" });
+  assert.equal(result.status, "success");
+  assert.equal(result.label, "Showed Title a");
+  assert.equal(result.presentation, "panel");
+  const events = f.calls.filter(call => call.method === "logEvent" && call.args.sessionId === "call-session");
+  assert.deepEqual(events.map(event => event.args.kind), ["tool.call", "tool.result"]);
+  assert.equal(events[0].args.payload.callId, result.callId);
+  assert.deepEqual(events[0].args.payload._id, result._id);
+  assert.equal(f.calls.some(call => call.method === "runTool" || call.method === "sendCompanion"), false);
+});
+
+test("desktop focus_thread retains server navigation even if a local presenter exists", async () => {
+  for (const entry of ["composer", "handsfree"]) {
+    const f = fixture(false);
+    if (entry === "handsfree") f.agent.bind({ ...f.base, context: { threadId: null, projectId: null, onNewThreadScreen: false } });
+    f.workspace.registerPresenter({ available: () => true, reveal: () => { throw new Error("Desktop must not use the drawer"); } });
+    const result = await f.execute("focus_thread", { thread_id: "a" });
+    assert.equal(result.status, "success");
+    assert.equal(result.presentation, "navigation");
+    assert.equal(f.calls.some(call => call.method === "resolveThreadViews"), false);
+    assert.equal(f.calls.filter(call => call.method === "runTool" && call.args.name === "focus_thread").length, 1);
+    assert.equal(f.workspace.get().views.length, 0);
+  }
+});
+
+test("stale desktop sessions cannot activate mobile drawer tools", async () => {
+  const f = fixture(false);
+  for (const name of ["focus_threads", "manage_views", "set_view_behavior"]) {
+    const result = await f.execute(name, { action: "clear", thread_ids: ["a"], behavior: "new" });
+    assert.equal(result.status, "error");
+    assert.match(result.output, /mobile-only/);
+  }
+  assert.equal(f.calls.some(call => call.method === "runTool" || call.method === "resolveThreadViews"), false);
 });
 
 test("a host rejection, exception, or absent presenter returns an error to the model", async () => {

--- a/voice-views.test.ts
+++ b/voice-views.test.ts
@@ -1,0 +1,132 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { VoiceAgent, type Bindings } from "./voice-agent.ts";
+import { ViewWorkspace } from "./view-workspace.ts";
+import { clientDescriptor } from "./client-identity.ts";
+
+type Call = { method: string; args: any };
+function fixture() {
+  const workspace = new ViewWorkspace();
+  const agent = new VoiceAgent(workspace);
+  const internal = agent as unknown as {
+    nonce: string | null;
+    state: string;
+    handleToolCall(dc: RTCDataChannel, event: Record<string, unknown>): Promise<void>;
+    logQueue: Promise<unknown> | null;
+  };
+  const calls: Call[] = [];
+  const sent: any[] = [];
+  const dc = { readyState: "open", send: (text: string) => sent.push(JSON.parse(text)) } as unknown as RTCDataChannel;
+  const rpc = { call: async (method: string, args: any) => {
+    calls.push({ method, args });
+    if (method === "resolveThreadViews") return {
+      views: [...new Set(args.threadIds as string[])].map(threadId => ({ kind: "thread", id: `thread:${threadId}`, threadId, projectId: `project-${threadId}`, title: `Title ${threadId}` })),
+      preference: "auto",
+    };
+    if (method === "runTool") return { output: JSON.stringify(args), status: "success" };
+    return { ok: true };
+  } } as Bindings["rpc"];
+  const base: Bindings = { rpc, context: { threadId: "original", projectId: "original-project", onNewThreadScreen: false }, openNewThread() {} };
+  agent.bind(base);
+  internal.nonce = "call-session";
+  internal.state = "live";
+  let count = 0;
+  const execute = async (name: string, args: Record<string, unknown>) => {
+    await internal.handleToolCall(dc, { name, call_id: `tool-${++count}`, arguments: JSON.stringify(args) });
+    while (internal.logQueue) await internal.logQueue;
+    return calls.filter(call => call.method === "logEvent" && call.args.kind === "tool.result").at(-1)?.args.payload;
+  };
+  return { workspace, agent, internal, calls, sent, dc, base, execute };
+}
+
+test("mobile and desktop openings use local panels, preserving correlated tool events", async () => {
+  const oldMobile = clientDescriptor.mobile;
+  try {
+    for (const mobile of [true, false]) {
+      clientDescriptor.mobile = mobile;
+      const f = fixture();
+      f.workspace.registerPresenter({ available: () => true, reveal: () => true });
+      const result = await f.execute("focus_thread", { thread_id: "a" });
+      assert.equal(result.status, "success");
+      assert.equal(result.label, "Showed Title a");
+      assert.equal(result.presentation, "panel");
+      const events = f.calls.filter(call => call.method === "logEvent" && call.args.sessionId === "call-session");
+      assert.deepEqual(events.map(event => event.args.kind), ["tool.call", "tool.result"]);
+      assert.equal(events[0].args.payload.callId, result.callId);
+      assert.deepEqual(events[0].args.payload._id, result._id);
+      assert.equal(f.calls.some(call => call.method === "runTool" || call.method === "sendCompanion"), false);
+    }
+  } finally { clientDescriptor.mobile = oldMobile; }
+});
+
+test("a host rejection, exception, or absent presenter returns an error to the model", async () => {
+  for (const reveal of [null, () => false, () => { throw new Error("host crashed"); }]) {
+    const f = fixture();
+    if (reveal) f.workspace.registerPresenter({ available: () => true, reveal });
+    const result = await f.execute("focus_thread", { thread_id: "a" });
+    assert.equal(result.status, "error");
+    assert.match(result.output, /^Tool error:/);
+    assert.equal(f.workspace.get().views.length, 0);
+    const response = f.sent.find(message => message.type === "conversation.item.create");
+    assert.equal(response.item.output, result.output);
+  }
+});
+
+test("batch opens, selection, and closing feed the displayed thread into get_context", async () => {
+  const f = fixture();
+  f.workspace.registerPresenter({ available: () => true, reveal: () => true });
+  const unmount = f.workspace.registerVisiblePanel(() => true);
+  await f.execute("focus_threads", { thread_ids: ["a", "b"] });
+  await f.execute("manage_views", { action: "select", view_id: "thread:b" });
+  let result = await f.execute("get_context", {});
+  assert.equal(JSON.parse(result.output).threadId, "b");
+  assert.equal(JSON.parse(result.output).projectId, "project-b");
+  await f.execute("manage_views", { action: "close", view_id: "thread:b" });
+  result = await f.execute("get_context", {});
+  assert.equal(JSON.parse(result.output).threadId, "a");
+  unmount();
+  result = await f.execute("get_context", {});
+  assert.equal(JSON.parse(result.output).threadId, "original");
+  assert.equal(f.internal.state, "live");
+});
+
+test("composer bindings clean up without clobbering a newer binding", async () => {
+  const f = fixture();
+  const disposeA = f.agent.bind({ ...f.base, context: { ...f.base.context, threadId: "a" } });
+  const disposeB = f.agent.bind({ ...f.base, context: { ...f.base.context, threadId: "b" } });
+  disposeA();
+  assert.equal(JSON.parse((await f.execute("get_context", {})).output).threadId, "b");
+  disposeB();
+  assert.equal(JSON.parse((await f.execute("get_context", {})).output).threadId, "original");
+});
+
+test("voice cannot write into an unrelated composer while another thread is shown", async () => {
+  const f = fixture();
+  let wrote = false;
+  f.agent.bind({ ...f.base, composer: { setText() { wrote = true; }, updateText() { wrote = true; } } });
+  f.workspace.registerPresenter({ available: () => true, reveal: () => true });
+  f.workspace.registerVisiblePanel(() => true);
+  await f.execute("focus_thread", { thread_id: "a" });
+  const result = await f.execute("set_composer_text", { text: "wrong thread" });
+  assert.equal(result.status, "error");
+  assert.equal(wrote, false);
+});
+
+test("stopping during metadata resolution prevents a late open and logs to the original session", async () => {
+  const f = fixture();
+  let resolve!: (value: unknown) => void;
+  f.base.rpc.call = (async (method: string, args: any) => {
+    f.calls.push({ method, args });
+    if (method === "resolveThreadViews") return new Promise<unknown>(done => { resolve = done; });
+    return { ok: true };
+  }) as Bindings["rpc"]["call"];
+  f.workspace.registerPresenter({ available: () => true, reveal: () => true });
+  const pending = f.execute("focus_thread", { thread_id: "a" });
+  f.internal.nonce = "new-session";
+  resolve({ views: [{ kind: "thread", id: "thread:a", threadId: "a", projectId: null, title: "A" }], preference: "auto" });
+  const result = await pending;
+  assert.equal(result.status, "error");
+  assert.equal(f.workspace.get().views.length, 0);
+  assert.equal(f.sent.length, 0);
+  assert.equal(f.calls.filter(call => call.args.kind === "tool.result").at(-1)?.args.sessionId, "call-session");
+});


### PR DESCRIPTION
During a mobile voice call, `focus_thread` previously refused navigation and told the user what to tap because leaving the current surface could suspend the microphone. This PR shows threads in a local bottom drawer instead. **Desktop keeps its existing `focus_thread` navigation from both the composer and Handsfree page.**

## Mobile behavior
- Show or replace the current thread without navigating away from the call. Supported local destinations are the Handsfree page and existing thread panels.
- Optionally keep several threads in the drawer's selector; `focus_threads` opens batches, and `manage_views` selects/closes them. These are views inside one drawer, not separate native bb tabs.
- Behavior → Mobile thread drawer offers replace/keep-in-switcher preferences. An explicitly requested lasting mobile preference can also be saved by voice. Desktop navigation is unaffected.
- The selected visible view supplies mobile voice context. Embedded composers bind their actual thread, and bindings release on unmount.
- Opens stay in the calling runtime; no cross-device relay. Unavailable surfaces, host declines, and exceptions return failures. Stopped calls cannot apply late opens.

## Desktop compatibility
- Desktop `focus_thread` still calls the original server operation, `bb.sdk.threads.open`.
- Desktop sessions do not advertise the mobile batch/view/preference tools or a focus disposition parameter.
- Registration is evaluated per client: desktop receives no new fixed Views tab or thread-panel launcher action.
- Per-call-origin desktop settings, navigation versus side-panel destinations, and multiple native tabs are deferred. The proposal is in `docs/desktop-navigation-plan.md`; the broader prototype is preserved at `0755bcf` on `handsfree/desktop-views-exploration` as reference material, not the desired final desktop behavior.

## Shared correctness and logging
Session history and plugin logs derive from the same stored tool events, with call IDs, device/session identity, and explicit outcomes. Both client- and server-handled actions are included. Failed tool results mark the session error filter; historical transcripts remain readable. The independent server-only action log is removed.

## Boundaries
Uses production SDK 0.4.21; no bb core modifications. The host owns drawer presentation and thread rendering. Acceptance does not guarantee completed loading, and unsupported separate native runtimes report their missing presenter. The view collection lasts for the loaded app session. Arbitrary cross-plugin embedding and dynamic native tabs on the Handsfree page remain separate bb API work.

## Validation
- `npm test`: 61 passing tests, including desktop navigation from both entry points, actual device-specific app registration, tool-schema separation, mobile preferences/routing/context, failure handling, database/log parity, and drawer controls.
- `npm run typecheck`: passes, including tests.
- `bb plugin build`: passes; reloaded successfully in local bb.
- Still required before merge: real-phone regression testing from Handsfree and an existing thread composer (audio continuity, draft preservation, switching across projects, another device unaffected), plus desktop navigation from both entry points. The harness does not reproduce native microphone behavior.

Design and device checklist: `docs/thread-views.md`.
