### PR TITLE
Let Aide call you: incoming voice calls with greet-first answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ bb handsfree live --json     # machine-readable
 bb handsfree read thr_xxxxx  # a thread's status + latest assistant output
 bb handsfree usage           # what your voice sessions cost, per day (estimated)
 bb handsfree stop            # stop an active voice session in any bb window
+bb handsfree ring --title "Morning brief" --briefing "Plan the day"  # ring every window with an incoming-call invite
 ```
 
 Agents discover these commands automatically through bb's plugin-commands

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ bb handsfree read thr_xxxxx  # a thread's status + latest assistant output
 bb handsfree usage           # what your voice sessions cost, per day (estimated)
 bb handsfree stop            # stop an active voice session in any bb window
 bb handsfree ring --title "Morning brief" --briefing "Plan the day"  # ring every window with an incoming-call invite
+                             # flags: --ttl 60 (10-600s), --no-banner (skip the native OS banner)
+                               # add --ttl 60, or --no-banner to skip the native OS banner
 ```
 
 Agents discover these commands automatically through bb's plugin-commands
@@ -108,6 +110,9 @@ Open the Handsfree plugin settings for curated sections:
   credential Aide will use.
 - **Behavior** — whether Aide announces thread events, and which installed
   plugins' `bb` commands it may run (all / none / a specific list).
+- **Incoming calls** — whether automations may ring this device (`bb
+  handsfree ring`), the ringtone, how long Snooze waits, and whether Aide
+  speaks first with the call reason when you pick up.
 - **Audio** — pick and test the microphone with a live input-level meter. The
   chosen mic is stored in the current browser and applies to the next voice
   session; if it disconnects, Handsfree falls back to the system default.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ bb handsfree read thr_xxxxx  # a thread's status + latest assistant output
 bb handsfree usage           # what your voice sessions cost, per day (estimated)
 bb handsfree stop            # stop an active voice session in any bb window
 bb handsfree ring --title "Morning brief" --briefing "Plan the day"  # ring every window with an incoming-call invite
