### PR TITLE
Preview voices before starting a Handsfree call

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,13 @@ Dev loop:
 bb plugin dev          # rebuild + reload on save
 bb plugin logs handsfree -f # tool traffic and errors
 ```
+
+## Preview a voice
+
+In **Settings → Plugins → Handsfree → Models & voice**, select a voice and click
+**Preview voice** to hear a short sample using your configured model and credentials.
+Click **Stop preview** to end it early. Changing the voice/model or leaving
+settings also stops playback. The preview does not capture microphone audio
+or run the operator’s tools. Normal voice-service usage applies.
+
+Run `bun run test:voice-preview` for the playback lifecycle tests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,8 @@
         "sonner": "^1.7.4",
         "tailwind-merge": "^3.4.0",
         "typescript": "^5.7.0",
-        "vaul": "^1.1.2"
+        "vaul": "^1.1.2",
+        "happy-dom": "^20.14.0"
       },
       "engines": {
         "bb": ">=0.40",
@@ -1337,6 +1338,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.4.0.tgz",
@@ -1438,6 +1456,19 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/ccount": {
@@ -1608,6 +1639,16 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -1648,6 +1689,25 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.14.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.14.0.tgz",
+      "integrity": "sha512-4bRh1KzRvKDnFNTlLhzT1RZTpkKhQbQDl9j+7GXszWsvuspYdo29k6OHRf4PwiM6oLb8r/pMWeYiJjkfod5AvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ws": "^8.21.0",
+        "entities": "^7.0.1",
+        "@types/ws": "^8.18.1",
+        "@types/node": ">=20.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "buffer-image-size": "^0.6.4",
+        "@types/whatwg-mimetype": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
@@ -2575,12 +2635,44 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/zod": {
       "version": "4.5.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "test": "node --test audio-devices.test.ts voice-agent.test.ts shortcuts.test.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:voice-preview": "bun test voice-preview.test.tsx"
   },
   "engines": {
     "bb": ">=0.40",
@@ -51,6 +52,7 @@
     "clsx": "^2.1.1",
     "sonner": "^1.7.4",
     "tailwind-merge": "^3.4.0",
-    "vaul": "^1.1.2"
+    "vaul": "^1.1.2",
+    "happy-dom": "^20.14.0"
   }
 }

--- a/server.ts
+++ b/server.ts
@@ -34,6 +34,11 @@ const shortcutsSchema = z
   .strict();
 
 export const rpcContract = defineRpcContract({
+  /** A receive-only voice sample, separate from the user's operator session. */
+  previewVoice: {
+    input: z.object({ sdp: z.string().min(1).max(16384), voice: z.enum(VOICE_OPTIONS) }).strict(),
+    output: z.object({ sdp: z.string().max(65536) }).strict(),
+  },
   /** Exchange a WebRTC SDP offer with OpenAI Realtime. Returns the answer. */
   createCall: {
     input: z
@@ -613,7 +618,7 @@ export default async function plugin(bb: BbPluginApi) {
     }
   }
 
-  async function codexToken(): Promise<string | null> {
+  async function codexToken(signal?: AbortSignal): Promise<string | null> {
     let auth: { tokens?: { access_token?: string; refresh_token?: string } };
     try {
       auth = JSON.parse(readFileSync(CODEX_AUTH_PATH, "utf8"));
@@ -627,6 +632,7 @@ export default async function plugin(bb: BbPluginApi) {
     if (!refresh) return null;
     try {
       const response = await fetch("https://auth.openai.com/oauth/token", {
+        signal,
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -665,19 +671,19 @@ export default async function plugin(bb: BbPluginApi) {
     }
   }
 
-  async function apiKey(): Promise<string> {
+  async function apiKey(signal?: AbortSignal): Promise<string> {
     const { openaiApiKey } = await settings.get();
     const { credentialPreference } = await readConfig();
     const key = openaiApiKey || process.env.OPENAI_API_KEY;
     // When the user pinned the subscription, try it first and only fall back to
     // a key. Otherwise (auto / apiKey) a key wins, then the subscription.
     if (credentialPreference === "subscription") {
-      const codex = await codexToken();
+      const codex = await codexToken(signal);
       if (codex) return codex;
       if (key) return key;
     } else {
       if (key) return key;
-      const codex = await codexToken();
+      const codex = await codexToken(signal);
       if (codex) return codex;
     }
     throw new Error(
@@ -1135,7 +1141,39 @@ export default async function plugin(bb: BbPluginApi) {
     },
   });
 
+  let previewConnecting: boolean = false;
   bb.rpc.register(rpcContract, {
+    async previewVoice({ sdp, voice }): Promise<{ sdp: string }> {
+      if (previewConnecting) throw new Error("Another voice preview is connecting. Try again in a moment.");
+      previewConnecting = true;
+      try {
+        const signal: AbortSignal = AbortSignal.timeout(15000);
+        const key: string = await apiKey(signal);
+        const { model } = await readConfig();
+        const form: FormData = new FormData();
+        form.set("sdp", sdp);
+        form.set("session", JSON.stringify({
+          type: "realtime", model,
+          instructions: 'Say exactly: "Hi there! Here’s a quick preview of my voice. How can I help you today?"',
+          max_output_tokens: 256,
+          audio: { input: { turn_detection: null }, output: { voice } },
+          tools: [], tool_choice: "none",
+        }));
+        const response: Response = await fetch(REALTIME_ENDPOINT, {
+          method: "POST", headers: { Authorization: `Bearer ${key}` },
+          body: form, signal,
+        });
+        if (!response.ok) {
+          await response.body?.cancel();
+          throw new Error(`Voice preview could not connect (${response.status}). Check your OpenAI credential in Models & voice.`);
+        }
+        const answer: string = await response.text();
+        if (answer.length > 65536) throw new Error("Voice preview returned an oversized answer.");
+        return { sdp: answer };
+      } finally {
+        previewConnecting = false;
+      }
+    },
     async createCall({ sdp, threadId, projectId, onNewThreadScreen, nonce }) {
       const key = await apiKey();
       const { model, voice } = await readConfig();

--- a/settings-sections.tsx
+++ b/settings-sections.tsx
@@ -29,6 +29,7 @@ import {
   type Voice,
 } from "./models";
 import { voiceAgent } from "./voice-agent";
+import { VoicePreview } from "./voice-preview";
 import { deviceDisplayLabel } from "./audio-devices";
 import {
   DEFAULT_SHORTCUTS,
@@ -297,6 +298,7 @@ export function ModelsSettings() {
           ))}
         </select>
       </label>
+      <VoicePreview key={`${model}:${voice}`} voice={voice} disabled={loading} />
     </div>
   );
 }

--- a/voice-preview.test.tsx
+++ b/voice-preview.test.tsx
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+const browser: Window = new Window();
+Object.assign(globalThis, {
+  window: browser,
+  document: browser.document,
+  navigator: browser.navigator,
+  HTMLElement: browser.HTMLElement,
+  IS_REACT_ACT_ENVIRONMENT: true,
+});
+const exchange = mock(async (): Promise<{ sdp: string }> => ({
+  sdp: "answer",
+}));
+mock.module("@get-bb/plugin-sdk/app", () => ({
+  useRpc: () => ({ call: exchange }),
+}));
+class FakeChannel {
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  send = mock((_message: string): void => {});
+  close = mock((): void => {});
+}
+class FakePeer {
+  static instances: FakePeer[] = [];
+  channel: FakeChannel = new FakeChannel();
+  localDescription: { sdp: string } = { sdp: "offer" };
+  connectionState: string = "new";
+  ontrack: ((event: { streams: object[] }) => void) | null = null;
+  onconnectionstatechange: (() => void) | null = null;
+  trackStop = mock((): void => {});
+  close = mock((): void => {});
+  setRemoteDescription = mock(async (): Promise<void> => {});
+  addTransceiver = mock(
+    (_kind: string, _options: { direction: string }): void => {},
+  );
+  constructor() {
+    FakePeer.instances.push(this);
+  }
+  createDataChannel(): FakeChannel {
+    return this.channel;
+  }
+  async createOffer(): Promise<{ sdp: string }> {
+    return this.localDescription;
+  }
+  async setLocalDescription(): Promise<void> {}
+  getReceivers(): { track: { stop: () => void } }[] {
+    return [{ track: { stop: this.trackStop } }];
+  }
+}
+const play = mock(async (): Promise<void> => {});
+Object.assign(globalThis, {
+  RTCPeerConnection: FakePeer,
+  Audio: function (): HTMLAudioElement {
+    const audio: HTMLAudioElement = document.createElement("audio");
+    audio.play = play;
+    audio.pause = mock((): void => {});
+    return audio;
+  },
+});
+const { VoicePreview } = await import("./voice-preview");
+let root: Root;
+let container: HTMLDivElement;
+async function render(element: ReactElement): Promise<void> {
+  await act(async (): Promise<void> => {
+    root.render(element);
+  });
+}
+async function click(): Promise<void> {
+  await act(async (): Promise<void> => {
+    container.querySelector("button")?.click();
+  });
+}
+function peer(): FakePeer {
+  const value: FakePeer | undefined = FakePeer.instances.at(-1);
+  if (!value) throw new Error("Expected preview peer");
+  return value;
+}
+beforeEach((): void => {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  FakePeer.instances = [];
+  exchange.mockReset().mockResolvedValue({ sdp: "answer" });
+  play.mockReset().mockResolvedValue();
+});
+afterEach(async (): Promise<void> => {
+  await act(async (): Promise<void> => {
+    root.unmount();
+  });
+  container.remove();
+});
+test("receive-only sample plays once and stops when playback ends", async (): Promise<void> => {
+  await render(<VoicePreview voice="marin" disabled={false} />);
+  await click();
+  expect(peer().addTransceiver).toHaveBeenCalledWith("audio", {
+    direction: "recvonly",
+  });
+  expect(exchange).toHaveBeenCalledWith("previewVoice", {
+    sdp: "offer",
+    voice: "marin",
+  });
+  await act(async (): Promise<void> => {
+    peer().channel.onopen?.();
+    peer().ontrack?.({ streams: [new browser.MediaStream()] });
+    peer().channel.onmessage?.({
+      data: JSON.stringify({ type: "output_audio_buffer.started" }),
+    });
+  });
+  expect(play).toHaveBeenCalledTimes(1);
+  expect(peer().channel.send).toHaveBeenCalledTimes(1);
+  expect(container.textContent).toContain("Playing marin");
+  await act(async (): Promise<void> => {
+    peer().channel.onmessage?.({
+      data: JSON.stringify({ type: "output_audio_buffer.stopped" }),
+    });
+  });
+  expect(peer().close).toHaveBeenCalledTimes(1);
+  expect(peer().trackStop).toHaveBeenCalledTimes(1);
+  expect(document.querySelectorAll("audio").length).toBe(0);
+  expect(container.textContent).toContain("Preview voice");
+});
+test("Stop prevents a late answer from reviving a cancelled sample", async (): Promise<void> => {
+  let resolveAnswer: ((answer: { sdp: string }) => void) | undefined;
+  exchange.mockImplementation(
+    (): Promise<{ sdp: string }> =>
+      new Promise((resolve) => {
+        resolveAnswer = resolve;
+      }),
+  );
+  await render(<VoicePreview voice="cedar" disabled={false} />);
+  await click();
+  expect(container.textContent).toContain("Connecting preview");
+  await click();
+  await act(async (): Promise<void> => {
+    resolveAnswer?.({ sdp: "late" });
+  });
+  expect(peer().setRemoteDescription).not.toHaveBeenCalled();
+  expect(peer().close).toHaveBeenCalledTimes(1);
+});
+test("voice change stops the previous sample", async (): Promise<void> => {
+  await render(<VoicePreview key="marin" voice="marin" disabled={false} />);
+  await click();
+  const previous: FakePeer = peer();
+  await render(<VoicePreview key="cedar" voice="cedar" disabled={false} />);
+  expect(previous.close).toHaveBeenCalledTimes(1);
+  expect(document.querySelectorAll("audio").length).toBe(0);
+  await click();
+  expect(exchange).toHaveBeenLastCalledWith("previewVoice", {
+    sdp: "offer",
+    voice: "cedar",
+  });
+});
+test("connection and speaker failures are visible and release resources", async (): Promise<void> => {
+  exchange.mockRejectedValueOnce(new Error("Check your credential"));
+  await render(<VoicePreview voice="marin" disabled={false} />);
+  await click();
+  expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+    "Check your credential",
+  );
+  expect(peer().close).toHaveBeenCalledTimes(1);
+  play.mockRejectedValue(new Error("NotAllowedError"));
+  await click();
+  await act(async (): Promise<void> => {
+    peer().ontrack?.({ streams: [new browser.MediaStream()] });
+  });
+  expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+    "Check your speaker",
+  );
+  expect(peer().close).toHaveBeenCalledTimes(1);
+});
+test("unmount closes the connection and removes hidden audio", async (): Promise<void> => {
+  await render(<VoicePreview voice="marin" disabled={false} />);
+  await click();
+  const previous: FakePeer = peer();
+  await render(<div />);
+  expect(previous.close).toHaveBeenCalledTimes(1);
+  expect(document.querySelectorAll("audio").length).toBe(0);
+});

--- a/voice-preview.tsx
+++ b/voice-preview.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useRef, useState, type ReactElement } from "react";
+import { useRpc } from "@get-bb/plugin-sdk/app";
+import { Button } from "./components/ui/button";
+import type { Voice } from "./models";
+import type { rpcContract } from "./server";
+
+type PreviewState = "idle" | "connecting" | "playing";
+
+/** Key by voice/model so changing either disposes the previous sample. */
+export function VoicePreview({
+  voice,
+  disabled,
+}: {
+  voice: Voice;
+  disabled: boolean;
+}): ReactElement {
+  const rpc = useRpc<typeof rpcContract>();
+  const [state, setState] = useState<PreviewState>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const stop = useRef<(() => void) | null>(null);
+  useEffect(
+    () => () => {
+      stop.current?.();
+    },
+    [],
+  );
+
+  function start(): void {
+    if (stop.current) {
+      stop.current();
+      return;
+    }
+    setError(null);
+    setState("connecting");
+    let peer: RTCPeerConnection;
+    try {
+      peer = new RTCPeerConnection();
+    } catch {
+      setState("idle");
+      setError("Voice previews are unavailable in this browser.");
+      return;
+    }
+    const audio: HTMLAudioElement = new Audio();
+    audio.autoplay = true;
+    audio.setAttribute("playsinline", "");
+    audio.hidden = true;
+    document.body.append(audio);
+    const channel: RTCDataChannel = peer.createDataChannel("voice-preview");
+    let disposed: boolean = false;
+    const timeout: ReturnType<typeof setTimeout> = setTimeout(() => {
+      fail("Voice preview timed out. Please try again.");
+    }, 30000);
+
+    function dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      clearTimeout(timeout);
+      channel.onopen = channel.onmessage = channel.onclose = null;
+      peer.ontrack = peer.onconnectionstatechange = null;
+      channel.close();
+      peer
+        .getReceivers()
+        .forEach((receiver: RTCRtpReceiver): void => receiver.track.stop());
+      peer.close();
+      audio.pause();
+      audio.srcObject = null;
+      audio.remove();
+      stop.current = null;
+      setState("idle");
+    }
+    function fail(message: string): void {
+      if (disposed) return;
+      dispose();
+      setError(message);
+    }
+    stop.current = dispose;
+    // Receive only: never ask for microphone permission or send user audio.
+    peer.addTransceiver("audio", { direction: "recvonly" });
+    peer.ontrack = (event: RTCTrackEvent): void => {
+      if (disposed) return;
+      audio.srcObject = event.streams[0] ?? new MediaStream([event.track]);
+      void audio
+        .play()
+        .catch((): void =>
+          fail("Could not play the preview. Check your speaker and try again."),
+        );
+    };
+    peer.onconnectionstatechange = (): void => {
+      if (
+        peer.connectionState === "failed" ||
+        peer.connectionState === "disconnected"
+      ) {
+        fail("Voice preview disconnected. Please try again.");
+      }
+    };
+    channel.onopen = (): void => {
+      if (!disposed) channel.send(JSON.stringify({ type: "response.create" }));
+    };
+    channel.onclose = (): void =>
+      fail("Voice preview disconnected. Please try again.");
+    channel.onmessage = (message: MessageEvent<string>): void => {
+      if (disposed) return;
+      let event: unknown;
+      try {
+        event = JSON.parse(message.data);
+      } catch {
+        return;
+      }
+      if (typeof event !== "object" || event === null || !("type" in event))
+        return;
+      if (event.type === "output_audio_buffer.started") setState("playing");
+      if (event.type === "output_audio_buffer.stopped") dispose();
+      if (event.type === "error")
+        fail(
+          "The voice service could not play this preview. Please try again.",
+        );
+      if (event.type === "response.done" && "response" in event) {
+        const response: unknown = event.response;
+        if (
+          typeof response === "object" &&
+          response !== null &&
+          "status" in response &&
+          response.status !== "completed"
+        ) {
+          fail("The voice sample could not finish. Please try again.");
+        }
+      }
+    };
+    async function connect(): Promise<void> {
+      const offer: RTCSessionDescriptionInit = await peer.createOffer();
+      if (disposed) return;
+      await peer.setLocalDescription(offer);
+      if (disposed) return;
+      const sdp: string | undefined = peer.localDescription?.sdp;
+      if (!sdp) throw new Error("Could not prepare the voice preview.");
+      const answer: { sdp: string } = await rpc.call("previewVoice", {
+        sdp,
+        voice,
+      });
+      if (!disposed)
+        await peer.setRemoteDescription({ type: "answer", sdp: answer.sdp });
+    }
+    void connect().catch((cause: unknown): void => {
+      fail(
+        cause instanceof Error
+          ? cause.message
+          : "Could not connect the voice preview.",
+      );
+    });
+  }
+
+  return (
+    <div className="space-y-2">
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        disabled={disabled}
+        onClick={start}
+        aria-label={
+          state === "idle" ? `Preview ${voice} voice` : "Stop voice preview"
+        }
+      >
+        {state === "idle" ? "Preview voice" : "Stop preview"}
+      </Button>
+      <p className="text-xs text-muted-foreground" role="status">
+        {state === "connecting"
+          ? "Connecting preview…"
+          : state === "playing"
+            ? `Playing ${voice}…`
+            : "Hear a short sample. Uses your configured voice service; microphone stays off."}
+      </p>
+      {error ? (
+        <p className="text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
The voice picker lets users choose a voice without hearing it. This adds **Preview voice** and **Stop preview** to Models & voice so users can compare voices before starting a call.

| Task | Before | After |
| --- | --- | --- |
| Hear the selected voice | Start a full operator call | Play a short sample with the configured Realtime model and credentials |
| Stop or compare another voice | Manage the active call | Stop explicitly; changing voice/model or leaving settings disposes the preview |
| Diagnose a failed preview | No preview control | Connecting/playing status and visible connection or speaker errors |

The preview uses a receive-only WebRTC connection: no microphone capture, operator tools, or `voice-call` broadcast. It leaves the normal call and saved instructions alone. The server validates the voice and SDP, limits connection setup to one request at a time with a 15-second deadline, and caps the sample at 256 output tokens. The client closes the preview after playback or a 30-second deadline. Normal voice-service usage applies.

Validation:
- `bun run test`: all 35 existing tests pass.
- `bun run test:voice-preview`: 5 tests / 21 assertions pass for receive-only playback, completion, cancellation during connection, late answers, voice switching, errors, and unmount cleanup.
- `bun run typecheck`: passes with the existing SDK 0.4.21 pin.
- `bb plugin build .` and `git diff --check`: pass.
- A locally installed build reports running with a compatible frontend; invalid voice input returns HTTP 400 and existing saved instructions are preserved.

Actual speaker playback has not been verified end-to-end in the bb UI. Manual verification: preview Marin and Cedar, stop while connecting and while playing, then switch voices and leave settings during playback. Confirm the microphone remains off and each sample stops cleanly.

The React playback tests use Bun and happy-dom through the separate `test:voice-preview` script; the existing Node test command remains unchanged.