-                             # flags: --ttl 60 (10-600s), --no-banner (skip the native OS banner)
+                             # flags: --ttl 60 (10-600s), --banner (native OS banner, opt-in)
                                # add --ttl 60, or --no-banner to skip the native OS banner
 ```
 

--- a/app.tsx
+++ b/app.tsx
@@ -20,6 +20,7 @@ import type { PluginThreadListProps } from "@get-bb/plugin-sdk/app";
 import type { rpcContract } from "./server";
 import { clientDescriptor } from "./client-identity";
 import { voiceAgent } from "./voice-agent";
+import { GlobalInviteOverlay } from "./voice-invite.tsx";
 import { SessionsPanel } from "./sessions-panel";
 import { viewWorkspace } from "./view-workspace";
 import { COMPANION_TAB, CompanionTab, THREAD_WORKSPACE_ACTION } from "./companion";
@@ -420,6 +421,14 @@ export default definePluginApp((app) => {
     title: "Handsfree voice bar",
     description: "Adds a persistent voice control bar above the thread list.",
     component: ThreadListWithVoiceBar,
+  });
+  // Tier-0 autonomous invocation: one app-wide incoming-call overlay, mounted
+  // on every page (threads, Handsfree, settings, other plugins' pages) so an
+  // invite rings wherever the user happens to be. Null-safe by design: with
+  // no invite it renders nothing.
+  app.slots.experimental_appOverlay({
+    id: "incoming-call",
+    component: GlobalInviteOverlay,
   });
   // The session deliberately outlives any component, so tie it to the plugin
   // frontend generation instead: on reload/disable the old bundle's singleton

--- a/app.tsx
+++ b/app.tsx
@@ -24,7 +24,7 @@ import { GlobalInviteOverlay } from "./voice-invite.tsx";
 import { SessionsPanel } from "./sessions-panel";
 import { viewWorkspace } from "./view-workspace";
 import { COMPANION_TAB, CompanionTab, THREAD_WORKSPACE_ACTION } from "./companion";
-import { AudioSettings, BehaviorSettings, ModelsSettings, ShortcutsSettings } from "./settings-sections";
+import { AudioSettings, BehaviorSettings, IncomingCallsSettings, ModelsSettings, ShortcutsSettings } from "./settings-sections";
 import { cn } from "@/lib/utils";
 import { AUDIO_DEVICE_STORAGE_KEY } from "./audio-devices";
 import { MicIcon, StopIcon, WaveformIcon, useCallElapsed } from "./voice-chrome";
@@ -356,6 +356,11 @@ export default definePluginApp((app) => {
     id: "behavior",
     title: "Behavior",
     component: BehaviorSettings,
+  });
+  app.slots.settingsSection({
+    id: "incoming-calls",
+    title: "Incoming calls",
+    component: IncomingCallsSettings,
   });
   app.slots.settingsSection({
     id: "audio",

--- a/server.test.ts
+++ b/server.test.ts
@@ -103,26 +103,26 @@ test("ring broadcasts an incoming-call invite to every window", async () => {  c
     assert.equal(payload.title, "Morning brief");
     assert.match(String(payload.inviteId), /^inv-/);
     assert.ok((payload.expiresAt as number) > (payload.createdAt as number));
-    // A native OS banner goes out alongside the in-app invite…
+    // Toast-only by default: no native banner without --banner.
+    assert.equal(harness.inspection.realtimeSignals.some((s) => s.channel === "notification"), false);
+  } finally { await harness.lifecycle.dispose(); }
+});
+
+test("ring --banner adds the native OS banner alongside the invite", async () => {
+  const { bb, harness } = createFakePluginHost({ pluginId: "handsfree" });
+  try {
+    await plugin(bb);
+    const result = await harness.behavior.runCli(["ring", "--title", "Morning brief", "--banner"]);
+    assert.equal(result.exitCode, 0);
+    const invite = harness.inspection.realtimeSignals.find((s) => s.channel === "voice-invite");
     const banner = harness.inspection.realtimeSignals.find((s) => s.channel === "notification");
     assert.deepEqual(banner?.payload, {
-      id: payload.inviteId,
+      id: (invite?.payload as Record<string, unknown>)?.inviteId,
       title: "Aide calling: Morning brief",
       body: "Accept the call in BB to talk.",
       threadId: null,
       channels: ["web", "desktop"],
     });
-  } finally { await harness.lifecycle.dispose(); }
-});
-
-test("ring --no-banner skips the native OS banner", async () => {
-  const { bb, harness } = createFakePluginHost({ pluginId: "handsfree" });
-  try {
-    await plugin(bb);
-    const result = await harness.behavior.runCli(["ring", "--no-banner"]);
-    assert.equal(result.exitCode, 0);
-    assert.ok(harness.inspection.realtimeSignals.some((s) => s.channel === "voice-invite"));
-    assert.equal(harness.inspection.realtimeSignals.some((s) => s.channel === "notification"), false);
   } finally { await harness.lifecycle.dispose(); }
 });
 

--- a/server.test.ts
+++ b/server.test.ts
@@ -103,6 +103,26 @@ test("ring broadcasts an incoming-call invite to every window", async () => {  c
     assert.equal(payload.title, "Morning brief");
     assert.match(String(payload.inviteId), /^inv-/);
     assert.ok((payload.expiresAt as number) > (payload.createdAt as number));
+    // A native OS banner goes out alongside the in-app invite…
+    const banner = harness.inspection.realtimeSignals.find((s) => s.channel === "notification");
+    assert.deepEqual(banner?.payload, {
+      id: payload.inviteId,
+      title: "Aide calling: Morning brief",
+      body: "Accept the call in BB to talk.",
+      threadId: null,
+      channels: ["web", "desktop"],
+    });
+  } finally { await harness.lifecycle.dispose(); }
+});
+
+test("ring --no-banner skips the native OS banner", async () => {
+  const { bb, harness } = createFakePluginHost({ pluginId: "handsfree" });
+  try {
+    await plugin(bb);
+    const result = await harness.behavior.runCli(["ring", "--no-banner"]);
+    assert.equal(result.exitCode, 0);
+    assert.ok(harness.inspection.realtimeSignals.some((s) => s.channel === "voice-invite"));
+    assert.equal(harness.inspection.realtimeSignals.some((s) => s.channel === "notification"), false);
   } finally { await harness.lifecycle.dispose(); }
 });
 

--- a/server.test.ts
+++ b/server.test.ts
@@ -91,8 +91,7 @@ test("mobile settings never replace desktop navigation and migrate the prototype
   } finally { await harness.lifecycle.dispose(); }
 });
 
-test("ring broadcasts an incoming-call invite to every window", async () => {
-  const { bb, harness } = createFakePluginHost({ pluginId: "handsfree" });
+test("ring broadcasts an incoming-call invite to every window", async () => {  const { bb, harness } = createFakePluginHost({ pluginId: "handsfree" });
   try {
     await plugin(bb);
     const result = await harness.behavior.runCli(["ring", "--title", "Morning brief", "--ttl", "45"]);
@@ -104,6 +103,19 @@ test("ring broadcasts an incoming-call invite to every window", async () => {
     assert.equal(payload.title, "Morning brief");
     assert.match(String(payload.inviteId), /^inv-/);
     assert.ok((payload.expiresAt as number) > (payload.createdAt as number));
+  } finally { await harness.lifecycle.dispose(); }
+});
+
+test("resolveInvite rebroadcasts answers and dismissals to every window", async () => {
+  const { bb, harness } = createFakePluginHost({ pluginId: "handsfree" });
+  try {
+    await plugin(bb);
+    const result = await harness.behavior.callRpc("resolveInvite", { inviteId: "inv-1", action: "answered" });
+    assert.deepEqual(result, { ok: true });
+    const signal = harness.inspection.realtimeSignals.find((s) => s.channel === "voice-invite-resolved");
+    assert.deepEqual(signal?.payload, { inviteId: "inv-1", action: "answered" });
+    await assert.rejects(harness.behavior.callRpc("resolveInvite", { inviteId: "", action: "answered" }));
+    await assert.rejects(harness.behavior.callRpc("resolveInvite", { inviteId: "inv-1", action: "maybe" }));
   } finally { await harness.lifecycle.dispose(); }
 });
 

--- a/server.test.ts
+++ b/server.test.ts
@@ -91,6 +91,22 @@ test("mobile settings never replace desktop navigation and migrate the prototype
   } finally { await harness.lifecycle.dispose(); }
 });
 
+test("ring broadcasts an incoming-call invite to every window", async () => {
+  const { bb, harness } = createFakePluginHost({ pluginId: "handsfree" });
+  try {
+    await plugin(bb);
+    const result = await harness.behavior.runCli(["ring", "--title", "Morning brief", "--ttl", "45"]);
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /Morning brief/);
+    const signal = harness.inspection.realtimeSignals.find((s) => s.channel === "voice-invite");
+    assert.ok(signal, "expected a voice-invite broadcast");
+    const payload = signal!.payload as Record<string, unknown>;
+    assert.equal(payload.title, "Morning brief");
+    assert.match(String(payload.inviteId), /^inv-/);
+    assert.ok((payload.expiresAt as number) > (payload.createdAt as number));
+  } finally { await harness.lifecycle.dispose(); }
+});
+
 test("desktop focus still opens the real bb thread through the original SDK operation", async () => {
   const { bb, harness } = createFakePluginHost({ pluginId: "handsfree", sdk: {
     threads: { open: async () => ({ delivered: 1 }) },

--- a/server.test.ts
+++ b/server.test.ts
@@ -152,3 +152,37 @@ test("desktop focus still opens the real bb thread through the original SDK oper
     assert.equal(harness.inspection.sdk.callsTo("threads.open").length, 1);
   } finally { await harness.lifecycle.dispose(); }
 });
+
+test("incoming-call preferences round-trip through getConfig/setConfig", async () => {
+  const { bb, harness } = createFakePluginHost({ pluginId: "handsfree" });
+  try {
+    await plugin(bb);
+    const current = await harness.behavior.callRpc("getConfig", null) as any;
+    assert.equal(current.incomingCalls, true);
+    assert.equal(current.ringtone, true);
+    assert.equal(current.snoozeMinutes, 10);
+    assert.equal(current.greetFirst, true);
+    const saved = await harness.behavior.callRpc("setConfig", {
+      incomingCalls: false, ringtone: false, snoozeMinutes: 5, greetFirst: false,
+    }) as any;
+    assert.equal(saved.incomingCalls, false);
+    assert.equal(saved.ringtone, false);
+    assert.equal(saved.snoozeMinutes, 5);
+    assert.equal(saved.greetFirst, false);
+    await assert.rejects(harness.behavior.callRpc("setConfig", { snoozeMinutes: 0 }));
+    await assert.rejects(harness.behavior.callRpc("setConfig", { snoozeMinutes: "soon" }));
+  } finally { await harness.lifecycle.dispose(); }
+});
+
+test("ring stays silent while incoming calls are disabled", async () => {
+  const { bb, harness } = createFakePluginHost({ pluginId: "handsfree" });
+  try {
+    await plugin(bb);
+    await bb.storage.kv.set("config", { incomingCalls: false });
+    const result = await harness.behavior.runCli(["ring", "--title", "Should not ring"]);
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /disabled/);
+    assert.equal(harness.inspection.realtimeSignals.some((s) => s.channel === "voice-invite"), false);
+    assert.equal(harness.inspection.realtimeSignals.some((s) => s.channel === "notification"), false);
+  } finally { await harness.lifecycle.dispose(); }
+});

--- a/server.ts
+++ b/server.ts
@@ -1088,6 +1088,7 @@ export default async function plugin(bb: BbPluginApi) {
       { name: "stop", summary: "Stop any active Aide voice session in any bb window.", usage: "bb handsfree stop" },
       { name: "mute", summary: "Mute the active voice session's microphone (call stays up).", usage: "bb handsfree mute" },
       { name: "unmute", summary: "Unmute the active voice session's microphone.", usage: "bb handsfree unmute" },
+      { name: "ring", summary: "Ring every connected bb window with an incoming voice-call invite (Tier-0 autonomous invocation).", usage: 'bb handsfree ring [--title "..."] [--briefing "..."] [--ttl 60]' },
     ],
     async run(argv) {
       const [command, ...rest] = argv;
@@ -1100,6 +1101,7 @@ export default async function plugin(bb: BbPluginApi) {
         "  bb handsfree usage [--days N] [--json] voice-session tokens and estimated cost",
         "  bb handsfree stop                     stop any active voice session",
         "  bb handsfree mute | unmute            mute/unmute the active session's mic",
+        '  bb handsfree ring [--title "..."]     ring every window with an incoming-call invite',
       ].join("\n");
       try {
         if (command === undefined || command === "help" || command === "--help" || command === "-h") {
@@ -1114,6 +1116,33 @@ export default async function plugin(bb: BbPluginApi) {
           // session whose nonce differs — an unknown nonce stops them all.
           bb.realtime.publish("voice-call", { nonce: `cli-stop-${Date.now()}` });
           return { exitCode: 0, stdout: "Stop signal broadcast to all bb windows." };
+        }
+        if (command === "ring") {
+          // Tier-0 autonomous invocation ("the call"): broadcast an
+          // incoming-call invite that every connected surface rings on until
+          // the user accepts (which starts a normal voice session),
+          // snoozes, dismisses, or the invite expires. Automations invoke
+          // this on a schedule instead of starting audio themselves — the
+          // human is the arbiter, so no mic-busy detection is needed.
+          const flag = (name: string): string | null => {
+            const index = rest.indexOf(`--${name}`);
+            if (index < 0) return null;
+            const value = rest[index + 1];
+            return value !== undefined && !value.startsWith("--") ? value : null;
+          };
+          const title = flag("title")?.trim() || "Aide wants to talk";
+          const briefing = flag("briefing")?.trim() || "";
+          const ttlSec = Math.min(Math.max(Number(flag("ttl") ?? 60) || 60, 10), 600);
+          const now = Date.now();
+          const invite = {
+            inviteId: `inv-${now.toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+            title: title.slice(0, 120),
+            briefing: briefing.slice(0, 500),
+            createdAt: now,
+            expiresAt: now + ttlSec * 1000,
+          };
+          bb.realtime.publish("voice-invite", invite);
+          return { exitCode: 0, stdout: `Ringing all bb windows: "${invite.title}" (${invite.inviteId}, expires in ${ttlSec}s).` };
         }
         if (command === "live") {
           const live = await liveThreads();

--- a/server.ts
+++ b/server.ts
@@ -21,6 +21,7 @@ import {
 } from "./models";
 import { sessionEventLog } from "./session-events.ts";
 import { DEFAULT_SHORTCUTS, isValidShortcut, normalizeShortcuts, type Shortcuts } from "./shortcuts";
+import { INVITE_CHANNEL, INVITE_RESOLVED_CHANNEL } from "./voice-invite.ts";
 
 /**
  * Rebindable keyboard shortcuts (see shortcuts.ts): each value is a
@@ -1098,7 +1099,7 @@ export default async function plugin(bb: BbPluginApi) {
       { name: "stop", summary: "Stop any active Aide voice session in any bb window.", usage: "bb handsfree stop" },
       { name: "mute", summary: "Mute the active voice session's microphone (call stays up).", usage: "bb handsfree mute" },
       { name: "unmute", summary: "Unmute the active voice session's microphone.", usage: "bb handsfree unmute" },
-      { name: "ring", summary: "Ring every connected bb window with an incoming voice-call invite (Tier-0 autonomous invocation).", usage: 'bb handsfree ring [--title "..."] [--briefing "..."] [--ttl 60]' },
+      { name: "ring", summary: "Ring every connected bb window with an incoming voice-call invite (Tier-0 autonomous invocation).", usage: 'bb handsfree ring [--title "..."] [--briefing "..."] [--ttl 60] [--no-banner]' },
     ],
     async run(argv) {
       const [command, ...rest] = argv;
@@ -1112,6 +1113,7 @@ export default async function plugin(bb: BbPluginApi) {
         "  bb handsfree stop                     stop any active voice session",
         "  bb handsfree mute | unmute            mute/unmute the active session's mic",
         '  bb handsfree ring [--title "..."]     ring every window with an incoming-call invite',
+        '    --briefing "..." --ttl 60 --no-banner',
       ].join("\n");
       try {
         if (command === undefined || command === "help" || command === "--help" || command === "-h") {
@@ -1151,7 +1153,22 @@ export default async function plugin(bb: BbPluginApi) {
             createdAt: now,
             expiresAt: now + ttlSec * 1000,
           };
-          bb.realtime.publish("voice-invite", invite);
+          bb.realtime.publish(INVITE_CHANNEL, invite);
+          if (!rest.includes("--no-banner")) {
+            // Native OS banner (macOS Notification Center included) via the
+            // push plugin's global "notification" listener: reaches
+            // backgrounded tabs and the desktop app, where our overlay can't
+            // be seen. Needs Notification permission on that client; mobile
+            // webviews ignore this channel (Expo path instead — see HF-12).
+            // Clicking focuses BB; threadId null means no navigation.
+            bb.realtime.publish("notification", {
+              id: invite.inviteId,
+              title: `Aide calling: ${invite.title}`.slice(0, 80),
+              body: (invite.briefing || "Accept the call in BB to talk.").slice(0, 180),
+              threadId: null,
+              channels: ["web", "desktop"],
+            });
+          }
           return { exitCode: 0, stdout: `Ringing all bb windows: "${invite.title}" (${invite.inviteId}, expires in ${ttlSec}s).` };
         }
         if (command === "live") {
@@ -1395,7 +1412,7 @@ export default async function plugin(bb: BbPluginApi) {
       return { ok: true as const };
     },
     async resolveInvite({ inviteId, action }) {
-      bb.realtime.publish("voice-invite-resolved", { inviteId, action });
+      bb.realtime.publish(INVITE_RESOLVED_CHANNEL, { inviteId, action });
       return { ok: true as const };
     },
     async listSessions(input) {

--- a/server.ts
+++ b/server.ts
@@ -128,6 +128,10 @@ export const rpcContract = defineRpcContract({
         pluginCommands: z.string(),
         credentialPreference: z.enum(["auto", "apiKey", "subscription"]),
         shortcuts: shortcutsSchema,
+        incomingCalls: z.boolean(),
+        ringtone: z.boolean(),
+        snoozeMinutes: z.number(),
+        greetFirst: z.boolean(),
       })
       .strict(),
   },
@@ -142,6 +146,10 @@ export const rpcContract = defineRpcContract({
         pluginCommands: z.string().max(2000).optional(),
         credentialPreference: z.enum(["auto", "apiKey", "subscription"]).optional(),
         shortcuts: shortcutsSchema.optional(),
+        incomingCalls: z.boolean().optional(),
+        ringtone: z.boolean().optional(),
+        snoozeMinutes: z.number().int().min(1).max(120).optional(),
+        greetFirst: z.boolean().optional(),
       })
       .strict(),
     output: z
@@ -153,6 +161,10 @@ export const rpcContract = defineRpcContract({
         pluginCommands: z.string(),
         credentialPreference: z.enum(["auto", "apiKey", "subscription"]),
         shortcuts: shortcutsSchema,
+        incomingCalls: z.boolean(),
+        ringtone: z.boolean(),
+        snoozeMinutes: z.number().int().min(1).max(120),
+        greetFirst: z.boolean(),
       })
       .strict(),
   },
@@ -524,6 +536,10 @@ export default async function plugin(bb: BbPluginApi) {
     pluginCommands: string;
     credentialPreference: CredentialPreference;
     shortcuts: Shortcuts;
+    incomingCalls: boolean;
+    ringtone: boolean;
+    snoozeMinutes: number;
+    greetFirst: boolean;
   }
   const CONFIG_KEY = "config";
   const CONFIG_DEFAULTS: VoiceConfig = {
@@ -534,9 +550,17 @@ export default async function plugin(bb: BbPluginApi) {
     pluginCommands: "all",
     credentialPreference: "auto",
     shortcuts: { ...DEFAULT_SHORTCUTS },
+    incomingCalls: true,
+    ringtone: true,
+    snoozeMinutes: 10,
+    greetFirst: true,
   };
   async function readConfig(): Promise<VoiceConfig> {
     const stored = (await bb.storage.kv.get<Partial<VoiceConfig> & { viewBehavior?: string }>(CONFIG_KEY)) ?? {};
+    const snoozeMinutes =
+      typeof stored.snoozeMinutes === "number" && Number.isInteger(stored.snoozeMinutes)
+        ? Math.min(Math.max(stored.snoozeMinutes, 1), 120)
+        : CONFIG_DEFAULTS.snoozeMinutes;
     return {
       model: isModel(stored.model) ? stored.model : CONFIG_DEFAULTS.model,
       voice: isVoice(stored.voice) ? stored.voice : CONFIG_DEFAULTS.voice,
@@ -549,6 +573,11 @@ export default async function plugin(bb: BbPluginApi) {
         ? stored.credentialPreference
         : CONFIG_DEFAULTS.credentialPreference,
       shortcuts: normalizeShortcuts(stored.shortcuts),
+      incomingCalls:
+        typeof stored.incomingCalls === "boolean" ? stored.incomingCalls : CONFIG_DEFAULTS.incomingCalls,
+      ringtone: typeof stored.ringtone === "boolean" ? stored.ringtone : CONFIG_DEFAULTS.ringtone,
+      snoozeMinutes,
+      greetFirst: typeof stored.greetFirst === "boolean" ? stored.greetFirst : CONFIG_DEFAULTS.greetFirst,
     };
   }
   async function writeConfig(patch: Partial<VoiceConfig>): Promise<VoiceConfig> {
@@ -1136,6 +1165,10 @@ export default async function plugin(bb: BbPluginApi) {
           // snoozes, dismisses, or the invite expires. Automations invoke
           // this on a schedule instead of starting audio themselves — the
           // human is the arbiter, so no mic-busy detection is needed.
+          const { incomingCalls, ringtone } = await readConfig();
+          if (!incomingCalls) {
+            return { exitCode: 0, stdout: "Incoming calls are disabled in settings; not ringing." };
+          }
           const flag = (name: string): string | null => {
             const index = rest.indexOf(`--${name}`);
             if (index < 0) return null;
@@ -1154,7 +1187,7 @@ export default async function plugin(bb: BbPluginApi) {
             expiresAt: now + ttlSec * 1000,
           };
           bb.realtime.publish(INVITE_CHANNEL, invite);
-          if (!rest.includes("--no-banner")) {
+          if (ringtone && !rest.includes("--no-banner")) {
             // Native OS banner (macOS Notification Center included) via the
             // push plugin's global "notification" listener: reaches
             // backgrounded tabs and the desktop app, where our overlay can't

--- a/server.ts
+++ b/server.ts
@@ -266,6 +266,16 @@ export const rpcContract = defineRpcContract({
     input: z.object({ nonce: z.string().min(1) }).strict(),
     output: z.object({ ok: z.literal(true) }).strict(),
   },
+  /**
+   * Resolve an incoming-call invite from any surface: the server rebroadcasts
+   * so every other surface stops ringing it (frontends are subscribe-only and
+   * cannot tell each other directly). Answering also releases the other
+   * surfaces; snooze stays local by design and needs no call here.
+   */
+  resolveInvite: {
+    input: z.object({ inviteId: z.string().min(1), action: z.enum(["answered", "dismissed"]) }).strict(),
+    output: z.object({ ok: z.literal(true) }).strict(),
+  },
   /** List voice sessions, newest first, with counts and estimated cost. */
   listSessions: {
     input: z.object({ offset: z.number().int().min(0) }).strict().nullable(),
@@ -1382,6 +1392,10 @@ export default async function plugin(bb: BbPluginApi) {
       bb.realtime.publish("voice-presence", { nonce, phase: "idle", startedAt: null });
       bb.realtime.publish("voice-command", { nonce, action: "stop" });
       bb.realtime.publish("aide-log", { sessionId: nonce });
+      return { ok: true as const };
+    },
+    async resolveInvite({ inviteId, action }) {
+      bb.realtime.publish("voice-invite-resolved", { inviteId, action });
       return { ok: true as const };
     },
     async listSessions(input) {

--- a/server.ts
+++ b/server.ts
@@ -1128,7 +1128,7 @@ export default async function plugin(bb: BbPluginApi) {
       { name: "stop", summary: "Stop any active Aide voice session in any bb window.", usage: "bb handsfree stop" },
       { name: "mute", summary: "Mute the active voice session's microphone (call stays up).", usage: "bb handsfree mute" },
       { name: "unmute", summary: "Unmute the active voice session's microphone.", usage: "bb handsfree unmute" },
-      { name: "ring", summary: "Ring every connected bb window with an incoming voice-call invite (Tier-0 autonomous invocation).", usage: 'bb handsfree ring [--title "..."] [--briefing "..."] [--ttl 60] [--no-banner]' },
+      { name: "ring", summary: "Ring every connected bb window with an incoming voice-call invite (Tier-0 autonomous invocation).", usage: 'bb handsfree ring [--title "..."] [--briefing "..."] [--ttl 60] [--banner]' },
     ],
     async run(argv) {
       const [command, ...rest] = argv;
@@ -1142,7 +1142,7 @@ export default async function plugin(bb: BbPluginApi) {
         "  bb handsfree stop                     stop any active voice session",
         "  bb handsfree mute | unmute            mute/unmute the active session's mic",
         '  bb handsfree ring [--title "..."]     ring every window with an incoming-call invite',
-        '    --briefing "..." --ttl 60 --no-banner',
+        '    --briefing "..." --ttl 60 --banner (native OS banner, opt-in while flaky)',
       ].join("\n");
       try {
         if (command === undefined || command === "help" || command === "--help" || command === "-h") {
@@ -1187,7 +1187,11 @@ export default async function plugin(bb: BbPluginApi) {
             expiresAt: now + ttlSec * 1000,
           };
           bb.realtime.publish(INVITE_CHANNEL, invite);
-          if (ringtone && !rest.includes("--no-banner")) {
+          bb.log.info(`voice-invite published: ${invite.inviteId} "${invite.title}"`);
+          // Native banner is opt-in while unreliable (see PR #32): valid
+          // publishes on the push plugin's channel repeatedly never display,
+          // though identical test/thread banners do. Toast is the default.
+          if (ringtone && rest.includes("--banner")) {
             // Native OS banner (macOS Notification Center included) via the
             // push plugin's global "notification" listener: reaches
             // backgrounded tabs and the desktop app, where our overlay can't
@@ -1201,6 +1205,7 @@ export default async function plugin(bb: BbPluginApi) {
               threadId: null,
               channels: ["web", "desktop"],
             });
+            bb.log.info(`invite banner published: ${invite.inviteId}`);
           }
           return { exitCode: 0, stdout: `Ringing all bb windows: "${invite.title}" (${invite.inviteId}, expires in ${ttlSec}s).` };
         }

--- a/sessions-panel.tsx
+++ b/sessions-panel.tsx
@@ -704,6 +704,8 @@ export function SessionsPanel() {
 
   // Cross-surface presence: mirror a call owned by another realm so the console
   // reflects it, and relay stop/mute from the console back to the owning realm.
+  // (Incoming-call invites ring through the app-wide overlay instead — one
+  // ringer everywhere, so this page mounts no invite listener of its own.)
   useRealtime("voice-presence", (payload) => voiceAgent.ingestPresence(payload));
   useRealtime("voice-command", (payload) => voiceAgent.applyVoiceCommand(payload));
   useRealtime("voice-presence-query", () => voiceAgent.answerPresenceQuery());

--- a/settings-sections.tsx
+++ b/settings-sections.tsx
@@ -307,7 +307,7 @@ export function ModelsSettings() {
  * voice): bump BUILD_STAMP with each iteration so a device can prove which
  * bundle it is actually running — webviews are aggressive JS cachers.
  */
-export const BUILD_STAMP = "ring-v3";
+export const BUILD_STAMP = "ring-v4";
 
 function BuildStamp() {
   return (

--- a/settings-sections.tsx
+++ b/settings-sections.tsx
@@ -57,6 +57,10 @@ interface VoiceConfig {
   pluginCommands: string;
   credentialPreference: CredentialPreference;
   shortcuts: Shortcuts;
+  incomingCalls: boolean;
+  ringtone: boolean;
+  snoozeMinutes: number;
+  greetFirst: boolean;
 }
 
 /**
@@ -307,7 +311,7 @@ export function ModelsSettings() {
  * voice): bump BUILD_STAMP with each iteration so a device can prove which
  * bundle it is actually running — webviews are aggressive JS cachers.
  */
-export const BUILD_STAMP = "ring-v6";
+export const BUILD_STAMP = "ring-v7";
 
 function BuildStamp() {
   return (
@@ -405,6 +409,83 @@ export function BehaviorSettings() {
 
 const linkClass =
   "text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline";
+
+// ---------------------------------------------------------------------------
+// Incoming calls: whether automations may ring this device, and how the
+// overlay behaves when they do. The briefing itself (what the call is about)
+// travels with each invite — set it where the call is scheduled
+// (bb handsfree ring --briefing, or the automation's prompt).
+// ---------------------------------------------------------------------------
+
+const SNOOZE_OPTIONS = [5, 10, 15, 30];
+
+export function IncomingCallsSettings() {
+  const { config, update } = useVoiceConfig();
+  const loading = config === null;
+  const incomingCalls = config?.incomingCalls ?? true;
+  const ringtone = config?.ringtone ?? true;
+  const snoozeMinutes = config?.snoozeMinutes ?? 10;
+  const greetFirst = config?.greetFirst ?? true;
+
+  return (
+    <div className="space-y-5">
+      <Group label="Ringing" hint="Automations and bb handsfree ring reach every connected device; each device follows these settings.">
+        <label className="flex items-center justify-between gap-3">
+          <span className="text-sm text-foreground">Allow incoming calls</span>
+          <input
+            type="checkbox"
+            checked={incomingCalls}
+            disabled={loading}
+            onChange={(event) => void update({ incomingCalls: event.target.checked })}
+            className="size-4 shrink-0 accent-primary"
+          />
+        </label>
+        <label className="flex items-center justify-between gap-3">
+          <span className="text-sm text-foreground">Play a ringtone while ringing</span>
+          <input
+            type="checkbox"
+            checked={ringtone}
+            disabled={loading || !incomingCalls}
+            onChange={(event) => void update({ ringtone: event.target.checked })}
+            className="size-4 shrink-0 accent-primary"
+          />
+        </label>
+        <div>
+          <label htmlFor="handsfree-snooze" className="mb-2 block text-sm">Snooze rings again after</label>
+          <select
+            id="handsfree-snooze"
+            className={selectClass}
+            disabled={loading || !incomingCalls}
+            value={snoozeMinutes}
+            onChange={(event) => void update({ snoozeMinutes: Number(event.target.value) })}
+          >
+            {SNOOZE_OPTIONS.includes(snoozeMinutes) ? null : (
+              <option value={snoozeMinutes}>{snoozeMinutes} minutes (custom)</option>
+            )}
+            {SNOOZE_OPTIONS.map((minutes) => (
+              <option key={minutes} value={minutes}>
+                {minutes} minutes
+              </option>
+            ))}
+          </select>
+        </div>
+      </Group>
+
+      <Group label="Answering" hint="What Aide knows when you pick up: the call reason from the invite, plus the thread and project in view.">
+        <label className="flex items-center justify-between gap-3">
+          <span className="text-sm text-foreground">Aide speaks first with the call reason</span>
+          <input
+            type="checkbox"
+            checked={greetFirst}
+            disabled={loading || !incomingCalls}
+            onChange={(event) => void update({ greetFirst: event.target.checked })}
+            className="size-4 shrink-0 accent-primary"
+          />
+        </label>
+      </Group>
+    </div>
+  );
+}
 
 /** A small link that opens a read-only list of Aide's built-in tools. */
 function BuiltInToolsLink() {

--- a/settings-sections.tsx
+++ b/settings-sections.tsx
@@ -307,7 +307,7 @@ export function ModelsSettings() {
  * voice): bump BUILD_STAMP with each iteration so a device can prove which
  * bundle it is actually running — webviews are aggressive JS cachers.
  */
-export const BUILD_STAMP = "ring-v5";
+export const BUILD_STAMP = "ring-v6";
 
 function BuildStamp() {
   return (

--- a/settings-sections.tsx
+++ b/settings-sections.tsx
@@ -311,7 +311,7 @@ export function ModelsSettings() {
  * voice): bump BUILD_STAMP with each iteration so a device can prove which
  * bundle it is actually running — webviews are aggressive JS cachers.
  */
-export const BUILD_STAMP = "ring-v8";
+export const BUILD_STAMP = "ring-v9";
 
 function BuildStamp() {
   return (

--- a/settings-sections.tsx
+++ b/settings-sections.tsx
@@ -311,7 +311,7 @@ export function ModelsSettings() {
  * voice): bump BUILD_STAMP with each iteration so a device can prove which
  * bundle it is actually running — webviews are aggressive JS cachers.
  */
-export const BUILD_STAMP = "ring-v9";
+export const BUILD_STAMP = "ring-v10";
 
 function BuildStamp() {
   return (

--- a/settings-sections.tsx
+++ b/settings-sections.tsx
@@ -261,8 +261,7 @@ export function ModelsSettings() {
 
   return (
     <div className="space-y-4">
-      <CredentialCard />
-      <label className="block space-y-1">
+      <CredentialCard />      <label className="block space-y-1">
         <span className="text-sm font-medium text-foreground">Model</span>
         <select
           value={model}
@@ -298,7 +297,23 @@ export function ModelsSettings() {
           ))}
         </select>
       </label>
+      <BuildStamp />
     </div>
+  );
+}
+
+/**
+ * Visible frontend build marker (Settings → Plugins → Handsfree → Model &
+ * voice): bump BUILD_STAMP with each iteration so a device can prove which
+ * bundle it is actually running — webviews are aggressive JS cachers.
+ */
+export const BUILD_STAMP = "ring-v3";
+
+function BuildStamp() {
+  return (
+    <p className="text-[11px] tabular-nums text-muted-foreground/60" title="Frontend build marker">
+      Build {BUILD_STAMP}
+    </p>
   );
 }
 

--- a/settings-sections.tsx
+++ b/settings-sections.tsx
@@ -307,7 +307,7 @@ export function ModelsSettings() {
  * voice): bump BUILD_STAMP with each iteration so a device can prove which
  * bundle it is actually running — webviews are aggressive JS cachers.
  */
-export const BUILD_STAMP = "ring-v4";
+export const BUILD_STAMP = "ring-v5";
 
 function BuildStamp() {
   return (

--- a/settings-sections.tsx
+++ b/settings-sections.tsx
@@ -311,7 +311,7 @@ export function ModelsSettings() {
  * voice): bump BUILD_STAMP with each iteration so a device can prove which
  * bundle it is actually running — webviews are aggressive JS cachers.
  */
-export const BUILD_STAMP = "ring-v7";
+export const BUILD_STAMP = "ring-v8";
 
 function BuildStamp() {
   return (

--- a/voice-agent.test.ts
+++ b/voice-agent.test.ts
@@ -328,3 +328,100 @@ test("stopping during the SDP exchange closes the mic and cancels startup", asyn
     else delete (globalThis as { Audio?: unknown }).Audio;
   }
 });
+
+test("accepting an invite greets first with the call reason on open", async () => {
+  const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  const originalPeerConnection = Object.getOwnPropertyDescriptor(globalThis, "RTCPeerConnection");
+  const originalAudio = Object.getOwnPropertyDescriptor(globalThis, "Audio");
+  const track = { enabled: true, muted: false, readyState: "live", stop() {}, onmute: null, onunmute: null, onended: null };
+  const stream = { getTracks: () => [track], getAudioTracks: () => [track] } as unknown as MediaStream;
+  const sent: string[] = [];
+  let dc: { readyState: string; send(message: string): void; close(): void; onopen: (() => void) | null; onclose: (() => void) | null; onmessage: ((message: unknown) => void) | null } | null = null;
+
+  class FakePeerConnection {
+    iceGatheringState = "complete";
+    connectionState = "new";
+    localDescription: RTCSessionDescriptionInit | null = null;
+    ontrack: ((event: RTCTrackEvent) => void) | null = null;
+    onconnectionstatechange: (() => void) | null = null;
+    oniceconnectionstatechange: (() => void) | null = null;
+    addTrack() {}
+    addEventListener() {}
+    removeEventListener() {}
+    close() {}
+    createDataChannel() {
+      dc = {
+        readyState: "open",
+        send: (message: string) => sent.push(message),
+        close() {},
+        onopen: null,
+        onclose: null,
+        onmessage: null,
+      };
+      return dc;
+    }
+    async createOffer() {
+      return { type: "offer" as const, sdp: "offer" };
+    }
+    async setLocalDescription(description: RTCSessionDescriptionInit) {
+      this.localDescription = description;
+    }
+    async setRemoteDescription() {}
+  }
+
+  class FakeAudio {
+    autoplay = false;
+    srcObject: MediaStream | null = null;
+    async play() {}
+    remove() {}
+  }
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+      mediaDevices: {
+        getUserMedia: async () => stream,
+        enumerateDevices: async () => [{ deviceId: "mic-1", kind: "audioinput", label: "Built-in Mic" }],
+      },
+    },
+  });
+  Object.defineProperty(globalThis, "RTCPeerConnection", { configurable: true, value: FakePeerConnection });
+  Object.defineProperty(globalThis, "Audio", { configurable: true, value: FakeAudio });
+
+  const agent = new VoiceAgent();
+  agent.bind({
+    rpc: { call: (async (method: string) => (method === "createCall" ? { sdp: "answer" } : { ok: true })) as never },
+    context: { threadId: null, projectId: null, onNewThreadScreen: false },
+    openNewThread() {},
+  });
+
+  try {
+    agent.acceptInvite("Morning brief", "Plan the day");
+    // Read through a call so control-flow narrowing (from the loop's !dc
+    // check) can't pin the variable to null.
+    const currentDc = () => dc;
+    for (let i = 0; i < 20 && !currentDc(); i++) await new Promise((resolve) => setImmediate(resolve));
+    const channel = currentDc();
+    assert.ok(channel, "expected the data channel to be created");
+    channel.onopen?.();
+    assert.equal(agent.getState(), "live");
+    assert.equal(sent.length, 2);
+    const greeting = JSON.parse(sent[0]);
+    assert.equal(greeting.type, "conversation.item.create");
+    assert.equal(greeting.item.role, "system");
+    assert.match(greeting.item.content[0].text, /Morning brief/);
+    assert.match(greeting.item.content[0].text, /Plan the day/);
+    assert.deepEqual(JSON.parse(sent[1]), { type: "response.create" });
+    // A later open must not greet again.
+    channel.onopen?.();
+    assert.equal(sent.length, 2);
+  } finally {
+    agent.stop();
+    if (originalNavigator) Object.defineProperty(globalThis, "navigator", originalNavigator);
+    else delete (globalThis as { navigator?: unknown }).navigator;
+    if (originalPeerConnection) Object.defineProperty(globalThis, "RTCPeerConnection", originalPeerConnection);
+    else delete (globalThis as { RTCPeerConnection?: unknown }).RTCPeerConnection;
+    if (originalAudio) Object.defineProperty(globalThis, "Audio", originalAudio);
+    else delete (globalThis as { Audio?: unknown }).Audio;
+  }
+});

--- a/voice-agent.test.ts
+++ b/voice-agent.test.ts
@@ -525,3 +525,90 @@ test("a greeting owed to a call that never goes live is dropped, not reused", as
     else delete (globalThis as { Audio?: unknown }).Audio;
   }
 });
+
+test("accepting with greet off starts a normal session that waits for the user", async () => {
+  const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  const originalPeerConnection = Object.getOwnPropertyDescriptor(globalThis, "RTCPeerConnection");
+  const originalAudio = Object.getOwnPropertyDescriptor(globalThis, "Audio");
+  const track = { enabled: true, muted: false, readyState: "live", stop() {}, onmute: null, onunmute: null, onended: null };
+  const stream = { getTracks: () => [track], getAudioTracks: () => [track] } as unknown as MediaStream;
+  const sent: string[] = [];
+  const dcs: { readyState: string; send(message: string): void; close(): void; onopen: (() => void) | null; onclose: (() => void) | null; onmessage: ((message: unknown) => void) | null }[] = [];
+
+  class FakePeerConnection {
+    iceGatheringState = "complete";
+    connectionState = "new";
+    localDescription: RTCSessionDescriptionInit | null = null;
+    ontrack: ((event: RTCTrackEvent) => void) | null = null;
+    onconnectionstatechange: (() => void) | null = null;
+    oniceconnectionstatechange: (() => void) | null = null;
+    addTrack() {}
+    addEventListener() {}
+    removeEventListener() {}
+    close() {}
+    createDataChannel() {
+      const dc = {
+        readyState: "open",
+        send: (message: string) => sent.push(message),
+        close() {},
+        onopen: null,
+        onclose: null,
+        onmessage: null,
+      };
+      dcs.push(dc);
+      return dc;
+    }
+    async createOffer() {
+      return { type: "offer" as const, sdp: "offer" };
+    }
+    async setLocalDescription(description: RTCSessionDescriptionInit) {
+      this.localDescription = description;
+    }
+    async setRemoteDescription() {}
+  }
+
+  class FakeAudio {
+    autoplay = false;
+    srcObject: MediaStream | null = null;
+    async play() {}
+    remove() {}
+  }
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+      mediaDevices: {
+        getUserMedia: async () => stream,
+        enumerateDevices: async () => [{ deviceId: "mic-1", kind: "audioinput", label: "Built-in Mic" }],
+      },
+    },
+  });
+  Object.defineProperty(globalThis, "RTCPeerConnection", { configurable: true, value: FakePeerConnection });
+  Object.defineProperty(globalThis, "Audio", { configurable: true, value: FakeAudio });
+
+  const agent = new VoiceAgent();
+  agent.bind({
+    rpc: { call: (async (method: string) => (method === "createCall" ? { sdp: "answer" } : { ok: true })) as never },
+    context: { threadId: null, projectId: null, onNewThreadScreen: false },
+    openNewThread() {},
+  });
+
+  try {
+    agent.acceptInvite("Quiet brief", "no greeting please", { greet: false });
+    const currentDc = () => dcs[dcs.length - 1] ?? null;
+    for (let i = 0; i < 20 && !currentDc(); i++) await new Promise((resolve) => setImmediate(resolve));
+    const channel = currentDc();
+    assert.ok(channel, "expected the data channel to be created");
+    channel.onopen?.();
+    assert.equal(agent.getState(), "live");
+    assert.equal(sent.length, 0);
+  } finally {
+    agent.stop();
+    if (originalNavigator) Object.defineProperty(globalThis, "navigator", originalNavigator);
+    else delete (globalThis as { navigator?: unknown }).navigator;
+    if (originalPeerConnection) Object.defineProperty(globalThis, "RTCPeerConnection", originalPeerConnection);
+    else delete (globalThis as { RTCPeerConnection?: unknown }).RTCPeerConnection;
+    if (originalAudio) Object.defineProperty(globalThis, "Audio", originalAudio);
+    else delete (globalThis as { Audio?: unknown }).Audio;
+  }
+});

--- a/voice-agent.test.ts
+++ b/voice-agent.test.ts
@@ -425,3 +425,103 @@ test("accepting an invite greets first with the call reason on open", async () =
     else delete (globalThis as { Audio?: unknown }).Audio;
   }
 });
+
+test("a greeting owed to a call that never goes live is dropped, not reused", async () => {
+  const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  const originalPeerConnection = Object.getOwnPropertyDescriptor(globalThis, "RTCPeerConnection");
+  const originalAudio = Object.getOwnPropertyDescriptor(globalThis, "Audio");
+  let micAvailable = false;
+  const track = { enabled: true, muted: false, readyState: "live", stop() {}, onmute: null, onunmute: null, onended: null };
+  const stream = { getTracks: () => [track], getAudioTracks: () => [track] } as unknown as MediaStream;
+  const sent: string[] = [];
+  const dcs: { readyState: string; send(message: string): void; close(): void; onopen: (() => void) | null; onclose: (() => void) | null; onmessage: ((message: unknown) => void) | null }[] = [];
+
+  class FakePeerConnection {
+    iceGatheringState = "complete";
+    connectionState = "new";
+    localDescription: RTCSessionDescriptionInit | null = null;
+    ontrack: ((event: RTCTrackEvent) => void) | null = null;
+    onconnectionstatechange: (() => void) | null = null;
+    oniceconnectionstatechange: (() => void) | null = null;
+    addTrack() {}
+    addEventListener() {}
+    removeEventListener() {}
+    close() {}
+    createDataChannel() {
+      const dc = {
+        readyState: "open",
+        send: (message: string) => sent.push(message),
+        close() {},
+        onopen: null,
+        onclose: null,
+        onmessage: null,
+      };
+      dcs.push(dc);
+      return dc;
+    }
+    async createOffer() {
+      return { type: "offer" as const, sdp: "offer" };
+    }
+    async setLocalDescription(description: RTCSessionDescriptionInit) {
+      this.localDescription = description;
+    }
+    async setRemoteDescription() {}
+  }
+
+  class FakeAudio {
+    autoplay = false;
+    srcObject: MediaStream | null = null;
+    async play() {}
+    remove() {}
+  }
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+      mediaDevices: {
+        getUserMedia: async () => {
+          if (!micAvailable) throw new DOMException("Permission denied", "NotAllowedError");
+          return stream;
+        },
+        enumerateDevices: async () => [{ deviceId: "mic-1", kind: "audioinput", label: "Built-in Mic" }],
+      },
+    },
+  });
+  Object.defineProperty(globalThis, "RTCPeerConnection", { configurable: true, value: FakePeerConnection });
+  Object.defineProperty(globalThis, "Audio", { configurable: true, value: FakeAudio });
+
+  const agent = new VoiceAgent();
+  agent.bind({
+    rpc: { call: (async (method: string) => (method === "createCall" ? { sdp: "answer" } : { ok: true })) as never },
+    context: { threadId: null, projectId: null, onNewThreadScreen: false },
+    openNewThread() {},
+  });
+  const settled = () => new Promise((resolve) => setImmediate(resolve));
+
+  try {
+    // First accept: mic denied, call never goes live — nothing may be sent.
+    agent.acceptInvite("Stale brief", "should never be greeted");
+    for (let i = 0; i < 20 && agent.getState() !== "idle"; i++) await settled();
+    assert.equal(agent.getState(), "idle");
+    assert.equal(sent.length, 0);
+    // Second accept with the mic back: only the fresh reason is greeted.
+    micAvailable = true;
+    agent.acceptInvite("Fresh brief", "greet this one");
+    const currentDc = () => dcs[dcs.length - 1] ?? null;
+    for (let i = 0; i < 20 && !currentDc(); i++) await settled();
+    const channel = currentDc();
+    assert.ok(channel, "expected the data channel to be created");
+    channel.onopen?.();
+    assert.equal(sent.length, 2);
+    assert.match(JSON.parse(sent[0]).item.content[0].text, /Fresh brief/);
+    assert.doesNotMatch(JSON.stringify(sent), /Stale brief/);
+  } finally {
+    agent.stop();
+    if (originalNavigator) Object.defineProperty(globalThis, "navigator", originalNavigator);
+    else delete (globalThis as { navigator?: unknown }).navigator;
+    if (originalPeerConnection) Object.defineProperty(globalThis, "RTCPeerConnection", originalPeerConnection);
+    else delete (globalThis as { RTCPeerConnection?: unknown }).RTCPeerConnection;
+    if (originalAudio) Object.defineProperty(globalThis, "Audio", originalAudio);
+    else delete (globalThis as { Audio?: unknown }).Audio;
+  }
+});

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -194,7 +194,7 @@ export class VoiceAgent {
    * the data channel opens so Aide greets first with the call's reason.
    * Cleared by stop() — a call that never goes live owes no greeting.
    */
-  private pendingInviteGreeting: { title: string; briefing: string } | null = null;
+  private pendingInviteGreeting: { title: string; briefing: string; greet: boolean } | null = null;
   // ---- thread-event notifications (see server: `notifications` setting) ----
   /** Pending thread events, deduped per thread; latest state wins. */
   private pendingNotices = new Map<string, ThreadEventNotice>();
@@ -531,13 +531,15 @@ export class VoiceAgent {
   /**
    * Accept an incoming call invite: starts like toggleFromSurface, but carries
    * the call's reason along so Aide speaks first on open (see greetIfInvited)
-   * instead of waiting for the user.
+   * instead of waiting for the user. Pass `{ greet: false }` (the "Aide
+   * speaks first" setting off) to start a normal session that waits for the
+   * user instead.
    */
-  acceptInvite(title: string, briefing: string) {
+  acceptInvite(title: string, briefing: string, opts?: { greet?: boolean }) {
     if (this.hasLocalCall()) return this.toggle();
     const remote = this.remotePresenceLive();
     if (remote) return this.stopRemote(remote.nonce);
-    this.pendingInviteGreeting = { title, briefing };
+    this.pendingInviteGreeting = { title, briefing, greet: opts?.greet ?? true };
     void this.start();
   }
 
@@ -928,15 +930,16 @@ export class VoiceAgent {
   }
 
   /**
-   * If this call was accepted from an incoming invite, Aide speaks first:
-   * the call's reason goes in as a system instruction and a response is
-   * requested immediately, instead of waiting for the user to talk. Consumed
-   * once — a later reconnect in the same session must not re-greet.
+   * If this call was accepted from an incoming invite (and greeting is on),
+   * Aide speaks first: the call's reason goes in as a system instruction and
+   * a response is requested immediately, instead of waiting for the user to
+   * talk. Consumed once — a later reconnect in the same session must not
+   * re-greet.
    */
   private greetIfInvited(dc: RTCDataChannel) {
     const invite = this.pendingInviteGreeting;
     this.pendingInviteGreeting = null;
-    if (!invite || dc.readyState !== "open") return;
+    if (!invite || !invite.greet || dc.readyState !== "open") return;
     const reason = invite.briefing ? ` — ${invite.briefing}` : "";
     this.log("invite.greet", { title: invite.title });
     dc.send(

--- a/voice-agent.ts
+++ b/voice-agent.ts
@@ -189,6 +189,12 @@ export class VoiceAgent {
   private responseActive = false;
   /** A response.create is owed once the active response finishes. */
   private responsePending = false;
+  /**
+   * The invite this call was accepted from (see acceptInvite), consumed when
+   * the data channel opens so Aide greets first with the call's reason.
+   * Cleared by stop() — a call that never goes live owes no greeting.
+   */
+  private pendingInviteGreeting: { title: string; briefing: string } | null = null;
   // ---- thread-event notifications (see server: `notifications` setting) ----
   /** Pending thread events, deduped per thread; latest state wins. */
   private pendingNotices = new Map<string, ThreadEventNotice>();
@@ -519,6 +525,19 @@ export class VoiceAgent {
     if (this.hasLocalCall()) return this.toggle();
     const remote = this.remotePresenceLive();
     if (remote) return this.stopRemote(remote.nonce);
+    void this.start();
+  }
+
+  /**
+   * Accept an incoming call invite: starts like toggleFromSurface, but carries
+   * the call's reason along so Aide speaks first on open (see greetIfInvited)
+   * instead of waiting for the user.
+   */
+  acceptInvite(title: string, briefing: string) {
+    if (this.hasLocalCall()) return this.toggle();
+    const remote = this.remotePresenceLive();
+    if (remote) return this.stopRemote(remote.nonce);
+    this.pendingInviteGreeting = { title, briefing };
     void this.start();
   }
 
@@ -908,6 +927,36 @@ export class VoiceAgent {
     dc.send(JSON.stringify({ type: "response.create" }));
   }
 
+  /**
+   * If this call was accepted from an incoming invite, Aide speaks first:
+   * the call's reason goes in as a system instruction and a response is
+   * requested immediately, instead of waiting for the user to talk. Consumed
+   * once — a later reconnect in the same session must not re-greet.
+   */
+  private greetIfInvited(dc: RTCDataChannel) {
+    const invite = this.pendingInviteGreeting;
+    this.pendingInviteGreeting = null;
+    if (!invite || dc.readyState !== "open") return;
+    const reason = invite.briefing ? ` — ${invite.briefing}` : "";
+    this.log("invite.greet", { title: invite.title });
+    dc.send(
+      JSON.stringify({
+        type: "conversation.item.create",
+        item: {
+          type: "message",
+          role: "system",
+          content: [
+            {
+              type: "input_text",
+              text: `[bb incoming call] You placed this call ("${invite.title}"${reason}) and the user just accepted. Greet them in one short sentence and open the topic directly — do not wait for them to speak first and do not ask "how can I help". Ground everything in the call reason above; reach for your tools when you need live facts.`,
+            },
+          ],
+        },
+      }),
+    );
+    this.requestResponse(dc);
+  }
+
   stop() {
     const endedNonce = this.nonce;
     if (this.session) this.log("session.stopped");
@@ -921,6 +970,7 @@ export class VoiceAgent {
     this.setResponseActive(false);
     this.setAssistantSpeaking(false);
     this.responsePending = false;
+    this.pendingInviteGreeting = null;
     this.pendingNotices.clear();
     this.recentNoticeFingerprints.clear();
     if (this.noticeTimer) clearTimeout(this.noticeTimer);
@@ -1204,6 +1254,7 @@ export class VoiceAgent {
           this.startPresenceHeartbeat();
           this.log("session.live");
           this.logDiag("conn.dc.open");
+          this.greetIfInvited(dc);
         }
       };
       dc.onclose = () => this.logDiag("conn.dc.close");

--- a/voice-invite.test.ts
+++ b/voice-invite.test.ts
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { inviteStore } from "./voice-invite.ts";
+
+function invite(overrides = {}) {
+  const now = Date.now();
+  return {
+    inviteId: "inv-test-1",
+    title: "Morning brief",
+    briefing: "Plan the day",
+    createdAt: now,
+    expiresAt: now + 60_000,
+    ...overrides,
+  };
+}
+
+test("ingests a valid invite and dismisses it", () => {
+  try {
+    assert.equal(inviteStore.getSnapshot(), null);
+    assert.equal(inviteStore.ingestInvite(invite()), true);
+    assert.equal(inviteStore.getSnapshot()?.title, "Morning brief");
+    inviteStore.dismiss();
+    assert.equal(inviteStore.getSnapshot(), null);
+  } finally {
+    inviteStore.reset();
+  }
+});
+
+test("ignores malformed and already-expired invites", () => {
+  try {
+    assert.equal(inviteStore.ingestInvite(null), false);
+    assert.equal(inviteStore.ingestInvite({ inviteId: "x" }), false);
+    assert.equal(inviteStore.ingestInvite(invite({ expiresAt: Date.now() - 1000 })), false);
+    assert.equal(inviteStore.getSnapshot(), null);
+  } finally {
+    inviteStore.reset();
+  }
+});
+
+test("the latest invite replaces a ringing one and expiry goes quiet", async () => {
+  try {
+    assert.equal(inviteStore.ingestInvite(invite({ inviteId: "inv-1" })), true);
+    assert.equal(inviteStore.ingestInvite(invite({ inviteId: "inv-2" })), true);
+    assert.equal(inviteStore.getSnapshot()?.inviteId, "inv-2");
+    assert.equal(inviteStore.ingestInvite(invite({ inviteId: "inv-3", expiresAt: Date.now() + 30 })), true);
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    assert.equal(inviteStore.getSnapshot(), null);
+  } finally {
+    inviteStore.reset();
+  }
+});
+
+test("snooze hides the invite and rings again shortly after", async () => {
+  try {
+    assert.equal(inviteStore.ingestInvite(invite()), true);
+    inviteStore.snooze(0.001); // ~60ms
+    assert.equal(inviteStore.getSnapshot(), null);
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    assert.equal(inviteStore.getSnapshot()?.inviteId, "inv-test-1");
+  } finally {
+    inviteStore.reset();
+  }
+});

--- a/voice-invite.test.ts
+++ b/voice-invite.test.ts
@@ -61,3 +61,26 @@ test("snooze hides the invite and rings again shortly after", async () => {
     inviteStore.reset();
   }
 });
+
+test("resolveInvite drops only the matching invite, including a snoozed one", async () => {
+  const ringing = () => inviteStore.getSnapshot()?.inviteId ?? null;
+  try {
+    assert.equal(inviteStore.ingestInvite(invite({ inviteId: "inv-a" })), true);
+    assert.equal(inviteStore.resolveInvite("inv-other"), false);
+    assert.equal(ringing(), "inv-a");
+    inviteStore.snooze(0.001); // ~60ms; re-ring pending
+    assert.equal(ringing(), null);
+    // Answered elsewhere while snoozed: the re-ring must never arrive.
+    assert.equal(inviteStore.resolveInvite("inv-a"), true);
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    assert.equal(ringing(), null);
+    // A newer ring after the resolve is unaffected.
+    assert.equal(inviteStore.ingestInvite(invite({ inviteId: "inv-b" })), true);
+    assert.equal(inviteStore.resolveInvite("inv-a"), false);
+    assert.equal(ringing(), "inv-b");
+    assert.equal(inviteStore.resolveInvite("inv-b"), true);
+    assert.equal(ringing(), null);
+  } finally {
+    inviteStore.reset();
+  }
+});

--- a/voice-invite.ts
+++ b/voice-invite.ts
@@ -1,0 +1,125 @@
+// Tier-0 autonomous invocation ("the call"): the server publishes a
+// `voice-invite` when an automation (or `bb handsfree ring`) wants to talk.
+// Every connected surface rings until the user accepts, snoozes, dismisses,
+// or the invite expires. Accepting is the user gesture that lets mic capture
+// and audio playback succeed — the server never starts audio itself.
+//
+// The human is the arbiter here, so no mic-busy / idle detection is needed:
+// in a meeting, just snooze or ignore it and it goes away on its own.
+
+export interface VoiceInvite {
+  inviteId: string;
+  title: string;
+  briefing: string;
+  createdAt: number;
+  expiresAt: number;
+}
+
+export const INVITE_CHANNEL = "voice-invite";
+/** How long a re-shown (snoozed) invite rings before expiring on its own. */
+export const RESHOW_TTL_MS = 60_000;
+export const DEFAULT_SNOOZE_MINUTES = 10;
+
+const listeners = new Set<() => void>();
+let current: VoiceInvite | null = null;
+let expiryTimer: ReturnType<typeof setTimeout> | null = null;
+let snoozeTimer: ReturnType<typeof setTimeout> | null = null;
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+function clearExpiry() {
+  if (expiryTimer) clearTimeout(expiryTimer);
+  expiryTimer = null;
+}
+
+function clearSnooze() {
+  if (snoozeTimer) clearTimeout(snoozeTimer);
+  snoozeTimer = null;
+}
+
+function armExpiry() {
+  clearExpiry();
+  if (!current) return;
+  const delay = current.expiresAt - Date.now();
+  if (delay <= 0) {
+    current = null;
+    emit();
+    return;
+  }
+  expiryTimer = setTimeout(() => {
+    expiryTimer = null;
+    current = null;
+    emit();
+  }, delay);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/** Latest invite wins; an already-ringing invite is replaced, not stacked. */
+export const inviteStore = {
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+
+  getSnapshot(): VoiceInvite | null {
+    return current;
+  },
+
+  /** Returns true when the payload was a live invite worth ringing for. */
+  ingestInvite(payload: unknown): boolean {
+    if (!isRecord(payload)) return false;
+    const { inviteId, title, briefing, createdAt, expiresAt } = payload;
+    if (typeof inviteId !== "string" || !inviteId) return false;
+    if (typeof title !== "string" || !title) return false;
+    if (typeof expiresAt !== "number" || expiresAt <= Date.now()) return false;
+    clearSnooze();
+    current = {
+      inviteId,
+      title,
+      briefing: typeof briefing === "string" ? briefing : "",
+      createdAt: typeof createdAt === "number" ? createdAt : Date.now(),
+      expiresAt,
+    };
+    armExpiry();
+    emit();
+    return true;
+  },
+
+  dismiss() {
+    clearExpiry();
+    clearSnooze();
+    if (current === null) return;
+    current = null;
+    emit();
+  },
+
+  /** Hide now, ring again in `minutes`. A pending snooze replaces any other. */
+  snooze(minutes: number = DEFAULT_SNOOZE_MINUTES) {
+    const invite = current;
+    if (!invite) return;
+    clearExpiry();
+    clearSnooze();
+    current = null;
+    emit();
+    const delayMs = Math.max(0, minutes) * 60_000;
+    snoozeTimer = setTimeout(() => {
+      snoozeTimer = null;
+      if (current) return; // a newer invite arrived while snoozed — keep it
+      current = { ...invite, expiresAt: Math.max(invite.expiresAt, Date.now() + RESHOW_TTL_MS) };
+      armExpiry();
+      emit();
+    }, delayMs);
+  },
+
+  /** Test-only: drop all state and timers. */
+  reset() {
+    clearExpiry();
+    clearSnooze();
+    current = null;
+  },
+};

--- a/voice-invite.ts
+++ b/voice-invite.ts
@@ -16,12 +16,16 @@ export interface VoiceInvite {
 }
 
 export const INVITE_CHANNEL = "voice-invite";
+/** Broadcast when any surface answers/dismisses; all others drop the invite. */
+export const INVITE_RESOLVED_CHANNEL = "voice-invite-resolved";
 /** How long a re-shown (snoozed) invite rings before expiring on its own. */
 export const RESHOW_TTL_MS = 60_000;
 export const DEFAULT_SNOOZE_MINUTES = 10;
 
 const listeners = new Set<() => void>();
 let current: VoiceInvite | null = null;
+/** Snoozed invite waiting to re-ring; cancelled if another surface resolves it. */
+let snoozed: VoiceInvite | null = null;
 let expiryTimer: ReturnType<typeof setTimeout> | null = null;
 let snoozeTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -93,27 +97,55 @@ export const inviteStore = {
   dismiss() {
     clearExpiry();
     clearSnooze();
+    snoozed = null;
     if (current === null) return;
     current = null;
     emit();
   },
 
-  /** Hide now, ring again in `minutes`. A pending snooze replaces any other. */
+  /** Hide now, ring again in `minutes`. Snooze is local to this surface; an
+   * answer/dismiss from anywhere (see resolveInvite) still wins everywhere. */
   snooze(minutes: number = DEFAULT_SNOOZE_MINUTES) {
     const invite = current;
     if (!invite) return;
     clearExpiry();
     clearSnooze();
     current = null;
+    snoozed = invite;
     emit();
     const delayMs = Math.max(0, minutes) * 60_000;
     snoozeTimer = setTimeout(() => {
       snoozeTimer = null;
-      if (current) return; // a newer invite arrived while snoozed — keep it
-      current = { ...invite, expiresAt: Math.max(invite.expiresAt, Date.now() + RESHOW_TTL_MS) };
+      const pending = snoozed;
+      snoozed = null;
+      if (!pending || current) return; // resolved elsewhere, or a newer invite arrived
+      current = { ...pending, expiresAt: Math.max(pending.expiresAt, Date.now() + RESHOW_TTL_MS) };
       armExpiry();
       emit();
     }, delayMs);
+  },
+
+  /**
+   * Drop an invite answered/dismissed on any surface (via the server's
+   * `voice-invite-resolved` broadcast). Only the matching invite is
+   * affected — a newer ring is never collateral. Returns true when
+   * something was actually cleared.
+   */
+  resolveInvite(inviteId: unknown): boolean {
+    if (typeof inviteId !== "string" || !inviteId) return false;
+    let changed = false;
+    if (current?.inviteId === inviteId) {
+      clearExpiry();
+      current = null;
+      changed = true;
+    }
+    if (snoozed?.inviteId === inviteId) {
+      clearSnooze();
+      snoozed = null;
+      changed = true;
+    }
+    if (changed) emit();
+    return changed;
   },
 
   /** Test-only: drop all state and timers. */
@@ -121,5 +153,6 @@ export const inviteStore = {
     clearExpiry();
     clearSnooze();
     current = null;
+    snoozed = null;
   },
 };

--- a/voice-invite.ts
+++ b/voice-invite.ts
@@ -82,6 +82,7 @@ export const inviteStore = {
     if (typeof title !== "string" || !title) return false;
     if (typeof expiresAt !== "number" || expiresAt <= Date.now()) return false;
     clearSnooze();
+    snoozed = null; // a new ring replaces any pending re-ring, not just its timer
     current = {
       inviteId,
       title,
@@ -154,5 +155,6 @@ export const inviteStore = {
     clearSnooze();
     current = null;
     snoozed = null;
+    emit();
   },
 };

--- a/voice-invite.tsx
+++ b/voice-invite.tsx
@@ -93,6 +93,7 @@ function InviteBody({ onAccept, onDismiss }: { onAccept: () => void; onDismiss: 
         <button
           type="button"
           onClick={onAccept}
+          autoFocus
           className="flex-1 rounded-full bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
         >
           Accept
@@ -165,8 +166,18 @@ export function GlobalInviteOverlay() {
   const [accepted, setAccepted] = useState<{ inviteId: string; title: string } | null>(null);
   useRingtone(!!invite && !inCall && !mobile);
   useEffect(() => {
-    if (invite && inCall) inviteStore.dismiss();
-  }, [invite, inCall]);
+    // A call went live while this invite was still ringing here (started
+    // manually mid-ring, or accepted on a surface whose resolve hasn't
+    // arrived yet): stand down locally and tell the rest to do the same.
+    // The normal accept path already dismissed + resolved, so this is a no-op
+    // there (invite is null by the time the call goes live).
+    if (invite && inCall) {
+      inviteStore.dismiss();
+      void rpc
+        .call("resolveInvite", { inviteId: invite.inviteId, action: "dismissed" })
+        .catch(() => undefined);
+    }
+  }, [invite, inCall, rpc]);
   useEffect(() => {
     if (state === "idle") setAccepted(null);
   }, [state]);
@@ -180,7 +191,12 @@ export function GlobalInviteOverlay() {
       .catch(() => undefined);
   };
   const accept = () => {
-    if (!invite) return;
+    // Re-check at click time: a call may have started in the beat between
+    // render and click, and acceptInvite would otherwise stop that live call.
+    if (!invite || voiceAgent.getState() !== "idle") {
+      inviteStore.dismiss();
+      return;
+    }
     setAccepted({ inviteId: invite.inviteId, title: invite.title });
     inviteStore.dismiss();
     resolve("answered");
@@ -194,6 +210,9 @@ export function GlobalInviteOverlay() {
     <div
       role="alertdialog"
       aria-label={invite ? `Incoming call: ${invite.title}` : `On call: ${accepted?.title ?? "Aide"}`}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") dismiss();
+      }}
       className={cn(
         "fixed right-4 top-4 z-50 w-80 max-w-[calc(100vw-2rem)]",
         "rounded-xl border border-primary/40 bg-card p-3.5 shadow-xl",

--- a/voice-invite.tsx
+++ b/voice-invite.tsx
@@ -13,7 +13,7 @@ import { toast } from "sonner";
 import type { rpcContract } from "./server";
 import { clientDescriptor } from "./client-identity";
 import { voiceAgent } from "./voice-agent";
-import { LiveCallControls } from "./voice-chrome";
+import { LiveCallControls, useCallElapsed } from "./voice-chrome";
 import {
   DEFAULT_SNOOZE_MINUTES,
   INVITE_CHANNEL,
@@ -218,6 +218,10 @@ export function GlobalInviteOverlay() {
   // Accepting from a page with no voice UI of its own never strands the call
   // without controls. Cleared when the call ends.
   const [accepted, setAccepted] = useState<{ inviteId: string; title: string } | null>(null);
+  // Mini-chip policy (option C): after Accept this surface keeps only a small
+  // floating chip (presence + elapsed); tap to expand full controls. Quiet
+  // next to the composer pill and console, sufficient where nothing else is.
+  const [expanded, setExpanded] = useState(false);
   // prefsLoaded gates the ring (never ring on unconfirmed defaults when the
   // user disabled calls), but never the live-call card: controls for a call
   // you already accepted must not vanish on a slow backend.
@@ -239,7 +243,10 @@ export function GlobalInviteOverlay() {
     }
   }, [invite, inCall, rpc]);
   useEffect(() => {
-    if (state === "idle") setAccepted(null);
+    if (state === "idle") {
+      setAccepted(null);
+      setExpanded(false);
+    }
   }, [state]);
   if (mobile) return null;
   if (!showInvite && !showLive) return null;
@@ -259,6 +266,7 @@ export function GlobalInviteOverlay() {
       return;
     }
     setAccepted({ inviteId: invite.inviteId, title: invite.title });
+    setExpanded(false); // start as a chip; tap to expand
     inviteStore.dismiss();
     resolve("answered");
     voiceAgent.acceptInvite(invite.title, invite.briefing, { greet: prefs.greetFirst });
@@ -267,12 +275,34 @@ export function GlobalInviteOverlay() {
     inviteStore.dismiss();
     resolve("dismissed");
   };
+  const elapsed = useCallElapsed();
+  const muted = state === "muted";
+  if (!showInvite && showLive && !expanded) {
+    return (
+      <button
+        type="button"
+        onClick={() => setExpanded(true)}
+        title={accepted?.title ? `On call — ${accepted.title}. Show controls.` : "On call. Show controls."}
+        aria-label={accepted?.title ? `On call — ${accepted.title}. Show controls.` : "On call. Show controls."}
+        className={cn(
+          "fixed right-4 top-4 z-50 flex items-center gap-1.5",
+          "rounded-full border border-primary/40 bg-card px-3 py-1.5 shadow-xl",
+          "text-xs tabular-nums text-muted-foreground transition-colors hover:text-foreground",
+          muted && "border-destructive/50 text-destructive hover:text-destructive",
+        )}
+      >
+        <span className={cn("size-2 rounded-full", muted ? "bg-destructive" : "bg-primary animate-pulse")} aria-hidden />
+        {muted ? "Muted" : "On call"}
+        {elapsed ? ` · ${elapsed}` : null}
+      </button>
+    );
+  }
   return (
     <div
       role="alertdialog"
-      aria-label={invite ? `Incoming call: ${invite.title}` : `On call: ${accepted?.title ?? "Aide"}`}
+      aria-label={showInvite && invite ? `Incoming call: ${invite.title}` : `On call: ${accepted?.title ?? "Aide"}`}
       onKeyDown={(event) => {
-        if (event.key === "Escape") dismiss();
+        if (event.key === "Escape" && showInvite) dismiss();
       }}
       className={cn(
         "fixed right-4 top-4 z-50 w-80 max-w-[calc(100vw-2rem)]",
@@ -288,6 +318,17 @@ export function GlobalInviteOverlay() {
             <span className="truncate text-xs font-medium uppercase tracking-wide text-muted-foreground">
               On call{accepted?.title ? ` — ${accepted.title}` : ""}
             </span>
+            <button
+              type="button"
+              onClick={() => setExpanded(false)}
+              aria-label="Minimize call controls"
+              title="Minimize"
+              className="ml-auto flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <svg viewBox="0 0 16 16" className="size-3" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" aria-hidden>
+                <path d="M4 10l4-4 4 4" />
+              </svg>
+            </button>
           </div>
           <div className="mt-2.5 flex justify-center">
             <LiveCallControls />

--- a/voice-invite.tsx
+++ b/voice-invite.tsx
@@ -2,7 +2,8 @@
 // `voice-invite` with Accept / Snooze / Dismiss. Accept starts a normal voice
 // session (the click is the user gesture mic + playback need); snooze re-rings
 // locally after N minutes; dismiss or expiry just goes quiet.
-import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import type { HTMLAttributes, PointerEvent as ReactPointerEvent } from "react";
 import {
   experimental_useSidebarThreadActions,
   useBbContext,
@@ -75,16 +76,17 @@ function useRingtone(ringing: boolean) {
     };
   }, [ringing]);
 }
-function InviteBody({ onAccept, onDismiss, snoozeMinutes }: {
+function InviteBody({ onAccept, onDismiss, snoozeMinutes, dragHandleProps }: {
   onAccept: () => void;
   onDismiss: () => void;
   snoozeMinutes: number;
+  dragHandleProps: HTMLAttributes<HTMLDivElement>;
 }) {
   const invite = useSyncExternalStore(inviteStore.subscribe, inviteStore.getSnapshot);
   if (!invite) return null;
   return (
     <div className="w-full">
-      <div className="flex items-center gap-2">
+      <div className="flex cursor-grab touch-none select-none items-center gap-2 active:cursor-grabbing" {...dragHandleProps}>
         <span className="size-2.5 shrink-0 animate-pulse rounded-full bg-primary" aria-hidden />
         <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
           Incoming call
@@ -171,6 +173,77 @@ function useInvitePrefs(): { prefs: InvitePrefs; loaded: boolean } {
   useEffect(refetch, [refetch]);
   useRealtime("config-changed", refetch);
   return { prefs: prefs ?? INVITE_PREF_DEFAULTS, loaded };
+}
+
+/**
+ * Draggable overlay position, persisted per browser. The whole toast follows
+ * a drag from any header; a press without movement still counts as a click
+ * (expand/minimize), told apart by a small movement threshold.
+ */
+const OVERLAY_POS_KEY = "bb-handsfree.invite-pos";
+
+function useOverlayPos() {
+  const [offset, setOffset] = useState<{ x: number; y: number }>(() => {
+    try {
+      const raw = typeof window === "undefined" ? null : window.localStorage.getItem(OVERLAY_POS_KEY);
+      const parsed = raw ? (JSON.parse(raw) as unknown) : null;
+      if (
+        parsed && typeof parsed === "object" &&
+        typeof (parsed as { x?: unknown }).x === "number" &&
+        typeof (parsed as { y?: unknown }).y === "number" &&
+        Math.abs((parsed as { x: number }).x) < 2000 &&
+        Math.abs((parsed as { y: number }).y) < 2000
+      ) {
+        return { x: (parsed as { x: number }).x, y: (parsed as { y: number }).y };
+      }
+    } catch {
+      /* fall through to the default corner */
+    }
+    return { x: 0, y: 0 };
+  });
+  const offsetRef = useRef(offset);
+  offsetRef.current = offset;
+  const drag = useRef<{ px: number; py: number; ox: number; oy: number; moved: boolean } | null>(null);
+  const suppressClick = useRef(false);
+
+  const onPointerDown = (event: ReactPointerEvent) => {
+    if (event.pointerType === "mouse" && event.button !== 0) return;
+    (event.currentTarget as HTMLElement).setPointerCapture?.(event.pointerId);
+    drag.current = { px: event.clientX, py: event.clientY, ox: offsetRef.current.x, oy: offsetRef.current.y, moved: false };
+  };
+  const onPointerMove = (event: ReactPointerEvent) => {
+    const d = drag.current;
+    if (!d) return;
+    const next = { x: Math.round(d.ox + event.clientX - d.px), y: Math.round(d.oy + event.clientY - d.py) };
+    if (Math.abs(next.x - d.ox) + Math.abs(next.y - d.oy) > 4) d.moved = true;
+    if (d.moved) setOffset(next);
+  };
+  const onPointerUp = (event: ReactPointerEvent) => {
+    const d = drag.current;
+    drag.current = null;
+    suppressClick.current = !!d?.moved;
+    if (d?.moved) {
+      const next = { x: Math.round(d.ox + event.clientX - d.px), y: Math.round(d.oy + event.clientY - d.py) };
+      setOffset(next);
+      try {
+        window.localStorage.setItem(OVERLAY_POS_KEY, JSON.stringify(next));
+      } catch {
+        /* position is a nicety */
+      }
+    }
+  };
+  /** False when the press turned into a drag — callers skip their click action. */
+  const clickAllowed = () => {
+    const allowed = !suppressClick.current;
+    suppressClick.current = false;
+    return allowed;
+  };
+  return {
+    offset,
+    dragHandleProps: { onPointerDown, onPointerMove, onPointerUp } as HTMLAttributes<HTMLDivElement>,
+    chipHandleProps: { onPointerDown, onPointerMove, onPointerUp } as HTMLAttributes<HTMLButtonElement>,
+    clickAllowed,
+  };
 }
 
 /**
@@ -280,15 +353,23 @@ export function GlobalInviteOverlay() {
     inviteStore.dismiss();
     resolve("dismissed");
   };
+  const { offset, dragHandleProps, chipHandleProps, clickAllowed } = useOverlayPos();
+  // Inline z-index (not a class): side panels and drawers have beaten the
+  // themed z-50 scale before, and a ringing phone must win stacking fights.
+  const frameStyle = { top: 16, right: 16, transform: `translate(${offset.x}px, ${offset.y}px)`, zIndex: 100 } as const;
   if (!showInvite && showLive && !expanded) {
     return (
       <button
         type="button"
-        onClick={() => setExpanded(true)}
+        onClick={() => {
+          if (clickAllowed()) setExpanded(true);
+        }}
+        {...chipHandleProps}
         title={accepted?.title ? `On call — ${accepted.title}. Show controls.` : "On call. Show controls."}
         aria-label={accepted?.title ? `On call — ${accepted.title}. Show controls.` : "On call. Show controls."}
+        style={frameStyle}
         className={cn(
-          "fixed right-4 top-4 z-50 flex items-center gap-1.5",
+          "fixed flex cursor-grab touch-none select-none items-center gap-1.5 active:cursor-grabbing",
           "rounded-full border border-primary/40 bg-card px-3 py-1.5 shadow-xl",
           "text-xs tabular-nums text-muted-foreground transition-colors hover:text-foreground",
           muted && "border-destructive/50 text-destructive hover:text-destructive",
@@ -307,33 +388,35 @@ export function GlobalInviteOverlay() {
       onKeyDown={(event) => {
         if (event.key === "Escape" && showInvite) dismiss();
       }}
-      className={cn(
-        "fixed right-4 top-4 z-50 w-80 max-w-[calc(100vw-2rem)]",
-        "rounded-xl border border-primary/40 bg-card p-3.5 shadow-xl",
-      )}
+      style={frameStyle}
+      className="fixed w-80 max-w-[calc(100vw-2rem)] rounded-xl border border-primary/40 bg-card p-3.5 shadow-xl"
     >
       {showInvite && invite ? (
-        <InviteBody onAccept={accept} onDismiss={dismiss} snoozeMinutes={prefs.snoozeMinutes} />
+        <InviteBody onAccept={accept} onDismiss={dismiss} snoozeMinutes={prefs.snoozeMinutes} dragHandleProps={dragHandleProps} />
       ) : (
+        // Bare controls, no box-in-box: the LiveCallControls pill already
+        // carries its own chrome. The header drags and minimizes on click —
+        // a whole row beats a 12px chevron next to stacked panels.
         <div className="w-full">
-          <div className="flex items-center gap-2">
+          <div
+            className="flex cursor-grab touch-none select-none items-center gap-2 rounded-md px-1 py-0.5 transition-colors hover:bg-accent active:cursor-grabbing"
+            onClick={() => {
+              if (clickAllowed()) setExpanded(false);
+            }}
+            title="Minimize call controls"
+            {...dragHandleProps}
+          >
             <span className="size-2.5 shrink-0 rounded-full bg-primary" aria-hidden />
             <span className="truncate text-xs font-medium uppercase tracking-wide text-muted-foreground">
               On call{accepted?.title ? ` — ${accepted.title}` : ""}
             </span>
-            <button
-              type="button"
-              onClick={() => setExpanded(false)}
-              aria-label="Minimize call controls"
-              title="Minimize"
-              className="ml-auto flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-            >
+            <span className="ml-auto flex size-6 shrink-0 items-center justify-center text-muted-foreground" aria-hidden>
               <svg viewBox="0 0 16 16" className="size-3" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" aria-hidden>
                 <path d="M4 10l4-4 4 4" />
               </svg>
-            </button>
+            </span>
           </div>
-          <div className="mt-2.5 flex justify-center">
+          <div className="mt-2 flex justify-center">
             <LiveCallControls />
           </div>
         </div>

--- a/voice-invite.tsx
+++ b/voice-invite.tsx
@@ -270,7 +270,16 @@ export function GlobalInviteOverlay() {
   const { threadId, projectId } = useBbContext();
   const sidebarActions = experimental_useSidebarThreadActions();
   const { prefs, loaded: prefsLoaded } = useInvitePrefs();
-  useRealtime(INVITE_CHANNEL, (payload) => inviteStore.ingestInvite(payload));
+  // TEMP-DEBUG: remote visibility into overlay lifecycle. Removed before merge.
+  const diag = (kind: string, payload: Record<string, unknown> = {}) => {
+    void rpc.call("logEvent", { sessionId: "invite-diag", kind, payload }).catch(() => undefined);
+  };
+  useEffect(() => {
+    diag("overlay.mounted", { mobile: clientDescriptor.mobile });
+  }, []);
+  useRealtime(INVITE_CHANNEL, (payload) => {
+    diag("invite.received", { ok: inviteStore.ingestInvite(payload) });
+  });
   useRealtime(INVITE_RESOLVED_CHANNEL, (payload) => {
     inviteStore.resolveInvite((payload as { inviteId?: unknown } | null)?.inviteId);
   });
@@ -308,6 +317,19 @@ export function GlobalInviteOverlay() {
   const mayRing = prefsLoaded && prefs.incomingCalls;
   const showInvite = !!invite && !inCall && mayRing;
   const showLive = !!accepted && inCall;
+  // TEMP-DEBUG: reports why a received invite isn't rendering.
+  useEffect(() => {
+    if (invite) {
+      diag("invite.gated", {
+        inviteId: invite.inviteId,
+        inCall,
+        prefsLoaded,
+        incomingCalls: prefs.incomingCalls,
+        mobile,
+        showInvite,
+      });
+    }
+  }, [invite, inCall, prefsLoaded]);
   useRingtone(showInvite && prefs.ringtone);
   useEffect(() => {
     // A call went live while this invite was still ringing here (started
@@ -330,8 +352,10 @@ export function GlobalInviteOverlay() {
   }, [state]);
   // Hooks below run on EVERY render: useCallElapsed must stay above the early
   // returns, or React (fewer-hooks-than-expected) unmounts the overlay and
-  // nothing rings anywhere — the overlay is the only ringer.
+  // nothing rings anywhere — the overlay is the only ringer. Same for
+  // useOverlayPos: its state refs must mount on the very first render.
   const elapsed = useCallElapsed();
+  const { offset, dragHandleProps, chipHandleProps, clickAllowed } = useOverlayPos();
   const muted = state === "muted";
   if (mobile) return null;
   if (!showInvite && !showLive) return null;
@@ -360,7 +384,6 @@ export function GlobalInviteOverlay() {
     inviteStore.dismiss();
     resolve("dismissed");
   };
-  const { offset, dragHandleProps, chipHandleProps, clickAllowed } = useOverlayPos();
   // Inline z-index (not a class): side panels and drawers have beaten the
   // themed z-50 scale before, and a ringing phone must win stacking fights.
   const frameStyle = { top: 16, right: 16, transform: `translate(${offset.x}px, ${offset.y}px)`, zIndex: 100 } as const;

--- a/voice-invite.tsx
+++ b/voice-invite.tsx
@@ -2,13 +2,14 @@
 // `voice-invite` with Accept / Snooze / Dismiss. Accept starts a normal voice
 // session (the click is the user gesture mic + playback need); snooze re-rings
 // locally after N minutes; dismiss or expiry just goes quiet.
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import {
   experimental_useSidebarThreadActions,
   useBbContext,
   useRealtime,
   useRpc,
 } from "@get-bb/plugin-sdk/app";
+import { toast } from "sonner";
 import type { rpcContract } from "./server";
 import { clientDescriptor } from "./client-identity";
 import { voiceAgent } from "./voice-agent";
@@ -74,7 +75,11 @@ function useRingtone(ringing: boolean) {
     };
   }, [ringing]);
 }
-function InviteBody({ onAccept, onDismiss }: { onAccept: () => void; onDismiss: () => void }) {
+function InviteBody({ onAccept, onDismiss, snoozeMinutes }: {
+  onAccept: () => void;
+  onDismiss: () => void;
+  snoozeMinutes: number;
+}) {
   const invite = useSyncExternalStore(inviteStore.subscribe, inviteStore.getSnapshot);
   if (!invite) return null;
   return (
@@ -100,11 +105,11 @@ function InviteBody({ onAccept, onDismiss }: { onAccept: () => void; onDismiss: 
         </button>
         <button
           type="button"
-          onClick={() => inviteStore.snooze(DEFAULT_SNOOZE_MINUTES)}
-          title={`Ring again in ${DEFAULT_SNOOZE_MINUTES} minutes`}
+          onClick={() => inviteStore.snooze(snoozeMinutes)}
+          title={`Ring again in ${snoozeMinutes} minutes`}
           className="rounded-full border border-border px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
         >
-          Snooze {DEFAULT_SNOOZE_MINUTES}m
+          Snooze {snoozeMinutes}m
         </button>
         <button
           type="button"
@@ -118,6 +123,54 @@ function InviteBody({ onAccept, onDismiss }: { onAccept: () => void; onDismiss: 
       </div>
     </div>
   );
+}
+
+/**
+ * This surface's incoming-call preferences (Settings → Plugins → Handsfree →
+ * Incoming calls), live-refreshed like every other settings consumer. Server
+ * defaults apply until the first fetch lands, so a slow backend still rings.
+ */
+interface InvitePrefs {
+  incomingCalls: boolean;
+  ringtone: boolean;
+  snoozeMinutes: number;
+  greetFirst: boolean;
+}
+
+const INVITE_PREF_DEFAULTS: InvitePrefs = {
+  incomingCalls: true,
+  ringtone: true,
+  snoozeMinutes: DEFAULT_SNOOZE_MINUTES,
+  greetFirst: true,
+};
+
+function useInvitePrefs(): { prefs: InvitePrefs; loaded: boolean } {
+  const rpc = useRpc<typeof rpcContract>();
+  const [prefs, setPrefs] = useState<InvitePrefs | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const refetch = useCallback(() => {
+    rpc.call("getConfig", null).then(
+      // Per-field coercion, not a blind spread: an older server answers
+      // without these fields, and a failure must never yield undefined prefs.
+      (raw: unknown) => {
+        const config = (raw ?? {}) as Partial<InvitePrefs>;
+        setPrefs({
+          incomingCalls: typeof config.incomingCalls === "boolean" ? config.incomingCalls : true,
+          ringtone: typeof config.ringtone === "boolean" ? config.ringtone : true,
+          snoozeMinutes:
+            typeof config.snoozeMinutes === "number" && Number.isInteger(config.snoozeMinutes)
+              ? Math.min(Math.max(config.snoozeMinutes, 1), 120)
+              : DEFAULT_SNOOZE_MINUTES,
+          greetFirst: typeof config.greetFirst === "boolean" ? config.greetFirst : true,
+        });
+        setLoaded(true);
+      },
+      () => setLoaded(true), // backend unreachable: fail open on defaults
+    );
+  }, [rpc]);
+  useEffect(refetch, [refetch]);
+  useRealtime("config-changed", refetch);
+  return { prefs: prefs ?? INVITE_PREF_DEFAULTS, loaded };
 }
 
 /**
@@ -136,6 +189,7 @@ export function GlobalInviteOverlay() {
   const rpc = useRpc<typeof rpcContract>();
   const { threadId, projectId } = useBbContext();
   const sidebarActions = experimental_useSidebarThreadActions();
+  const { prefs, loaded: prefsLoaded } = useInvitePrefs();
   useRealtime(INVITE_CHANNEL, (payload) => inviteStore.ingestInvite(payload));
   useRealtime(INVITE_RESOLVED_CHANNEL, (payload) => {
     inviteStore.resolveInvite((payload as { inviteId?: unknown } | null)?.inviteId);
@@ -164,7 +218,13 @@ export function GlobalInviteOverlay() {
   // Accepting from a page with no voice UI of its own never strands the call
   // without controls. Cleared when the call ends.
   const [accepted, setAccepted] = useState<{ inviteId: string; title: string } | null>(null);
-  useRingtone(!!invite && !inCall && !mobile);
+  // prefsLoaded gates the ring (never ring on unconfirmed defaults when the
+  // user disabled calls), but never the live-call card: controls for a call
+  // you already accepted must not vanish on a slow backend.
+  const mayRing = prefsLoaded && prefs.incomingCalls;
+  const showInvite = !!invite && !inCall && mayRing;
+  const showLive = !!accepted && inCall;
+  useRingtone(showInvite && prefs.ringtone);
   useEffect(() => {
     // A call went live while this invite was still ringing here (started
     // manually mid-ring, or accepted on a surface whose resolve hasn't
@@ -182,7 +242,7 @@ export function GlobalInviteOverlay() {
     if (state === "idle") setAccepted(null);
   }, [state]);
   if (mobile) return null;
-  if (!invite && !(accepted && inCall)) return null;
+  if (!showInvite && !showLive) return null;
   const resolve = (action: "answered" | "dismissed") => {
     const id = invite?.inviteId ?? accepted?.inviteId;
     if (!id) return;
@@ -193,14 +253,15 @@ export function GlobalInviteOverlay() {
   const accept = () => {
     // Re-check at click time: a call may have started in the beat between
     // render and click, and acceptInvite would otherwise stop that live call.
-    if (!invite || voiceAgent.getState() !== "idle") {
+    if (!showInvite || !invite || voiceAgent.getState() !== "idle") {
       inviteStore.dismiss();
+      if (invite) toast.info("Already in a call — invite dismissed.");
       return;
     }
     setAccepted({ inviteId: invite.inviteId, title: invite.title });
     inviteStore.dismiss();
     resolve("answered");
-    voiceAgent.acceptInvite(invite.title, invite.briefing);
+    voiceAgent.acceptInvite(invite.title, invite.briefing, { greet: prefs.greetFirst });
   };
   const dismiss = () => {
     inviteStore.dismiss();
@@ -218,8 +279,8 @@ export function GlobalInviteOverlay() {
         "rounded-xl border border-primary/40 bg-card p-3.5 shadow-xl",
       )}
     >
-      {invite && !inCall ? (
-        <InviteBody onAccept={accept} onDismiss={dismiss} />
+      {showInvite && invite ? (
+        <InviteBody onAccept={accept} onDismiss={dismiss} snoozeMinutes={prefs.snoozeMinutes} />
       ) : (
         <div className="w-full">
           <div className="flex items-center gap-2">

--- a/voice-invite.tsx
+++ b/voice-invite.tsx
@@ -3,9 +3,21 @@
 // session (the click is the user gesture mic + playback need); snooze re-rings
 // locally after N minutes; dismiss or expiry just goes quiet.
 import { useEffect, useSyncExternalStore } from "react";
-import { useRealtime } from "@get-bb/plugin-sdk/app";
+import {
+  experimental_useSidebarThreadActions,
+  useBbContext,
+  useRealtime,
+  useRpc,
+} from "@get-bb/plugin-sdk/app";
+import type { rpcContract } from "./server";
+import { clientDescriptor } from "./client-identity";
 import { voiceAgent } from "./voice-agent";
-import { DEFAULT_SNOOZE_MINUTES, INVITE_CHANNEL, inviteStore } from "./voice-invite.ts";
+import {
+  DEFAULT_SNOOZE_MINUTES,
+  INVITE_CHANNEL,
+  INVITE_RESOLVED_CHANNEL,
+  inviteStore,
+} from "./voice-invite.ts";
 import { cn } from "@/lib/utils";
 
 /** Double-beep ringtone while an invite is ringing. Best-effort: before the
@@ -61,8 +73,7 @@ function useRingtone(ringing: boolean) {
     };
   }, [ringing]);
 }
-
-function InviteBody({ onAccept }: { onAccept: () => void }) {
+function InviteBody({ onAccept, onDismiss }: { onAccept: () => void; onDismiss: () => void }) {
   const invite = useSyncExternalStore(inviteStore.subscribe, inviteStore.getSnapshot);
   if (!invite) return null;
   return (
@@ -95,7 +106,7 @@ function InviteBody({ onAccept }: { onAccept: () => void }) {
         </button>
         <button
           type="button"
-          onClick={() => inviteStore.dismiss()}
+          onClick={onDismiss}
           aria-label="Dismiss invite"
           title="Dismiss"
           className="rounded-full border border-border px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-destructive/15 hover:text-destructive"
@@ -106,26 +117,65 @@ function InviteBody({ onAccept }: { onAccept: () => void }) {
     </div>
   );
 }
+
 /**
  * App-wide incoming-call overlay (registered as `experimental_appOverlay`, so
  * it mounts on every page — thread views, the Handsfree page, settings, other
  * plugins' pages). Top-right toast placement keeps it clear of the composer.
  * While already in a call the invite is moot, so it steps aside (and drops
  * the invite — whoever is talking already has the floor).
+ *
+ * Answering/dismissing here resolves through the server, so every other
+ * surface stops ringing too; snooze stays local to this surface by design.
+ * Mobile stays silent for now: the native webview cannot reliably start a
+ * call (see HF-2), and the phone path waits on Expo push (HF-12).
  */
 export function GlobalInviteOverlay() {
+  const rpc = useRpc<typeof rpcContract>();
+  const { threadId, projectId } = useBbContext();
+  const sidebarActions = experimental_useSidebarThreadActions();
   useRealtime(INVITE_CHANNEL, (payload) => inviteStore.ingestInvite(payload));
+  useRealtime(INVITE_RESOLVED_CHANNEL, (payload) => {
+    inviteStore.resolveInvite((payload as { inviteId?: unknown } | null)?.inviteId);
+  });
+
+  // Fallback voice binding so Accept can start a call from pages with no
+  // composer of their own. Thread views keep their richer composer binding —
+  // fallbacks never win over those (see registerBindings).
+  useEffect(() => {
+    return voiceAgent.bindFallback({
+      rpc,
+      context: { threadId: threadId ?? null, projectId: projectId ?? null, onNewThreadScreen: false },
+      openNewThread: (targetProjectId) =>
+        sidebarActions.openNewThread({
+          ...(targetProjectId ? { projectId: targetProjectId } : {}),
+          focusPrompt: true,
+        }),
+    });
+  }, [rpc, threadId, projectId, sidebarActions]);
+
   const invite = useSyncExternalStore(inviteStore.subscribe, inviteStore.getSnapshot);
   const state = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
   const inCall = state !== "idle";
-  useRingtone(!!invite && !inCall);
+  const mobile = clientDescriptor.mobile;
+  useRingtone(!!invite && !inCall && !mobile);
   useEffect(() => {
     if (invite && inCall) inviteStore.dismiss();
   }, [invite, inCall]);
-  if (!invite || inCall) return null;
+  if (mobile || !invite || inCall) return null;
+  const resolve = (action: "answered" | "dismissed") => {
+    void rpc
+      .call("resolveInvite", { inviteId: invite.inviteId, action })
+      .catch(() => undefined);
+  };
   const accept = () => {
     inviteStore.dismiss();
+    resolve("answered");
     voiceAgent.acceptInvite(invite.title, invite.briefing);
+  };
+  const dismiss = () => {
+    inviteStore.dismiss();
+    resolve("dismissed");
   };
   return (
     <div
@@ -136,7 +186,7 @@ export function GlobalInviteOverlay() {
         "rounded-xl border border-primary/40 bg-card p-3.5 shadow-xl",
       )}
     >
-      <InviteBody onAccept={accept} />
+      <InviteBody onAccept={accept} onDismiss={dismiss} />
     </div>
   );
 }

--- a/voice-invite.tsx
+++ b/voice-invite.tsx
@@ -172,6 +172,13 @@ function useInvitePrefs(): { prefs: InvitePrefs; loaded: boolean } {
   }, [rpc]);
   useEffect(refetch, [refetch]);
   useRealtime("config-changed", refetch);
+  // Fail open on a timer: if the backend never answers, ring on defaults
+  // after 3s rather than staying silent forever. A hanging getConfig must
+  // degrade to a possibly-unwanted ring, never to a missed call.
+  useEffect(() => {
+    const fallback = setTimeout(() => setLoaded(true), 3000);
+    return () => clearTimeout(fallback);
+  }, []);
   return { prefs: prefs ?? INVITE_PREF_DEFAULTS, loaded };
 }
 

--- a/voice-invite.tsx
+++ b/voice-invite.tsx
@@ -1,0 +1,142 @@
+// Incoming-call UI for Tier-0 autonomous invocation: renders the ringing
+// `voice-invite` with Accept / Snooze / Dismiss. Accept starts a normal voice
+// session (the click is the user gesture mic + playback need); snooze re-rings
+// locally after N minutes; dismiss or expiry just goes quiet.
+import { useEffect, useSyncExternalStore } from "react";
+import { useRealtime } from "@get-bb/plugin-sdk/app";
+import { voiceAgent } from "./voice-agent";
+import { DEFAULT_SNOOZE_MINUTES, INVITE_CHANNEL, inviteStore } from "./voice-invite.ts";
+import { cn } from "@/lib/utils";
+
+/** Double-beep ringtone while an invite is ringing. Best-effort: before the
+ * user has ever interacted with the tab, autoplay policy keeps the context
+ * suspended and only the visual card + vibration ring. */
+function useRingtone(ringing: boolean) {
+  useEffect(() => {
+    if (!ringing || typeof window === "undefined") return;
+    let ctx: AudioContext | null = null;
+    let stopped = false;
+    let interval: ReturnType<typeof setInterval> | null = null;
+    try {
+      const AC =
+        window.AudioContext ??
+        (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+      if (!AC) return;
+      ctx = new AC();
+      void ctx.resume().catch(() => undefined);
+      const beep = (freq: number, at: number, dur = 0.18) => {
+        if (!ctx || stopped) return;
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.frequency.value = freq;
+        osc.type = "sine";
+        gain.gain.setValueAtTime(0.0001, at);
+        gain.gain.exponentialRampToValueAtTime(0.2, at + 0.02);
+        gain.gain.exponentialRampToValueAtTime(0.0001, at + dur);
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        osc.start(at);
+        osc.stop(at + dur + 0.05);
+      };
+      const pattern = () => {
+        if (!ctx || stopped) return;
+        const t = ctx.currentTime + 0.05;
+        beep(880, t);
+        beep(880, t + 0.28);
+      };
+      pattern();
+      interval = setInterval(pattern, 2000);
+      try {
+        navigator.vibrate?.([200, 100, 200]);
+      } catch {
+        /* vibration is a nicety */
+      }
+    } catch {
+      /* audio unavailable — the visual card still rings */
+    }
+    return () => {
+      stopped = true;
+      if (interval) clearInterval(interval);
+      ctx?.close().catch(() => undefined);
+    };
+  }, [ringing]);
+}
+
+function InviteBody({ onAccept }: { onAccept: () => void }) {
+  const invite = useSyncExternalStore(inviteStore.subscribe, inviteStore.getSnapshot);
+  if (!invite) return null;
+  return (
+    <div className="w-full">
+      <div className="flex items-center gap-2">
+        <span className="size-2.5 shrink-0 animate-pulse rounded-full bg-primary" aria-hidden />
+        <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Incoming call
+        </span>
+      </div>
+      <p className="mt-1.5 text-sm font-medium text-foreground">{invite.title}</p>
+      {invite.briefing ? (
+        <p className="mt-0.5 line-clamp-3 text-xs text-muted-foreground">{invite.briefing}</p>
+      ) : null}
+      <div className="mt-3 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onAccept}
+          className="flex-1 rounded-full bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+        >
+          Accept
+        </button>
+        <button
+          type="button"
+          onClick={() => inviteStore.snooze(DEFAULT_SNOOZE_MINUTES)}
+          title={`Ring again in ${DEFAULT_SNOOZE_MINUTES} minutes`}
+          className="rounded-full border border-border px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        >
+          Snooze {DEFAULT_SNOOZE_MINUTES}m
+        </button>
+        <button
+          type="button"
+          onClick={() => inviteStore.dismiss()}
+          aria-label="Dismiss invite"
+          title="Dismiss"
+          className="rounded-full border border-border px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-destructive/15 hover:text-destructive"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}
+/**
+ * App-wide incoming-call overlay (registered as `experimental_appOverlay`, so
+ * it mounts on every page — thread views, the Handsfree page, settings, other
+ * plugins' pages). Top-right toast placement keeps it clear of the composer.
+ * While already in a call the invite is moot, so it steps aside (and drops
+ * the invite — whoever is talking already has the floor).
+ */
+export function GlobalInviteOverlay() {
+  useRealtime(INVITE_CHANNEL, (payload) => inviteStore.ingestInvite(payload));
+  const invite = useSyncExternalStore(inviteStore.subscribe, inviteStore.getSnapshot);
+  const state = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
+  const inCall = state !== "idle";
+  useRingtone(!!invite && !inCall);
+  useEffect(() => {
+    if (invite && inCall) inviteStore.dismiss();
+  }, [invite, inCall]);
+  if (!invite || inCall) return null;
+  const accept = () => {
+    inviteStore.dismiss();
+    voiceAgent.acceptInvite(invite.title, invite.briefing);
+  };
+  return (
+    <div
+      role="alertdialog"
+      aria-label={`Incoming call: ${invite.title}`}
+      className={cn(
+        "fixed right-4 top-4 z-50 w-80 max-w-[calc(100vw-2rem)]",
+        "rounded-xl border border-primary/40 bg-card p-3.5 shadow-xl",
+      )}
+    >
+      <InviteBody onAccept={accept} />
+    </div>
+  );
+}

--- a/voice-invite.tsx
+++ b/voice-invite.tsx
@@ -2,7 +2,7 @@
 // `voice-invite` with Accept / Snooze / Dismiss. Accept starts a normal voice
 // session (the click is the user gesture mic + playback need); snooze re-rings
 // locally after N minutes; dismiss or expiry just goes quiet.
-import { useEffect, useSyncExternalStore } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import {
   experimental_useSidebarThreadActions,
   useBbContext,
@@ -12,6 +12,7 @@ import {
 import type { rpcContract } from "./server";
 import { clientDescriptor } from "./client-identity";
 import { voiceAgent } from "./voice-agent";
+import { LiveCallControls } from "./voice-chrome";
 import {
   DEFAULT_SNOOZE_MINUTES,
   INVITE_CHANNEL,
@@ -158,17 +159,29 @@ export function GlobalInviteOverlay() {
   const state = useSyncExternalStore(voiceAgent.subscribe, voiceAgent.getState);
   const inCall = state !== "idle";
   const mobile = clientDescriptor.mobile;
+  // The surface that accepted keeps a live-call card (mute/stop + status) so
+  // Accepting from a page with no voice UI of its own never strands the call
+  // without controls. Cleared when the call ends.
+  const [accepted, setAccepted] = useState<{ inviteId: string; title: string } | null>(null);
   useRingtone(!!invite && !inCall && !mobile);
   useEffect(() => {
     if (invite && inCall) inviteStore.dismiss();
   }, [invite, inCall]);
-  if (mobile || !invite || inCall) return null;
+  useEffect(() => {
+    if (state === "idle") setAccepted(null);
+  }, [state]);
+  if (mobile) return null;
+  if (!invite && !(accepted && inCall)) return null;
   const resolve = (action: "answered" | "dismissed") => {
+    const id = invite?.inviteId ?? accepted?.inviteId;
+    if (!id) return;
     void rpc
-      .call("resolveInvite", { inviteId: invite.inviteId, action })
+      .call("resolveInvite", { inviteId: id, action })
       .catch(() => undefined);
   };
   const accept = () => {
+    if (!invite) return;
+    setAccepted({ inviteId: invite.inviteId, title: invite.title });
     inviteStore.dismiss();
     resolve("answered");
     voiceAgent.acceptInvite(invite.title, invite.briefing);
@@ -180,13 +193,27 @@ export function GlobalInviteOverlay() {
   return (
     <div
       role="alertdialog"
-      aria-label={`Incoming call: ${invite.title}`}
+      aria-label={invite ? `Incoming call: ${invite.title}` : `On call: ${accepted?.title ?? "Aide"}`}
       className={cn(
         "fixed right-4 top-4 z-50 w-80 max-w-[calc(100vw-2rem)]",
         "rounded-xl border border-primary/40 bg-card p-3.5 shadow-xl",
       )}
     >
-      <InviteBody onAccept={accept} onDismiss={dismiss} />
+      {invite && !inCall ? (
+        <InviteBody onAccept={accept} onDismiss={dismiss} />
+      ) : (
+        <div className="w-full">
+          <div className="flex items-center gap-2">
+            <span className="size-2.5 shrink-0 rounded-full bg-primary" aria-hidden />
+            <span className="truncate text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              On call{accepted?.title ? ` — ${accepted.title}` : ""}
+            </span>
+          </div>
+          <div className="mt-2.5 flex justify-center">
+            <LiveCallControls />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/voice-invite.tsx
+++ b/voice-invite.tsx
@@ -248,6 +248,11 @@ export function GlobalInviteOverlay() {
       setExpanded(false);
     }
   }, [state]);
+  // Hooks below run on EVERY render: useCallElapsed must stay above the early
+  // returns, or React (fewer-hooks-than-expected) unmounts the overlay and
+  // nothing rings anywhere — the overlay is the only ringer.
+  const elapsed = useCallElapsed();
+  const muted = state === "muted";
   if (mobile) return null;
   if (!showInvite && !showLive) return null;
   const resolve = (action: "answered" | "dismissed") => {
@@ -275,8 +280,6 @@ export function GlobalInviteOverlay() {
     inviteStore.dismiss();
     resolve("dismissed");
   };
-  const elapsed = useCallElapsed();
-  const muted = state === "muted";
   if (!showInvite && showLive && !expanded) {
     return (
       <button


### PR DESCRIPTION
## Summary

Builds on [HF-10](https://github.com/swairshah/bb-handsfree/issues/21): instead of only starting calls yourself, automations (or `bb handsfree ring`) can now ring every connected BB window with an incoming call. Accepting starts a normal voice session with the call reason injected, so Aide greets first instead of waiting for you to speak. No mic-busy or idle detection needed — the human is the arbiter: Accept, Snooze, or Dismiss.

## What's new

- **Ring from anywhere.** `bb handsfree ring --title ... --briefing ... [--ttl 60] [--no-banner]` broadcasts a time-boxed invite; automations can invoke it on a schedule with a per-call brief.
- **One app-wide incoming-call toast.** Mounted as an app overlay, so it rings on thread views, the Handsfree page, settings, and other plugins' pages — top-right, clear of the composer, with ringtone and vibration.
- **Aide speaks first.** Accepting injects the call reason as a system instruction and opens with a greeting grounded in the brief. A setting turns this into a normal wait-for-you session.
- **Every surface stays in sync.** Answers and dismissals rebroadcast through the server so all devices stop ringing; snooze re-rings locally after a configurable delay; expiry goes quiet on its own.
- **The toast becomes call controls.** The accepting surface keeps a live On-call card (mute/stop, activity, elapsed), so calls started from pages with no voice UI keep controls.
- **Native OS banner alongside.** Ring also publishes the push plugin's global notification channel, reaching backgrounded tabs and the desktop app; clicking focuses BB.
- **Incoming calls settings section.** Per-device kill switch, ringtone toggle, snooze delay (5/10/15/30 min), and the speak-first toggle — kv-backed and live-synced like existing sections. The briefing itself travels with each invite, set where the call is scheduled.

## Screenshots & recordings

_To add: overlay toast + On-call card screenshot, settings section screenshot, and a recording of ring → Accept → greet-first._ 

## Behavior & limitations

- Desktop-only for now: the overlay stays silent on mobile (native-webview WebRTC is unreliable; see HF-2). The phone path waits on Expo push ([HF-12](https://github.com/swairshah/bb-handsfree/pull/32)).
- The banner needs Notification permission on that web/desktop client; mobile webviews ignore the notification channel.
- Overlapping surfaces can each show call status (composer pill, sidebar bar, Handsfree console, overlay card). Dedupe policy (binding-aware auto-show vs mini-chip) is open — see the PR discussion.
- Snooze is local to the surface that tapped it; other surfaces keep ringing until they answer, dismiss, or the invite expires.
- A call that starts manually while an invite rings resolves it as dismissed everywhere.

<details>
<summary>Validation</summary>

- 77 automated tests pass, plus TypeScript clean. New coverage: invite store lifecycle (ingest/dismiss/expiry/snooze/resolve), ring + resolveInvite + banner CLI behavior, greet-on-open (once-only, mic-denied cleanup, greet-off), settings round-trip and validation.
- Two review passes (subagent) over the full diff: fixed stale-snooze-on-ingest, missing resolve on manual starts, an Accept click race, prefs race/compat gaps, and server-side prefs enforcement.
- Verified live on desktop: ring on threads, the Handsfree page, other plugin pages, and backgrounded BB (in-app sight + sound); Accept from a plugin page starts the call; Aide greets first with the brief.
- Not yet verified: native banner on a backgrounded client, phone behavior after kill-and-reopen.
- UI checks use simulated WebRTC; they do not establish real microphone/audio continuity.

</details>